### PR TITLE
Featr: strict-serverターゲットを追加して、既存ハンドラを厳格にした

### DIFF
--- a/.github/release/v0.23.0.md
+++ b/.github/release/v0.23.0.md
@@ -1,11 +1,17 @@
 <!-- markdownlint-disable MD041 -->
 ## 更新概要
 
+- oapi-codegenのルーティング部分を厳密化する
+
 ## 更新内容
 
 <!-- - 変更内容 -->
 
--
+- internal/controller/handler/health/health_handler.go
+- internal/controller/handler/healthz/healthz_handler.go
+- internal/controller/handler/v1/users/v1_users_handler.go
+  - strict-serverターゲットを追加した
+  - strict-serverの仕様に合わせて実装済みのハンドラを修正
 
 ## 追加ライブラリ
 

--- a/internal/controller/README.md
+++ b/internal/controller/README.md
@@ -33,7 +33,7 @@
 
      ```go
      //go:generate oapi-codegen --include-tags=v1/users --package=gen --generate=types -o ./gen/type.gen.go /app/openapi/openapi.gen.yaml
-     //go:generate oapi-codegen --include-tags=v1/users --package=gen --generate=echo-server -o ./gen/server.gen.go /app/openapi/openapi.gen.yaml
+     //go:generate oapi-codegen --include-tags=v1/users --package=gen --generate=echo-server,strict-server -o ./gen/server.gen.go /app/openapi/openapi.gen.yaml
      ```
 
   4. `swagger-cli`でOpenAPIを結合・検証し、`oapi-codegen`で生成
@@ -103,7 +103,7 @@
 
 ```go
 //go:generate oapi-codegen --include-tags=v1/users --package=gen --generate=types -o ./gen/type.gen.go /app/openapi/openapi.gen.yaml
-//go:generate oapi-codegen --include-tags=v1/users --package=gen --generate=echo-server -o ./gen/server.gen.go /app/openapi/openapi.gen.yaml
+//go:generate oapi-codegen --include-tags=v1/users --package=gen --generate=echo-server,strict-server -o ./gen/server.gen.go /app/openapi/openapi.gen.yaml
 
 // パッケージ名は衝突防止のためURIに合わせてください
 package v1users
@@ -114,9 +114,9 @@ type server struct {
 
 // この関数をdi/handler.goで、[<package>.BindHandler,]として登録する。
 func BindHandler(e *echo.Echo, uc user.Service) {
-    gen.RegisterHandlers(e, &server{
+    gen.RegisterHandlers(e, gen.NewStrictHandler(&server{
         uc: uc,
-    })
+    }, nil))
 }
 
 // handler
@@ -151,6 +151,6 @@ func (s *server) GetV1UsersDetail(c echo.Context, params gen.GetUsersParams) err
       Offset: page.Offset(),
     }
 
-    return c.JSON(http.StatusOK, res)
+    return gen.GetUsersByName200JSONResponse(res), nil
 }
 ```

--- a/internal/controller/README.md
+++ b/internal/controller/README.md
@@ -120,14 +120,14 @@ func BindHandler(e *echo.Echo, uc user.Service) {
 }
 
 // handler
-func (s *server) GetV1UsersDetail(c echo.Context, params gen.GetUsersParams) error {
+func (s *server) GetV1UsersDetail(ctx context.Context, request gen.GetUsersRequestObject) (gen.GetUsersResponseObject, error) {
     // HTTP → VO
-    page := usecase.NewPageFrom1Based(params.Page, params.PerPage)
+    page := usecase.NewPageFrom1Based(request.Params.Page, request.Params.PerPage)
 
     // Usecase 呼び出し（DTO返却）
     // user.ConditionByName はUsecaseの持ち物
-    list, err := s.uc.GetV1UsersByName(c.Request().Context(), user.ConditionByName{
-        NameKeyword: ptr.StringVal(q.NameKeyword),
+    list, err := s.uc.GetV1UsersByName(ctx, user.ConditionByName{
+        NameKeyword: ptr.StringVal(request.Params.NameKeyword),
         Page:        page,
     })
     if err != nil {

--- a/internal/controller/handler/health/gen/server.gen.go
+++ b/internal/controller/handler/health/gen/server.gen.go
@@ -4,7 +4,13 @@
 package gen
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
 	"github.com/labstack/echo/v4"
+	strictecho "github.com/oapi-codegen/runtime/strictmiddleware/echo"
 )
 
 // ServerInterface represents all server handlers.
@@ -58,4 +64,62 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 
 	router.GET(baseURL+"/health", wrapper.GetHealth)
 
+}
+
+type GetHealthRequestObject struct {
+}
+
+type GetHealthResponseObject interface {
+	VisitGetHealthResponse(w http.ResponseWriter) error
+}
+
+type GetHealth200JSONResponse ResponseHealth
+
+func (response GetHealth200JSONResponse) VisitGetHealthResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+// StrictServerInterface represents all server handlers.
+type StrictServerInterface interface {
+	// サーバーのヘルスチェック
+	// (GET /health)
+	GetHealth(ctx context.Context, request GetHealthRequestObject) (GetHealthResponseObject, error)
+}
+
+type StrictHandlerFunc = strictecho.StrictEchoHandlerFunc
+type StrictMiddlewareFunc = strictecho.StrictEchoMiddlewareFunc
+
+func NewStrictHandler(ssi StrictServerInterface, middlewares []StrictMiddlewareFunc) ServerInterface {
+	return &strictHandler{ssi: ssi, middlewares: middlewares}
+}
+
+type strictHandler struct {
+	ssi         StrictServerInterface
+	middlewares []StrictMiddlewareFunc
+}
+
+// GetHealth operation middleware
+func (sh *strictHandler) GetHealth(ctx echo.Context) error {
+	var request GetHealthRequestObject
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetHealth(ctx.Request().Context(), request.(GetHealthRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetHealth")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(GetHealthResponseObject); ok {
+		return validResponse.VisitGetHealthResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
 }

--- a/internal/controller/handler/health/health_handler.go
+++ b/internal/controller/handler/health/health_handler.go
@@ -1,11 +1,11 @@
 //go:generate oapi-codegen --include-tags=health --package=gen --generate=types -o ./gen/type.gen.go /app/openapi/openapi.gen.yaml
-//go:generate oapi-codegen --include-tags=health --package=gen --generate=echo-server -o ./gen/server.gen.go /app/openapi/openapi.gen.yaml
+//go:generate oapi-codegen --include-tags=health --package=gen --generate=echo-server,strict-server -o ./gen/server.gen.go /app/openapi/openapi.gen.yaml
 
 // Package health は、サーバーのヘルスチェックのハンドラーを提供します。
 package health
 
 import (
-	"net/http"
+	"context"
 
 	"boilerplate-go/internal/controller/handler/health/gen"
 
@@ -15,12 +15,12 @@ import (
 type server struct{}
 
 func BindHandler(e *echo.Echo) {
-	gen.RegisterHandlers(e, &server{})
+	gen.RegisterHandlers(e, gen.NewStrictHandler(&server{}, nil))
 }
 
 // GetHealth は、サーバーのヘルスチェックを行います。
-func (s *server) GetHealth(ctx echo.Context) error {
-	return ctx.JSON(http.StatusOK, &gen.ResponseHealth{
+func (s *server) GetHealth(_ context.Context, _ gen.GetHealthRequestObject) (gen.GetHealthResponseObject, error) {
+	return gen.GetHealth200JSONResponse(gen.ResponseHealth{
 		Status: "ok",
-	})
+	}), nil
 }

--- a/internal/controller/handler/health/health_handler_test.go
+++ b/internal/controller/handler/health/health_handler_test.go
@@ -1,6 +1,7 @@
 package health
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -31,20 +32,15 @@ func TestBindHandler(t *testing.T) {
 func TestGetHealth(t *testing.T) {
 	t.Parallel()
 
-	e := echo.New()
-	BindHandler(e)
-
-	_, res, ctx := handlertest.
-		NewEchoTestClient(t, e).
-		Method(http.MethodGet).
-		RequestURL(targetPath).
-		Build()
-
-	s := &server{}
-	err := s.GetHealth(ctx)
-	require.NoError(t, err)
-
+	ctx := context.Background()
 	expectedResponse := gen.ResponseHealth{Status: "ok"}
 
-	handlertest.AssertJSONEqual(t, http.StatusOK, expectedResponse, res)
+	s := &server{}
+	resp, err := s.GetHealth(ctx, gen.GetHealthRequestObject{})
+	require.NoError(t, err)
+
+	actual, ok := resp.(gen.GetHealth200JSONResponse)
+	require.True(t, ok)
+
+	require.Equal(t, expectedResponse, gen.ResponseHealth(actual))
 }

--- a/internal/controller/handler/healthz/gen/server.gen.go
+++ b/internal/controller/handler/healthz/gen/server.gen.go
@@ -4,7 +4,13 @@
 package gen
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
 	"github.com/labstack/echo/v4"
+	strictecho "github.com/oapi-codegen/runtime/strictmiddleware/echo"
 )
 
 // ServerInterface represents all server handlers.
@@ -51,11 +57,68 @@ func RegisterHandlers(router EchoRouter, si ServerInterface) {
 // Registers handlers, and prepends BaseURL to the paths, so that the paths
 // can be served under a prefix.
 func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL string) {
-
 	wrapper := ServerInterfaceWrapper{
 		Handler: si,
 	}
 
 	router.GET(baseURL+"/healthz", wrapper.GetHealthz)
+}
 
+type GetHealthzRequestObject struct{}
+
+type GetHealthzResponseObject interface {
+	VisitGetHealthzResponse(w http.ResponseWriter) error
+}
+
+type GetHealthz200JSONResponse ResponseHealth
+
+func (response GetHealthz200JSONResponse) VisitGetHealthzResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+// StrictServerInterface represents all server handlers.
+type StrictServerInterface interface {
+	// サーバーのヘルスチェック
+	// (GET /healthz)
+	GetHealthz(ctx context.Context, request GetHealthzRequestObject) (GetHealthzResponseObject, error)
+}
+
+type (
+	StrictHandlerFunc    = strictecho.StrictEchoHandlerFunc
+	StrictMiddlewareFunc = strictecho.StrictEchoMiddlewareFunc
+)
+
+func NewStrictHandler(ssi StrictServerInterface, middlewares []StrictMiddlewareFunc) ServerInterface {
+	return &strictHandler{ssi: ssi, middlewares: middlewares}
+}
+
+type strictHandler struct {
+	ssi         StrictServerInterface
+	middlewares []StrictMiddlewareFunc
+}
+
+// GetHealthz operation middleware
+func (sh *strictHandler) GetHealthz(ctx echo.Context) error {
+	var request GetHealthzRequestObject
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetHealthz(ctx.Request().Context(), request.(GetHealthzRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetHealthz")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(GetHealthzResponseObject); ok {
+		return validResponse.VisitGetHealthzResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
 }

--- a/internal/controller/handler/healthz/healthz_handler.go
+++ b/internal/controller/handler/healthz/healthz_handler.go
@@ -1,11 +1,11 @@
 //go:generate oapi-codegen --include-tags=healthz --package=gen --generate=types -o ./gen/type.gen.go /app/openapi/openapi.gen.yaml
-//go:generate oapi-codegen --include-tags=healthz --package=gen --generate=echo-server -o ./gen/server.gen.go /app/openapi/openapi.gen.yaml
+//go:generate oapi-codegen --include-tags=healthz --package=gen --generate=echo-server,strict-server -o ./gen/server.gen.go /app/openapi/openapi.gen.yaml
 
 // Package healthz は、サーバーのヘルスチェックのハンドラーを提供します。
 package healthz
 
 import (
-	"net/http"
+	"context"
 
 	"boilerplate-go/internal/controller/handler/healthz/gen"
 
@@ -15,12 +15,14 @@ import (
 type server struct{}
 
 func BindHandler(e *echo.Echo) {
-	gen.RegisterHandlers(e, &server{})
+	gen.RegisterHandlers(e, gen.NewStrictHandler(&server{}, nil))
 }
 
 // GetHealthz は、サーバーのヘルスチェックを行います。
-func (s *server) GetHealthz(ctx echo.Context) error {
-	return ctx.JSON(http.StatusOK, &gen.ResponseHealth{
+func (s *server) GetHealthz(
+	_ context.Context, _ gen.GetHealthzRequestObject,
+) (gen.GetHealthzResponseObject, error) {
+	return gen.GetHealthz200JSONResponse(gen.ResponseHealth{
 		Status: "ok",
-	})
+	}), nil
 }

--- a/internal/controller/handler/healthz/healthz_handler_test.go
+++ b/internal/controller/handler/healthz/healthz_handler_test.go
@@ -1,6 +1,7 @@
 package healthz
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -32,20 +33,15 @@ func TestBindHandler(t *testing.T) {
 func TestGetHealthz(t *testing.T) {
 	t.Parallel()
 
-	e := echo.New()
-	BindHandler(e)
-
-	_, res, ctx := handlertest.
-		NewEchoTestClient(t, e).
-		Method(http.MethodGet).
-		RequestURL(targetPath).
-		Build()
-
+	ctx := context.Background()
 	s := &server{}
-	err := s.GetHealthz(ctx)
-	require.NoError(t, err)
-
 	expectedResponse := gen.ResponseHealth{Status: "ok"}
 
-	handlertest.AssertJSONEqual(t, http.StatusOK, expectedResponse, res)
+	resp, err := s.GetHealthz(ctx, gen.GetHealthzRequestObject{})
+	require.NoError(t, err)
+
+	actual, ok := resp.(gen.GetHealthz200JSONResponse)
+	require.True(t, ok)
+
+	require.Equal(t, expectedResponse, gen.ResponseHealth(actual))
 }

--- a/internal/controller/handler/v1/users/gen/server.gen.go
+++ b/internal/controller/handler/v1/users/gen/server.gen.go
@@ -4,11 +4,14 @@
 package gen
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 	"github.com/oapi-codegen/runtime"
+	strictecho "github.com/oapi-codegen/runtime/strictmiddleware/echo"
 )
 
 // ServerInterface represents all server handlers.
@@ -98,4 +101,177 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.GET(baseURL+"/v1/users", wrapper.GetUsers)
 	router.POST(baseURL+"/v1/users", wrapper.PostUsers)
 
+}
+
+type GetUsersRequestObject struct {
+	Params GetUsersParams
+}
+
+type GetUsersResponseObject interface {
+	VisitGetUsersResponse(w http.ResponseWriter) error
+}
+
+type GetUsers200JSONResponse ResponseV1Users
+
+func (response GetUsers200JSONResponse) VisitGetUsersResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetUsers401JSONResponse ErrorResponse
+
+func (response GetUsers401JSONResponse) VisitGetUsersResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetUsers403JSONResponse ErrorResponse
+
+func (response GetUsers403JSONResponse) VisitGetUsersResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetUsers500JSONResponse ErrorResponse
+
+func (response GetUsers500JSONResponse) VisitGetUsersResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostUsersRequestObject struct {
+	Body *PostUsersJSONRequestBody
+}
+
+type PostUsersResponseObject interface {
+	VisitPostUsersResponse(w http.ResponseWriter) error
+}
+
+type PostUsers201JSONResponse UserResponse
+
+func (response PostUsers201JSONResponse) VisitPostUsersResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostUsers400JSONResponse ErrorResponse
+
+func (response PostUsers400JSONResponse) VisitPostUsersResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostUsers401JSONResponse ErrorResponse
+
+func (response PostUsers401JSONResponse) VisitPostUsersResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostUsers403JSONResponse ErrorResponse
+
+func (response PostUsers403JSONResponse) VisitPostUsersResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostUsers500JSONResponse ErrorResponse
+
+func (response PostUsers500JSONResponse) VisitPostUsersResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+// StrictServerInterface represents all server handlers.
+type StrictServerInterface interface {
+	// ユーザー一覧の取得
+	// (GET /v1/users)
+	GetUsers(ctx context.Context, request GetUsersRequestObject) (GetUsersResponseObject, error)
+	// ユーザーの作成
+	// (POST /v1/users)
+	PostUsers(ctx context.Context, request PostUsersRequestObject) (PostUsersResponseObject, error)
+}
+
+type StrictHandlerFunc = strictecho.StrictEchoHandlerFunc
+type StrictMiddlewareFunc = strictecho.StrictEchoMiddlewareFunc
+
+func NewStrictHandler(ssi StrictServerInterface, middlewares []StrictMiddlewareFunc) ServerInterface {
+	return &strictHandler{ssi: ssi, middlewares: middlewares}
+}
+
+type strictHandler struct {
+	ssi         StrictServerInterface
+	middlewares []StrictMiddlewareFunc
+}
+
+// GetUsers operation middleware
+func (sh *strictHandler) GetUsers(ctx echo.Context, params GetUsersParams) error {
+	var request GetUsersRequestObject
+
+	request.Params = params
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetUsers(ctx.Request().Context(), request.(GetUsersRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetUsers")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(GetUsersResponseObject); ok {
+		return validResponse.VisitGetUsersResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// PostUsers operation middleware
+func (sh *strictHandler) PostUsers(ctx echo.Context) error {
+	var request PostUsersRequestObject
+
+	var body PostUsersJSONRequestBody
+	if err := ctx.Bind(&body); err != nil {
+		return err
+	}
+	request.Body = &body
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.PostUsers(ctx.Request().Context(), request.(PostUsersRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PostUsers")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(PostUsersResponseObject); ok {
+		return validResponse.VisitPostUsersResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
 }

--- a/internal/controller/handler/v1/users/v1_users_handler.go
+++ b/internal/controller/handler/v1/users/v1_users_handler.go
@@ -1,11 +1,11 @@
 //go:generate oapi-codegen --include-tags=v1/users --package=gen --generate=types -o ./gen/type.gen.go /app/openapi/openapi.gen.yaml
-//go:generate oapi-codegen --include-tags=v1/users --package=gen --generate=echo-server -o ./gen/server.gen.go /app/openapi/openapi.gen.yaml
+//go:generate oapi-codegen --include-tags=v1/users --package=gen --generate=echo-server,strict-server -o ./gen/server.gen.go /app/openapi/openapi.gen.yaml
 
 // Package v1users は、/v1/users エンドポイントに関連するハンドラを提供します。
 package v1users
 
 import (
-	"net/http"
+	"context"
 
 	"boilerplate-go/internal/controller/handler/v1/users/gen"
 	"boilerplate-go/internal/usecase/paging"
@@ -21,23 +21,24 @@ type server struct {
 }
 
 func BindHandler(e *echo.Echo, uc useruc.Usecase) {
-	gen.RegisterHandlers(e, &server{
+	gen.RegisterHandlers(e, gen.NewStrictHandler(&server{
 		uc: uc,
-	})
+	}, nil))
 }
 
 // GetUsers は、ユーザー一覧を取得します。
-func (s *server) GetUsers(ctx echo.Context, params gen.GetUsersParams) error {
+func (s *server) GetUsers(ctx context.Context, request gen.GetUsersRequestObject) (gen.GetUsersResponseObject, error) {
 	// WARN: 本来はここで認可を行うべきですが、今回は省略します。
-	page, err := paging.NewPagingFrom1Based(params.Page, params.PerPage)
+	page, err := paging.NewPagingFrom1Based(request.Params.Page, request.Params.PerPage)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	dtos, err := s.uc.GetAllUsers(ctx.Request().Context(), page)
+	dtos, err := s.uc.GetAllUsers(ctx, page)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
 	users := make([]gen.UserResponse, len(dtos))
 	for i, dto := range dtos {
 		users[i] = gen.UserResponse{
@@ -53,10 +54,10 @@ func (s *server) GetUsers(ctx echo.Context, params gen.GetUsersParams) error {
 		Offset: page.Offset(),
 	}
 
-	return ctx.JSON(http.StatusOK, res)
+	return gen.GetUsers200JSONResponse(res), nil
 }
 
 // PostUsers implements gen.ServerInterface.
-func (s *server) PostUsers(_ echo.Context) error {
+func (s *server) PostUsers(_ context.Context, _ gen.PostUsersRequestObject) (gen.PostUsersResponseObject, error) {
 	panic("unimplemented")
 }

--- a/internal/controller/handler/v1/users/v1_users_handler_test.go
+++ b/internal/controller/handler/v1/users/v1_users_handler_test.go
@@ -150,8 +150,12 @@ func Test_server_GetUsers(t *testing.T) {
 			defer ctrl.Finish()
 
 			invalidPage := 1_000_000
-			invalidParams := mockParams
-			invalidParams.Params.Page = ptr.To(invalidPage)
+			invalidParams := gen.GetUsersRequestObject{
+				Params: gen.GetUsersParams{
+					Page:    ptr.To(invalidPage),
+					PerPage: mockParams.Params.PerPage,
+				},
+			}
 
 			mockApp := mock_useruc.NewMockUsecase(ctrl)
 

--- a/internal/controller/handler/v1/users/v1_users_handler_test.go
+++ b/internal/controller/handler/v1/users/v1_users_handler_test.go
@@ -1,6 +1,7 @@
 package v1users
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -47,6 +48,8 @@ func TestBindHandler(t *testing.T) {
 func Test_server_GetUsers(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
+
 	expectedPage := 1
 	expectedPerPage := 10
 
@@ -56,9 +59,11 @@ func Test_server_GetUsers(t *testing.T) {
 	mockPaging, err := paging.NewPagingFrom1Based(ptr.To(expectedPage), ptr.To(expectedPerPage))
 	require.NoError(t, err)
 
-	mockParams := gen.GetUsersParams{
-		Page:    ptr.To(expectedPage),
-		PerPage: ptr.To(expectedPerPage),
+	mockParams := gen.GetUsersRequestObject{
+		Params: gen.GetUsersParams{
+			Page:    ptr.To(expectedPage),
+			PerPage: ptr.To(expectedPerPage),
+		},
 	}
 
 	t.Run("正常系", func(t *testing.T) {
@@ -66,7 +71,6 @@ func Test_server_GetUsers(t *testing.T) {
 
 		t.Run("複数のユーザーが存在する場合、ユーザー情報のリストが取得できる", func(t *testing.T) {
 			t.Parallel()
-			e := echo.New()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
@@ -93,24 +97,18 @@ func Test_server_GetUsers(t *testing.T) {
 				GetAllUsers(gomock.Any(), mockPaging).
 				Return(mockDTO, nil)
 
-			BindHandler(e, mockApp)
-
-			_, res, ctx := handlertest.
-				NewEchoTestClient(t, e).
-				Method(http.MethodGet).
-				RequestURL(targetPath).
-				Build()
-
 			s := &server{uc: mockApp}
-			err := s.GetUsers(ctx, mockParams)
+			resp, err := s.GetUsers(ctx, mockParams)
 			require.NoError(t, err)
 
-			handlertest.AssertJSONEqual(t, http.StatusOK, expectedResponse, res)
+			actual, ok := resp.(gen.GetUsers200JSONResponse)
+			require.True(t, ok)
+
+			require.Equal(t, expectedResponse, gen.ResponseV1Users(actual))
 		})
 
 		t.Run("単一のユーザーが存在する場合、ユーザー情報のリストが取得できる", func(t *testing.T) {
 			t.Parallel()
-			e := echo.New()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
@@ -132,19 +130,14 @@ func Test_server_GetUsers(t *testing.T) {
 				GetAllUsers(gomock.Any(), mockPaging).
 				Return(mockDTO, nil)
 
-			BindHandler(e, mockApp)
-
-			_, res, ctx := handlertest.
-				NewEchoTestClient(t, e).
-				Method(http.MethodGet).
-				RequestURL(targetPath).
-				Build()
-
 			s := &server{uc: mockApp}
-			err := s.GetUsers(ctx, mockParams)
+			resp, err := s.GetUsers(ctx, mockParams)
 			require.NoError(t, err)
 
-			handlertest.AssertJSONEqual(t, http.StatusOK, expectedResponse, res)
+			actual, ok := resp.(gen.GetUsers200JSONResponse)
+			require.True(t, ok)
+
+			require.Equal(t, expectedResponse, gen.ResponseV1Users(actual))
 		})
 	})
 
@@ -153,39 +146,26 @@ func Test_server_GetUsers(t *testing.T) {
 
 		t.Run("ページング処理が失敗した場合、エラーが返る", func(t *testing.T) {
 			t.Parallel()
-			e := echo.New()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
 			invalidPage := 1_000_000
 			invalidParams := mockParams
-			invalidParams.Page = ptr.To(invalidPage)
+			invalidParams.Params.Page = ptr.To(invalidPage)
 
 			mockApp := mock_useruc.NewMockUsecase(ctrl)
-			BindHandler(e, mockApp)
-
-			_, _, ctx := handlertest.
-				NewEchoTestClient(t, e).
-				Method(http.MethodGet).
-				RequestURL(targetPath).
-				Build()
 
 			s := &server{uc: mockApp}
-			err := s.GetUsers(ctx, invalidParams)
+			resp, err := s.GetUsers(ctx, invalidParams)
+			require.Nil(t, resp)
 			require.ErrorIs(t, err, apperror.ErrInvalidArgument)
 		})
 
 		t.Run("Usecaseがエラーを返した場合、エラーが返る", func(t *testing.T) {
 			t.Parallel()
 
-			e := echo.New()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-
-			mockParams := gen.GetUsersParams{
-				Page:    ptr.To(expectedPage),
-				PerPage: ptr.To(expectedPerPage),
-			}
 
 			expectedError := apperror.ErrInternal
 
@@ -194,16 +174,9 @@ func Test_server_GetUsers(t *testing.T) {
 				GetAllUsers(gomock.Any(), mockPaging).
 				Return(nil, expectedError)
 
-			BindHandler(e, mockApp)
-
-			_, _, ctx := handlertest.
-				NewEchoTestClient(t, e).
-				Method(http.MethodGet).
-				RequestURL(targetPath).
-				Build()
-
 			s := &server{uc: mockApp}
-			err := s.GetUsers(ctx, mockParams)
+			resp, err := s.GetUsers(ctx, mockParams)
+			require.Nil(t, resp)
 			require.ErrorIs(t, err, expectedError)
 		})
 	})

--- a/internal/usecase/user/mock/mock_user_usecase.go
+++ b/internal/usecase/user/mock/mock_user_usecase.go
@@ -10,11 +10,10 @@
 package mock_useruc
 
 import (
-	context "context"
-	reflect "reflect"
-
 	paging "boilerplate-go/internal/usecase/paging"
 	useruc "boilerplate-go/internal/usecase/user"
+	context "context"
+	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
 )


### PR DESCRIPTION
# 概要

<!-- このPRで**何を追加・変更・修正**したのかを簡潔に記述してください。 -->

<!-- - 例: `User API のエンドポイント追加`, `DBマイグレーション追加` -->

- oapi-codegenのルーティング部分を厳密化する

## 変更内容

<!-- - OpenAPI の更新（必要に応じて `openapi/api.yaml`） -->

- internal/controller/handler/health/health_handler.go
- internal/controller/handler/healthz/healthz_handler.go
- internal/controller/handler/v1/users/v1_users_handler.go
  - strict-serverターゲットを追加した
  - strict-serverの仕様に合わせて実装済みのハンドラを修正

## 動作確認方法

<!-- 1. make serve -->

サーバを起動し、各種APIを実行
