### PR TITLE
fmtコマンドの追加とlefthookの調整

### DIFF
--- a/.lefthook.yaml
+++ b/.lefthook.yaml
@@ -1,13 +1,7 @@
 pre-commit:
-  parallel: false
+  parallel: true
   commands:
-    fix:
-      run: make fix
-      stage_fixed: true
     lint:
       run: make lint
     test:
       run: make test
-
-skip_output:
-  - meta

--- a/.makefiles/dev/develop.mk
+++ b/.makefiles/dev/develop.mk
@@ -4,6 +4,7 @@
 .PHONY: tools ## 開発ツールの起動
 .PHONY: install ## goツールのインストール
 .PHONY: tidy-lib ## ローカルライブラリの依存関係更新
+.PHONY: fmt ## コードをフォーマット
 .PHONY: fix ## コードの自動修正
 .PHONY: lint ## コードの静的解析
 .PHONY: test ## CI用のテスト実行
@@ -42,6 +43,11 @@ tools:
 tidy-lib:
 	go mod tidy
 	go mod vendor
+
+fmt:
+	@echo "🔄 コードのフォーマットを実行します..."
+	@go fmt ./...
+	@echo "✅ コードのフォーマットが完了しました。"
 
 fix:
 	@golangci-lint run --fix --config .golangci-full.yaml

--- a/.makefiles/gen/generate.mk
+++ b/.makefiles/gen/generate.mk
@@ -8,6 +8,7 @@
 .PHONY: gen-sqlc ## SQLCのコード生成を行う
 .PHONY: gen-sqlc-repo ## ドメイン用のSQLCのコード生成を行う
 .PHONY: gen-sqlc-qs ## クエリサービス用のSQLCのコード生成を行う
+.PHONY: gen-sqlc-sysq ## システムクエリ用のSQLCのコード生成を行う
 
 gen-ctxkey:
 	@if [ -z "$(name)" ] || [ -z "$(type)" ]; then \
@@ -38,14 +39,23 @@ gen-sqlc:
 	@echo "🔄 SQLCのコードを生成します..."
 	@make gen-sqlc-repo
 	@make gen-sqlc-qs
+	@make gen-sqlc-sysq
 	@echo "✅ SQLCのコード生成が完了しました。"
 
 gen-sqlc-repo:
 	@echo "🔄 ドメイン用のSQLCのコード生成を行います..."; \
 	docker compose run --rm go_tool_runner go run cmd/main.go gen-sqlc --type=repository; \
 	echo "✅ ドメイン用のSQLCのコード生成が完了しました。"
+	@make fmt
 
 gen-sqlc-qs:
 	@echo "🔄 クエリサービス用のSQLCのコード生成を行います..."; \
 	docker compose run --rm go_tool_runner go run cmd/main.go gen-sqlc --type=query_service; \
 	echo "✅ クエリサービス用のSQLCのコード生成が完了しました。"
+	@make fmt
+
+gen-sqlc-sysq:
+	@echo "🔄 システムクエリ用のSQLCのコード生成を行います..."; \
+	docker compose run --rm go_tool_runner go run cmd/main.go gen-sqlc --type=system_query; \
+	echo "✅ システムクエリ用のSQLCのコード生成が完了しました。"
+	@make fmt


### PR DESCRIPTION
# 概要

<!-- このPRで**何を追加・変更・修正**したのかを簡潔に記述してください。 -->

フォーマット用の新しい`make fmt`コマンドを追加しました。
開発ワークフローを改善するためにlefthookのpre-commitを調整しました。

<!-- - 例: `User API のエンドポイント追加`, `DBマイグレーション追加` -->

## 変更内容

<!-- - OpenAPI の更新（必要に応じて `openapi/api.yaml`） -->

- フォーマットの`make fmt`として、`go fmt ./...`を実行するコマンドを追加しました
- SQLC コード生成後の自動フォーマットを実行するように実装
- 並列実行を有効にし、フックから fix コマンドを削除するようにlefthook構成を変更しました。


## 動作確認方法

<!-- 1. make serve -->
