### PR TITLE
Fix: テスト用のConfigのセッターの追加と利用箇所の修正

### DIFF
--- a/.github/release/v0.17.1.md
+++ b/.github/release/v0.17.1.md
@@ -1,0 +1,32 @@
+<!-- markdownlint-disable MD041 -->
+## 更新概要
+
+- テスト時にConfigを利用する場合、envを設定する必要をなくした。
+- 共通のエラーレスポンスのpackage名が他のものと不整合を起こしていたため、package名を変更した。
+
+## 更新内容
+
+- **テスト用ユーティリティの追加**
+  - `internal/config/config_testing_mock.go` を新規追加。
+    - テスト用のモック設定を提供し、テストコードの簡素化を実現。
+    - `MockConfigForTest` 関数を使用して、テスト用の設定を簡単に生成可能。
+  - `internal/config/config_testing_setter.go` を更新。
+    - テスト用の設定変更メソッドから現状使われていないものを削除。
+    - 例: `SetServerAppMode`, `SetDatabaseHost` など。
+
+- **エラーハンドリングの改善**
+  - `internal/controller/handler/error/response/` ディレクトリ内のコードをリファクタリング。
+    - パッケージ名を `response` に変更し、より直感的な命名に。
+
+- **テストコードの改善**
+  - env読み込みが不要になったので、各テストケースで並列実行を有効化し、テストの実行速度を向上。
+    - `MockConfigForTest` を活用して設定の初期化を簡素化。
+    - テストの可読性とメンテナンス性を向上。
+
+## 追加ライブラリ
+
+- 特になし。
+
+## 不具合修正
+
+- 特になし。

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -173,7 +173,7 @@ func TestIsAppDevelopmentMode(t *testing.T) {
 func TestDatabaseURL(t *testing.T) {
 	t.Parallel()
 
-	cfg := mockConfig(t)
+	cfg := MockConfigForTest(t)
 
 	t.Run("DatabaseURL", func(t *testing.T) {
 		t.Parallel()

--- a/internal/config/config_testing_mock.go
+++ b/internal/config/config_testing_mock.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -26,19 +27,21 @@ var (
 	expectedDBName     = "test"
 	expectedDBSSLMode  = "disable"
 	// dbconnection
-	expectedDBMaxOpenConns   = 10
-	expectedDBMaxIdleConns   = 5
-	expectedDBMaxLifetimeStr = "60s"
-	expectedDBMaxLifetime    = time.Duration(60) * time.Second
-	expectedDBMaxIdleTimeStr = "30s"
-	expectedDBMaxIdleTime    = time.Duration(30) * time.Second
+	expectedDBMaxOpenConns     = 10
+	expectedDBMaxIdleConns     = 5
+	expectedDBMaxLifetimeCount = 60
+	expectedDBMaxLifetimeStr   = fmt.Sprintf("%ds", expectedDBMaxLifetimeCount)
+	expectedDBMaxLifetime      = time.Duration(expectedDBMaxLifetimeCount) * time.Second
+	expectedDBMaxIdleTimeCount = 30
+	expectedDBMaxIdleTimeStr   = fmt.Sprintf("%ds", expectedDBMaxIdleTimeCount)
+	expectedDBMaxIdleTime      = time.Duration(expectedDBMaxIdleTimeCount) * time.Second
 	// security
 	expectedAllowedOrigins = "http://localhost,https://example.com"
 	expectedCIDRStr        = "192.168.0.0/24"
 )
 
-// mockConfig は、テスト用のConfigを返します。
-func mockConfig(t *testing.T) Config {
+// MockConfigForTest は、テスト用のConfigを返します。
+func MockConfigForTest(t testing.TB) Config {
 	t.Helper()
 	_, expectedCIDR, err := net.ParseCIDR(expectedCIDRStr)
 	require.NoError(t, err)
@@ -75,7 +78,7 @@ func mockConfig(t *testing.T) Config {
 }
 
 // mockLoader は、テスト用のLoaderを返します。
-func mockLoader(t *testing.T) Loader {
+func mockLoader(t testing.TB) Loader {
 	t.Helper()
 
 	return Loader{
@@ -104,7 +107,7 @@ func mockLoader(t *testing.T) Loader {
 }
 
 // setEnv は、テスト用の環境変数を設定します。
-func setEnv(t *testing.T) {
+func setEnv(t testing.TB) {
 	t.Helper()
 	t.Setenv("OS_TZ", expectedOSTimeZone)
 	t.Setenv("SERVER_ENV", expectedEnv)

--- a/internal/config/config_testing_setter.go
+++ b/internal/config/config_testing_setter.go
@@ -6,47 +6,9 @@ import (
 	"time"
 )
 
-// TODO: 必要最低限になるように、次のタスクで修正する
-
-// SetOSTimeZone は、テスト用にOSのタイムゾーンを設定します。
+// WARN: 本番コードでは使用しないでください。テスト用の設定を行うためのメソッドです。
 //
-// 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (c *Config) SetOSTimeZone(t testing.TB, tz string) {
-	t.Helper()
-	prev := c.OSTimeZone()
-	c.os.timezone = tz
-	t.Cleanup(func() { c.os.timezone = prev })
-}
-
-// SetServerHost は、テスト用にサーバーのホスト名を設定します。
-//
-// 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (c *Config) SetServerHost(t testing.TB, host string) {
-	t.Helper()
-	prev := c.ServerHost()
-	c.server.host = host
-	t.Cleanup(func() { c.server.host = prev })
-}
-
-// SetServerPort は、テスト用にサーバーのポート番号を設定します。
-//
-// 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (c *Config) SetServerPort(t testing.TB, port int) {
-	t.Helper()
-	prev := c.ServerPort()
-	c.server.port = port
-	t.Cleanup(func() { c.server.port = prev })
-}
-
-// SetServerEnv は、テスト用にサーバーのEnvを設定します。
-//
-// 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (c *Config) SetServerEnv(t testing.TB, env string) {
-	t.Helper()
-	prev := c.ServerEnv()
-	c.server.serverEnv = env
-	t.Cleanup(func() { c.server.serverEnv = prev })
-}
+// 実装メソッドは無闇に増やさず、必要なものだけを追加してください。
 
 // SetServerAppMode は、テスト用にサーバーのAppModeを設定します。
 //
@@ -146,26 +108,6 @@ func (c *Config) SetDBConnMaxLifetime(t testing.TB, d time.Duration) {
 	prev := c.DBConnMaxLifetime()
 	c.database.connection.maxLifetime = d
 	t.Cleanup(func() { c.database.connection.maxLifetime = prev })
-}
-
-// SetDBConnMaxIdleTime は、テスト用にデータベースの接続の最大アイドル時間を設定します。
-//
-// 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (c *Config) SetDBConnMaxIdleTime(t testing.TB, d time.Duration) {
-	t.Helper()
-	prev := c.DBConnMaxIdleTime()
-	c.database.connection.maxIdleTime = d
-	t.Cleanup(func() { c.database.connection.maxIdleTime = prev })
-}
-
-// SetAllowedOrigins は、テスト用に許可されたオリジンを設定します。
-//
-// 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (c *Config) SetAllowedOrigins(t testing.TB, origins []string) {
-	t.Helper()
-	prev := c.AllowedOrigins()
-	c.security.allowedOrigins = origins
-	t.Cleanup(func() { c.security.allowedOrigins = prev })
 }
 
 // SetCIDR は、テスト用にセキュリティのCIDRを設定します。

--- a/internal/config/model_test.go
+++ b/internal/config/model_test.go
@@ -14,7 +14,7 @@ func TestGetterMethods(t *testing.T) {
 	_, expectedCIDR, err := net.ParseCIDR(expectedCIDRStr)
 	require.NoError(t, err)
 
-	cfg := mockConfig(t)
+	cfg := MockConfigForTest(t)
 
 	t.Run("OSTimeZone", func(t *testing.T) {
 		t.Parallel()

--- a/internal/controller/handler/error/response/error_response.go
+++ b/internal/controller/handler/error/response/error_response.go
@@ -1,7 +1,7 @@
 //go:generate oapi-codegen --include-tags=internal/types/error-response --package=gen --generate=types -o ./gen/type.gen.go /app/openapi/openapi.gen.yaml
 
-// Package errorresponse は、echoでのエラーレスポンスを生成するためのユーティリティを提供します。
-package errorresponse
+// Package response は、echoでのエラーレスポンスを生成するためのユーティリティを提供します。
+package response
 
 import (
 	"fmt"

--- a/internal/controller/handler/error/response/error_response_test.go
+++ b/internal/controller/handler/error/response/error_response_test.go
@@ -1,4 +1,4 @@
-package errorresponse
+package response
 
 import (
 	"errors"

--- a/internal/controller/handler/error/response/http_error.go
+++ b/internal/controller/handler/error/response/http_error.go
@@ -1,4 +1,4 @@
-package errorresponse
+package response
 
 import "net/http"
 

--- a/internal/controller/handler/error/response/http_error_test.go
+++ b/internal/controller/handler/error/response/http_error_test.go
@@ -1,4 +1,4 @@
-package errorresponse
+package response
 
 import (
 	"net/http"

--- a/internal/controller/middleware/logging/logging_middleware_test.go
+++ b/internal/controller/middleware/logging/logging_middleware_test.go
@@ -5,13 +5,11 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
 	"boilerplate-go/internal/controller/ctxhelper"
 	"boilerplate-go/internal/domain/expectederrors"
-	"boilerplate-go/internal/testutil"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
@@ -19,10 +17,6 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
-
-func TestMain(m *testing.M) {
-	os.Exit(testutil.RunWithTestSetup(m))
-}
 
 func Test_buildFields(t *testing.T) {
 	t.Parallel()
@@ -102,6 +96,8 @@ func Test_buildFields(t *testing.T) {
 }
 
 func Test_logRequest(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name            string
 		status          int
@@ -146,6 +142,8 @@ func Test_logRequest(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			var buf bytes.Buffer
 			logger := newTestLogger(&buf)
 			c := newTestContext(tt.status)

--- a/internal/controller/server/http_error_handler.go
+++ b/internal/controller/server/http_error_handler.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"net/http"
 
-	errorresponse "boilerplate-go/internal/controller/handler/error/response"
+	"boilerplate-go/internal/controller/handler/error/response"
 	"boilerplate-go/internal/controller/middleware/requestid"
 
 	"github.com/labstack/echo/v4"
@@ -43,11 +43,11 @@ func NewHTTPErrorHandler(logger *zap.Logger) echo.HTTPErrorHandler {
 func normalizeHTTPError(
 	err error,
 	requestID string,
-) *errorresponse.HTTPErrorResponse {
-	var he *errorresponse.HTTPErrorResponse
+) *response.HTTPErrorResponse {
+	var he *response.HTTPErrorResponse
 	if errors.As(err, &he) {
 		if !isErrorStatus(he.HTTPStatus) {
-			res := errorresponse.New(
+			res := response.New(
 				http.StatusInternalServerError,
 				he.Internal,
 			)
@@ -67,12 +67,12 @@ func normalizeHTTPError(
 		if !isErrorStatus(status) {
 			status = http.StatusInternalServerError
 		}
-		res := errorresponse.New(status, err)
+		res := response.New(status, err)
 		res.RequestId = requestID
 		return res
 	}
 
-	res := errorresponse.New(http.StatusInternalServerError, err)
+	res := response.New(http.StatusInternalServerError, err)
 	res.RequestId = requestID
 	return res
 }
@@ -81,7 +81,7 @@ func normalizeHTTPError(
 func logHTTPError(
 	logger *zap.Logger,
 	c echo.Context,
-	he *errorresponse.HTTPErrorResponse,
+	he *response.HTTPErrorResponse,
 ) {
 	fields := []zap.Field{
 		zap.Int("status", he.HTTPStatus),

--- a/internal/controller/server/ip_extractor_test.go
+++ b/internal/controller/server/ip_extractor_test.go
@@ -10,33 +10,35 @@ import (
 )
 
 func TestNewIPExtractor(t *testing.T) {
+	t.Parallel()
+
 	cidr := "192.168.0.0/16"
 	_, parsedCIDR, err := net.ParseCIDR(cidr)
 	require.NoError(t, err)
 
 	t.Run("本番モードの場合", func(t *testing.T) {
-		require.NoError(t, config.Load())
-		t.Setenv("SERVER_APP_MODE", config.ProductionMode)
-		t.Setenv("SECURITY_CIDR", cidr)
-		cfg, err := config.New()
-		require.NoError(t, err)
+		t.Parallel()
+
+		cfg := config.MockConfigForTest(t)
+		cfg.SetServerAppMode(t, config.ProductionMode)
+		cfg.SetCIDR(t, parsedCIDR)
 		require.Equal(t, config.ProductionMode, cfg.ServerAppMode())
 		require.Equal(t, parsedCIDR.String(), cfg.CIDR().String())
 
-		actual := NewIPExtractor(cfg)
+		actual := NewIPExtractor(&cfg)
 		require.NotNil(t, actual)
 	})
 
 	t.Run("開発モードの場合", func(t *testing.T) {
-		require.NoError(t, config.Load())
-		t.Setenv("APP_MODE", config.DevelopmentMode)
-		t.Setenv("SECURITY_CIDR", cidr)
-		cfg, err := config.New()
-		require.NoError(t, err)
+		t.Parallel()
+
+		cfg := config.MockConfigForTest(t)
+		cfg.SetServerAppMode(t, config.DevelopmentMode)
+		cfg.SetCIDR(t, parsedCIDR)
 		require.Equal(t, config.DevelopmentMode, cfg.ServerAppMode())
 		require.Equal(t, parsedCIDR.String(), cfg.CIDR().String())
 
-		actual := NewIPExtractor(cfg)
+		actual := NewIPExtractor(&cfg)
 		require.NotNil(t, actual)
 	})
 

--- a/internal/controller/server/server_test.go
+++ b/internal/controller/server/server_test.go
@@ -1,19 +1,13 @@
 package server
 
 import (
-	"os"
 	"testing"
 
 	"boilerplate-go/internal/config"
-	"boilerplate-go/internal/testutil"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 )
-
-func TestMain(m *testing.M) {
-	os.Exit(testutil.RunWithTestSetup(m))
-}
 
 func TestNew(t *testing.T) {
 	t.Parallel()
@@ -33,17 +27,16 @@ func TestNew(t *testing.T) {
 }
 
 func TestSetPrimitiveEchoSettings(t *testing.T) {
-	// 環境変数を書き換えるため、並列実行は避ける
+	t.Parallel()
 	t.Run("本番環境モード", func(t *testing.T) {
+		t.Parallel()
+
 		e := echo.New()
 
-		err := config.Load()
-		require.NoError(t, err)
-		t.Setenv("SERVER_APP_MODE", config.ProductionMode)
-		cfg, err := config.New()
-		require.NoError(t, err)
+		cfg := config.MockConfigForTest(t)
+		cfg.SetServerAppMode(t, config.ProductionMode)
 
-		setPrimitiveEchoSettings(e, cfg)
+		setPrimitiveEchoSettings(e, &cfg)
 
 		require.False(t, e.Debug)
 		require.True(t, e.HideBanner)
@@ -51,15 +44,14 @@ func TestSetPrimitiveEchoSettings(t *testing.T) {
 	})
 
 	t.Run("開発環境モード", func(t *testing.T) {
+		t.Parallel()
+
 		e := echo.New()
 
-		err := config.Load()
-		require.NoError(t, err)
-		t.Setenv("SERVER_APP_MODE", config.DevelopmentMode)
-		cfg, err := config.New()
-		require.NoError(t, err)
+		cfg := config.MockConfigForTest(t)
+		cfg.SetServerAppMode(t, config.DevelopmentMode)
 
-		setPrimitiveEchoSettings(e, cfg)
+		setPrimitiveEchoSettings(e, &cfg)
 
 		require.True(t, e.Debug)
 		require.False(t, e.HideBanner)


### PR DESCRIPTION
# 概要

- テスト時にConfigを利用する場合、envを設定する必要をなくした。
- 共通のエラーレスポンスのpackage名が他のものと不整合を起こしていたため、package名を変更した。

## 変更内容

- **テスト用ユーティリティの追加**
- **エラーハンドリングの改善**
- **テストコードの改善**

## 動作確認方法

<!-- 1. make serve -->

1. make testの実行
