### PR TITLE
Feat: ctrl層用のテスト用インスタンスの関数を作成

### DIFF
--- a/internal/controller/handler/handlertest/test_instance.go
+++ b/internal/controller/handler/handlertest/test_instance.go
@@ -1,0 +1,34 @@
+package handlertest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// NewBindHandlerTestInstance は、BindHandler用インスタンスを生成します。
+func NewBindHandlerTestInstance(t *testing.T) (*echo.Echo, *gomock.Controller) {
+	t.Helper()
+	e := echo.New()
+	ctrl := gomock.NewController(t)
+
+	return e, ctrl
+}
+
+// NewImplementHandlerTestInstances は、エンドポイントのテスト用インスタンスを生成します。
+func NewImplementHandlerTestInstances(t *testing.T) (
+	context.Context, *gomock.Controller, *time.Location,
+) {
+	t.Helper()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	location, err := time.LoadLocation("Asia/Tokyo")
+	require.NoError(t, err)
+
+	return ctx, ctrl, location
+}

--- a/internal/controller/handler/handlertest/test_instance_test.go
+++ b/internal/controller/handler/handlertest/test_instance_test.go
@@ -1,0 +1,30 @@
+package handlertest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBindHandlerTestInstance(t *testing.T) {
+	t.Parallel()
+	e, ctrl := NewBindHandlerTestInstance(t)
+
+	require.NotNil(t, e)
+	require.NotNil(t, ctrl)
+}
+
+func TestNewImplementHandlerTestInstances(t *testing.T) {
+	t.Parallel()
+	expectedCtx := context.Background()
+	expectedLoc, err := time.LoadLocation("Asia/Tokyo")
+	require.NoError(t, err)
+
+	actualCtx, actualCtrl, actualLoc := NewImplementHandlerTestInstances(t)
+
+	require.Equal(t, expectedCtx, actualCtx)
+	require.NotNil(t, actualCtrl)
+	require.Equal(t, expectedLoc, actualLoc)
+}

--- a/internal/controller/handler/health/health_handler_test.go
+++ b/internal/controller/handler/health/health_handler_test.go
@@ -8,7 +8,6 @@ import (
 	"boilerplate-go/internal/controller/handler/handlertest"
 	"boilerplate-go/internal/controller/handler/health/gen"
 
-	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,7 +16,7 @@ const targetPath = "/health"
 func TestBindHandler(t *testing.T) {
 	t.Parallel()
 
-	e := echo.New()
+	e, _ := handlertest.NewBindHandlerTestInstance(t)
 	BindHandler(e)
 
 	expectedMethods := []string{http.MethodGet}

--- a/internal/controller/handler/healthz/healthz_handler_test.go
+++ b/internal/controller/handler/healthz/healthz_handler_test.go
@@ -8,7 +8,6 @@ import (
 	"boilerplate-go/internal/controller/handler/handlertest"
 	"boilerplate-go/internal/controller/handler/healthz/gen"
 
-	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,7 +16,7 @@ const targetPath = "/healthz"
 func TestBindHandler(t *testing.T) {
 	t.Parallel()
 
-	e := echo.New()
+	e, _ := handlertest.NewBindHandlerTestInstance(t)
 	BindHandler(e)
 
 	expectedMethods := []string{http.MethodGet}

--- a/internal/controller/handler/ready/ready_handler_test.go
+++ b/internal/controller/handler/ready/ready_handler_test.go
@@ -1,7 +1,6 @@
 package ready
 
 import (
-	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -13,9 +12,7 @@ import (
 	"boilerplate-go/internal/usecase/healthcheck/query"
 	"boilerplate-go/pkg/xerrors"
 
-	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 )
 
 const targetPath = "/ready"
@@ -23,10 +20,7 @@ const targetPath = "/ready"
 func TestBindHandler(t *testing.T) {
 	t.Parallel()
 
-	e := echo.New()
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	e, ctrl := handlertest.NewBindHandlerTestInstance(t)
 	uc := mock_healthcheckuc.NewMockUsecase(ctrl)
 
 	BindHandler(e, uc)
@@ -44,10 +38,7 @@ func TestBindHandler(t *testing.T) {
 func TestGetReady(t *testing.T) {
 	t.Parallel()
 
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := context.Background()
+	ctx, ctrl, loc := handlertest.NewImplementHandlerTestInstances(t)
 
 	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
@@ -55,8 +46,8 @@ func TestGetReady(t *testing.T) {
 		t.Run("レディネスチェックが成功する", func(t *testing.T) {
 			t.Parallel()
 			expectedStatus := healthcheckuc.Ok
-			expectedAppTime := time.Date(2024, time.June, 1, 12, 0, 1, 0, time.UTC)
-			expectedDBResAt := time.Date(2024, time.June, 1, 12, 0, 2, 0, time.UTC)
+			expectedAppTime := time.Date(2024, time.June, 1, 12, 0, 1, 0, loc)
+			expectedDBResAt := time.Date(2024, time.June, 1, 12, 0, 2, 0, loc)
 			expectedDBLatency := time.Duration(1500000)
 
 			uc := mock_healthcheckuc.NewMockUsecase(ctrl)

--- a/internal/controller/handler/v1/users/v1_users_handler_test.go
+++ b/internal/controller/handler/v1/users/v1_users_handler_test.go
@@ -1,7 +1,6 @@
 package v1users
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -13,7 +12,6 @@ import (
 	mock_useruc "boilerplate-go/internal/usecase/user/mock"
 	"boilerplate-go/pkg/ptr"
 
-	"github.com/labstack/echo/v4"
 	"github.com/oapi-codegen/runtime/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -24,10 +22,7 @@ const targetPath = "/v1/users"
 func TestBindHandler(t *testing.T) {
 	t.Parallel()
 
-	e := echo.New()
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	e, ctrl := handlertest.NewBindHandlerTestInstance(t)
 	mockApp := mock_useruc.NewMockUsecase(ctrl)
 
 	BindHandler(e, mockApp)
@@ -47,8 +42,6 @@ func TestBindHandler(t *testing.T) {
 
 func Test_server_GetUsers(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 
 	expectedPage := 1
 	expectedPerPage := 10
@@ -71,8 +64,7 @@ func Test_server_GetUsers(t *testing.T) {
 
 		t.Run("複数のユーザーが存在する場合、ユーザー情報のリストが取得できる", func(t *testing.T) {
 			t.Parallel()
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+			ctx, ctrl, _ := handlertest.NewImplementHandlerTestInstances(t)
 
 			expectedResponse := gen.ResponseV1Users{
 				Users: []gen.UserResponse{
@@ -109,8 +101,7 @@ func Test_server_GetUsers(t *testing.T) {
 
 		t.Run("単一のユーザーが存在する場合、ユーザー情報のリストが取得できる", func(t *testing.T) {
 			t.Parallel()
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+			ctx, ctrl, _ := handlertest.NewImplementHandlerTestInstances(t)
 
 			expectedResponse := gen.ResponseV1Users{
 				Users: []gen.UserResponse{
@@ -146,8 +137,7 @@ func Test_server_GetUsers(t *testing.T) {
 
 		t.Run("ページング処理が失敗した場合、エラーが返る", func(t *testing.T) {
 			t.Parallel()
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+			ctx, ctrl, _ := handlertest.NewImplementHandlerTestInstances(t)
 
 			invalidPage := 1_000_000
 			invalidParams := gen.GetUsersRequestObject{
@@ -168,8 +158,7 @@ func Test_server_GetUsers(t *testing.T) {
 		t.Run("Usecaseがエラーを返した場合、エラーが返る", func(t *testing.T) {
 			t.Parallel()
 
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+			ctx, ctrl, _ := handlertest.NewImplementHandlerTestInstances(t)
 
 			expectedError := apperror.ErrInternal
 

--- a/internal/integration/v1_users_test.go
+++ b/internal/integration/v1_users_test.go
@@ -20,7 +20,6 @@ func TestV1Users_Integration(t *testing.T) {
 		e := echo.New()
 
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		mockApp := mock_useruc.NewMockUsecase(ctrl)
 		mockApp.EXPECT().
 			GetAllUsers(gomock.Any(), gomock.Any()).

--- a/internal/usecase/healthcheck/health_check_usecase_test.go
+++ b/internal/usecase/healthcheck/health_check_usecase_test.go
@@ -43,7 +43,6 @@ func Test_usecase_CheckHealth(t *testing.T) {
 		t.Run("DBのヘルスチェックが正常な場合、OKステータスが返る", func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockSysQuery := mock_query.NewMockDBSystemQuery(ctrl)
 
 			mockSysQuery.EXPECT().CheckDBHealth(ctx).Return(query.DBHealth{
@@ -81,7 +80,6 @@ func Test_usecase_CheckHealth(t *testing.T) {
 			expectedErr := xerrors.New("DB connection failed")
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			mockSysQuery := mock_query.NewMockDBSystemQuery(ctrl)
 			mockSysQuery.EXPECT().CheckDBHealth(ctx).Return(expectedDBHealth, expectedErr).Times(1)


### PR DESCRIPTION
# 概要

<!-- このPRで**何を追加・変更・修正**したのかを簡潔に記述してください。 -->

<!-- - 例: `User API のエンドポイント追加`, `DBマイグレーション追加` -->

本PRでは、コントローラ層のテストで毎回発生していたボイラープレートコードを削減するため、共通のテストインスタンス生成を一元化するヘルパー関数を追加しました。

## 変更内容

- NewBindHandlerTestInstance() を追加し、
BindHandler のテスト用に Echo インスタンス と gomock.Controller をまとめて生成できるようにした
- NewImplementHandlerTestInstances() を追加し、
Handler 実装テスト向けに context.Context, gomock.Controller, Asia/Tokyo の time.Location をまとめて生成できるようにした
- 既存のテストコードをリファクタリングし、上記ヘルパーを利用する形に統一
→ 重複していたセットアップ処理を削除

<!-- - OpenAPI の更新（必要に応じて `openapi/api.yaml`） -->

## 動作確認方法

<!-- 1. make serve -->

1. make test を実行
2. コントローラ層のテストが正常に通ることを確認
3. 各テストファイルで重複していた Echo や gomock のセットアップコードが存在しないことを確認