### PR TITLE
Feat: コンフィグを分解して、それぞれをDIするようにする

### DIFF
--- a/.github/release/v0.24.0.md
+++ b/.github/release/v0.24.0.md
@@ -7,20 +7,21 @@ DIコンテナが正しく構築されるかを確認するためのWFを追加�
 
 health系のハンドラを定義したOpenAPI仕様の管理場所を変更しました。
 
-レディネスチェック用のエンドポイントを追加実装しました。
+巨大なConfig構造体を分割し、それぞれの責務に応じたConfig構造体に分割しました。
+
+テスト用のトランザクション管理を改善しました。
 
 ## 更新内容
 
 <!-- - 変更内容 -->
 
-- internal/infrastructure/rdb/rdbtest/test_instance.go
-  - driver/を利用して、テスト用トランザクションを構成するように変更
-    - これにより、DB操作をした時に成功でも失敗でも必ずロールバックされるように修正
+DIコンテナが正しく構築されるかを確認するためのWFを追加しました。
+
 - .github/workflows/app-di-startup-check.yaml
   - DIコンテナの起動確認用WFを追加
-- internal/controller/handler/health/health_handler.go
-- internal/controller/handler/healthz/healthz_handler.go
-  - ヘルスチェック用ハンドラの場所を変更
+
+サービスチェック用のAPIを用意し、システム全体の健全性を確認できるようにしました。
+
 - internal/controller/handler/ready/ready_handler.go
 - openapi/components/responses/ReadyResponse.yaml
   - レディネスチェック用ハンドラを追加実装
@@ -28,6 +29,23 @@ health系のハンドラを定義したOpenAPI仕様の管理場所を変更し�
   - ヘルスチェック用ユースケースを追加実装
 - internal/infrastructure/rdb/system_query/health_check/health_check_system_query.go
   - ヘルスチェック用のシステムクエリを追加実装
+
+health系のハンドラを定義したOpenAPI仕様の管理場所を変更しました。
+
+- internal/controller/handler/health/health_handler.go
+- internal/controller/handler/healthz/healthz_handler.go
+  - ヘルスチェック用ハンドラの場所を変更
+
+巨大なConfig構造体を分割し、それぞれの責務に応じたConfig構造体に分割しました。
+
+- config/
+  - Config構造体を分割し、責務に応じたConfig構造体を生成するように変更
+
+テスト用のトランザクション管理を改善しました。
+
+- internal/infrastructure/rdb/rdbtest/test_instance.go
+  - driver/を利用して、テスト用トランザクションを構成するように変更
+    - これにより、DB操作をした時に成功でも失敗でも必ずロールバックされるように修正
 
 ## 追加ライブラリ
 

--- a/.github/workflows/app-di-startup-check.yaml
+++ b/.github/workflows/app-di-startup-check.yaml
@@ -66,7 +66,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          for i in {1..150}; do
+          for i in {1..30}; do
             if curl -fsS "http://localhost:${PORT}/ready" > /dev/null; then
               echo "Readiness check OK"
               exit 0

--- a/internal/cli/gensqlc/gensqlc.go
+++ b/internal/cli/gensqlc/gensqlc.go
@@ -100,7 +100,10 @@ func generateSQLCRun(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		logger.Fatal("failed to load config", zap.NamedError("config", err))
 	}
-	dbURL := cfg.DatabaseDSN()
+	dbCfg := config.NewDatabaseConfig(cfg)
+	osCfg := config.NewOSConfig(cfg)
+
+	dbURL := dbCfg.DatabaseDSN(osCfg)
 
 	// 2) 設定YAMLの読み込み
 	sqlcYamlRaw, err := os.ReadFile(filepath.Join(workDir, sqlcRootDir, settingYamlFile))

--- a/internal/cli/migrate/common.go
+++ b/internal/cli/migrate/common.go
@@ -37,6 +37,8 @@ func buildMigrateInstance(tgtDB string) (*migrate.Migrate, error) {
 	if err != nil {
 		return nil, err
 	}
+	dbCfg := config.NewDatabaseConfig(cfg)
+	osCfg := config.NewOSConfig(cfg)
 
-	return migrate.New("file://"+migrateFilePlace, cfg.DatabaseDSN())
+	return migrate.New("file://"+migrateFilePlace, dbCfg.DatabaseDSN(osCfg))
 }

--- a/internal/cli/seed/seed.go
+++ b/internal/cli/seed/seed.go
@@ -61,8 +61,10 @@ func dbSeedRun(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		logger.Fatal("failed to load config", zap.Error(err))
 	}
+	dbCfg := config.NewDatabaseConfig(cfg)
+	osCfg := config.NewOSConfig(cfg)
 
-	db, err := sql.Open("postgres", cfg.DatabaseDSN())
+	db, err := sql.Open("postgres", dbCfg.DatabaseDSN(osCfg))
 	if err != nil {
 		logger.Panic("failed to open database connection", zap.Error(err))
 	}

--- a/internal/cli/server/metrics.go
+++ b/internal/cli/server/metrics.go
@@ -19,9 +19,12 @@ const (
 // MetricsServer は、メトリクスサーバーを生成します。
 // 非本番環境でのみ有効です。
 func MetricsServer(cfg *config.Config) *http.Server {
-	if !cfg.IsAppProductionMode() {
+	appCfg := config.NewApplicationConfig(cfg)
+
+	if !appCfg.IsAppProductionMode() {
+		mtcCfg := config.NewMetricsConfig(cfg)
 		return &http.Server{
-			Addr:              cfg.MetricsHost() + ":" + strconv.Itoa(cfg.MetricsPort()),
+			Addr:              mtcCfg.MetricsHost() + ":" + strconv.Itoa(mtcCfg.MetricsPort()),
 			Handler:           http.DefaultServeMux,
 			ReadHeaderTimeout: readHeaderTimeout,
 			ReadTimeout:       readTimeout,

--- a/internal/cli/server/serve.go
+++ b/internal/cli/server/serve.go
@@ -34,9 +34,10 @@ func serveRun(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	appCfg := config.NewApplicationConfig(cfg)
 
 	var metricsSrv *http.Server
-	if !cfg.IsAppProductionMode() {
+	if !appCfg.IsAppProductionMode() {
 		// 非本番環境では、メトリクスサーバーを起動
 		metricsSrv = MetricsServer(cfg)
 		go func() {
@@ -70,7 +71,7 @@ func serveRun(_ *cobra.Command, _ []string) error {
 
 	stopCtx, cancel := context.WithTimeout(
 		context.Background(),
-		cfg.AppShutdownTimeout(),
+		appCfg.AppShutdownTimeout(),
 	)
 	defer cancel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,24 +27,24 @@ func New() (*Config, error) {
 	}
 
 	return &Config{
-		os: operationSystem{
+		os: OperationSystemConfig{
 			timezone: cfg.OS.Timezone,
 		},
-		app: application{
+		app: ApplicationConfig{
 			env:             cfg.App.Env,
 			mode:            cfg.App.Mode,
 			shutdownTimeout: cfg.App.ShutdownTimeout,
 		},
-		server: server{
+		server: ServerConfig{
 			host:            cfg.Server.Host,
 			port:            cfg.Server.Port,
 			shutdownTimeout: cfg.Server.ShutdownTimeout,
 		},
-		metrics: metrics{
+		metrics: MetricsConfig{
 			host: cfg.Metrics.Host,
 			port: cfg.Metrics.Port,
 		},
-		database: database{
+		database: DatabaseConfig{
 			driver:   cfg.Database.Driver,
 			host:     cfg.Database.Host,
 			port:     cfg.Database.Port,
@@ -52,14 +52,14 @@ func New() (*Config, error) {
 			password: cfg.Database.Password,
 			name:     cfg.Database.Name,
 			sslMode:  cfg.Database.SSLMode,
-			connection: connection{
+			connection: DBConnectionConfig{
 				maxOpenConns: cfg.Database.Connection.MaxOpenConns,
 				maxIdleConns: cfg.Database.Connection.MaxIdleConns,
 				maxLifetime:  cfg.Database.Connection.MaxLifetime,
 				maxIdleTime:  cfg.Database.Connection.MaxIdleTime,
 			},
 		},
-		security: security{
+		security: SecurityConfig{
 			allowedOrigins: cfg.Security.AllowedOrigins,
 			cidr:           v.cidr,
 		},
@@ -102,28 +102,4 @@ func validateConfig(cfg Loader) (*validatedConfig, error) {
 	return &validatedConfig{
 		cidr: cidr,
 	}, nil
-}
-
-// IsAppProductionMode は、アプリケーションが本番環境モードかどうかを返します。
-func (c *Config) IsAppProductionMode() bool {
-	return c.app.mode == ProductionMode
-}
-
-// IsAppDevelopmentMode は、アプリケーションが開発環境モードかどうかを返します。
-func (c *Config) IsAppDevelopmentMode() bool {
-	return c.app.mode == DevelopmentMode
-}
-
-// DatabaseDSN は、データベースの接続URLを返します。
-func (c *Config) DatabaseDSN() string {
-	return fmt.Sprintf(
-		"postgres://%s:%s@%s:%d/%s?sslmode=%s&timezone=%s",
-		c.database.user,
-		c.database.password,
-		c.database.host,
-		c.database.port,
-		c.database.name,
-		c.database.sslMode,
-		url.QueryEscape(c.os.timezone),
-	)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"fmt"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -15,24 +13,24 @@ func TestNewConfig(t *testing.T) {
 		t.Run("configに必要な環境変数が全て設定されている場合", func(t *testing.T) {
 			setEnv(t)
 			expected := &Config{
-				os: operationSystem{
+				os: OperationSystemConfig{
 					timezone: expectedOSTimeZone,
 				},
-				app: application{
+				app: ApplicationConfig{
 					env:             expectedApplicationEnv,
 					mode:            expectedApplicationMode,
 					shutdownTimeout: expectedAppShutdownTimeout,
 				},
-				server: server{
+				server: ServerConfig{
 					host:            expectedHost,
 					port:            expectedPort,
 					shutdownTimeout: expectedServerShutdownTimeout,
 				},
-				metrics: metrics{
+				metrics: MetricsConfig{
 					host: expectedMetricsHost,
 					port: expectedMetricsPort,
 				},
-				database: database{
+				database: DatabaseConfig{
 					driver:   expectedDBDriver,
 					host:     expectedDBHost,
 					port:     expectedDBPort,
@@ -40,14 +38,14 @@ func TestNewConfig(t *testing.T) {
 					password: expectedDBPassword,
 					name:     expectedDBName,
 					sslMode:  expectedDBSSLMode,
-					connection: connection{
+					connection: DBConnectionConfig{
 						maxOpenConns: expectedDBMaxOpenConns,
 						maxIdleConns: expectedDBMaxIdleConns,
 						maxLifetime:  expectedDBMaxLifetime,
 						maxIdleTime:  expectedDBMaxIdleTime,
 					},
 				},
-				security: security{
+				security: SecurityConfig{
 					allowedOrigins: strings.Split(expectedAllowedOrigins, ","),
 					cidr:           expectedCIDR,
 				},
@@ -148,60 +146,5 @@ func Test_validateConfig(t *testing.T) {
 			require.Nil(t, actual)
 			require.ErrorIs(t, err, ErrFailedToParseCIDR)
 		})
-	})
-}
-
-func TestIsAppProductionMode(t *testing.T) {
-	t.Parallel()
-	t.Run("本番環境モードの場合", func(t *testing.T) {
-		t.Parallel()
-		cfg := Config{}
-		cfg.app.mode = ProductionMode
-		require.True(t, cfg.IsAppProductionMode())
-	})
-
-	t.Run("開発環境モードの場合", func(t *testing.T) {
-		t.Parallel()
-		cfg := Config{}
-		cfg.app.mode = DevelopmentMode
-		require.False(t, cfg.IsAppProductionMode())
-	})
-}
-
-func TestIsAppDevelopmentMode(t *testing.T) {
-	t.Parallel()
-	t.Run("開発環境モードの場合", func(t *testing.T) {
-		t.Parallel()
-		cfg := Config{}
-		cfg.app.mode = DevelopmentMode
-		require.True(t, cfg.IsAppDevelopmentMode())
-	})
-
-	t.Run("本番環境モードの場合", func(t *testing.T) {
-		t.Parallel()
-		cfg := Config{}
-		cfg.app.mode = ProductionMode
-		require.False(t, cfg.IsAppDevelopmentMode())
-	})
-}
-
-func TestDatabaseURL(t *testing.T) {
-	t.Parallel()
-
-	cfg := MockConfigForTest(t)
-
-	t.Run("DatabaseURL", func(t *testing.T) {
-		t.Parallel()
-		expectedURL := fmt.Sprintf(
-			"postgres://%s:%s@%s:%d/%s?sslmode=%s&timezone=%s",
-			expectedDBUser,
-			expectedDBPassword,
-			expectedDBHost,
-			expectedDBPort,
-			expectedDBName,
-			expectedDBSSLMode,
-			url.QueryEscape(expectedOSTimeZone),
-		)
-		require.Equal(t, expectedURL, cfg.DatabaseDSN())
 	})
 }

--- a/internal/config/config_testing_mock.go
+++ b/internal/config/config_testing_mock.go
@@ -55,24 +55,24 @@ var (
 func MockConfigForTest(t testing.TB) *Config {
 	t.Helper()
 	return &Config{
-		os: operationSystem{
+		os: OperationSystemConfig{
 			timezone: expectedOSTimeZone,
 		},
-		app: application{
+		app: ApplicationConfig{
 			env:             expectedApplicationEnv,
 			mode:            expectedApplicationMode,
 			shutdownTimeout: expectedAppShutdownTimeout,
 		},
-		server: server{
+		server: ServerConfig{
 			host:            expectedHost,
 			port:            expectedPort,
 			shutdownTimeout: expectedServerShutdownTimeout,
 		},
-		metrics: metrics{
+		metrics: MetricsConfig{
 			host: expectedMetricsHost,
 			port: expectedMetricsPort,
 		},
-		database: database{
+		database: DatabaseConfig{
 			driver:   expectedDBDriver,
 			host:     expectedDBHost,
 			port:     expectedDBPort,
@@ -80,14 +80,14 @@ func MockConfigForTest(t testing.TB) *Config {
 			password: expectedDBPassword,
 			name:     expectedDBName,
 			sslMode:  expectedDBSSLMode,
-			connection: connection{
+			connection: DBConnectionConfig{
 				maxOpenConns: expectedDBMaxOpenConns,
 				maxIdleConns: expectedDBMaxIdleConns,
 				maxLifetime:  expectedDBMaxLifetime,
 				maxIdleTime:  expectedDBMaxIdleTime,
 			},
 		},
-		security: security{
+		security: SecurityConfig{
 			allowedOrigins: strings.Split(expectedAllowedOrigins, ","),
 			cidr:           expectedCIDR,
 		},

--- a/internal/config/config_testing_mock_test.go
+++ b/internal/config/config_testing_mock_test.go
@@ -12,24 +12,24 @@ import (
 func TestMockConfigForTest(t *testing.T) {
 	t.Parallel()
 	expected := &Config{
-		os: operationSystem{
+		os: OperationSystemConfig{
 			timezone: expectedOSTimeZone,
 		},
-		app: application{
+		app: ApplicationConfig{
 			env:             expectedApplicationEnv,
 			mode:            expectedApplicationMode,
 			shutdownTimeout: expectedAppShutdownTimeout,
 		},
-		server: server{
+		server: ServerConfig{
 			host:            expectedHost,
 			port:            expectedPort,
 			shutdownTimeout: expectedServerShutdownTimeout,
 		},
-		metrics: metrics{
+		metrics: MetricsConfig{
 			host: expectedMetricsHost,
 			port: expectedMetricsPort,
 		},
-		database: database{
+		database: DatabaseConfig{
 			driver:   expectedDBDriver,
 			host:     expectedDBHost,
 			port:     expectedDBPort,
@@ -37,14 +37,14 @@ func TestMockConfigForTest(t *testing.T) {
 			password: expectedDBPassword,
 			name:     expectedDBName,
 			sslMode:  expectedDBSSLMode,
-			connection: connection{
+			connection: DBConnectionConfig{
 				maxOpenConns: expectedDBMaxOpenConns,
 				maxIdleConns: expectedDBMaxIdleConns,
 				maxLifetime:  expectedDBMaxLifetime,
 				maxIdleTime:  expectedDBMaxIdleTime,
 			},
 		},
-		security: security{
+		security: SecurityConfig{
 			allowedOrigins: strings.Split(expectedAllowedOrigins, ","),
 			cidr:           expectedCIDR,
 		},

--- a/internal/config/config_testing_setter.go
+++ b/internal/config/config_testing_setter.go
@@ -12,49 +12,49 @@ import (
 // SetServerAppMode は、テスト用にサーバーのAppModeを設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (c *Config) SetServerAppMode(t testing.TB, mode string) {
+func (a *ApplicationConfig) SetServerAppMode(t testing.TB, mode string) {
 	t.Helper()
-	prev := c.AppMode()
-	c.app.mode = mode
-	t.Cleanup(func() { c.app.mode = prev })
+	prev := a.AppMode()
+	a.mode = mode
+	t.Cleanup(func() { a.mode = prev })
 }
 
 // SetDatabaseDriver は、テスト用にデータベースのドライバーを設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (c *Config) SetDatabaseDriver(t testing.TB, driver string) {
+func (d *DatabaseConfig) SetDatabaseDriver(t testing.TB, driver string) {
 	t.Helper()
-	prev := c.DatabaseDriver()
-	c.database.driver = driver
-	t.Cleanup(func() { c.database.driver = prev })
+	prev := d.DatabaseDriver()
+	d.driver = driver
+	t.Cleanup(func() { d.driver = prev })
 }
 
 // SetDatabaseHost は、テスト用にデータベースのホスト名を設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (c *Config) SetDatabaseHost(t testing.TB, host string) {
+func (d *DatabaseConfig) SetDatabaseHost(t testing.TB, host string) {
 	t.Helper()
-	prev := c.DatabaseHost()
-	c.database.host = host
-	t.Cleanup(func() { c.database.host = prev })
+	prev := d.DatabaseHost()
+	d.host = host
+	t.Cleanup(func() { d.host = prev })
 }
 
 // SetDatabaseName は、テスト用にデータベースの名前を設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (c *Config) SetDatabaseName(t testing.TB, name string) {
+func (d *DatabaseConfig) SetDatabaseName(t testing.TB, name string) {
 	t.Helper()
-	prev := c.DatabaseName()
-	c.database.name = name
-	t.Cleanup(func() { c.database.name = prev })
+	prev := d.DatabaseName()
+	d.name = name
+	t.Cleanup(func() { d.name = prev })
 }
 
 // SetCIDR は、テスト用にセキュリティのCIDRを設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (c *Config) SetCIDR(t testing.TB, cidr *net.IPNet) {
+func (s *SecurityConfig) SetCIDR(t testing.TB, cidr *net.IPNet) {
 	t.Helper()
-	prev := c.CIDR()
-	c.security.cidr = cidr
-	t.Cleanup(func() { c.security.cidr = prev })
+	prev := s.CIDR()
+	s.cidr = cidr
+	t.Cleanup(func() { s.cidr = prev })
 }

--- a/internal/config/config_testing_setter_test.go
+++ b/internal/config/config_testing_setter_test.go
@@ -12,31 +12,31 @@ func TestConfigTestingSetters(t *testing.T) {
 
 	t.Run("SetAppMode", func(t *testing.T) {
 		expected := "test-mode"
-		cfg.SetServerAppMode(t, expected)
-		require.Equal(t, expected, cfg.AppMode())
+		cfg.app.SetServerAppMode(t, expected)
+		require.Equal(t, expected, cfg.app.AppMode())
 	})
 
 	t.Run("SetDatabaseDriver", func(t *testing.T) {
 		expected := "test-driver"
-		cfg.SetDatabaseDriver(t, expected)
-		require.Equal(t, expected, cfg.DatabaseDriver())
+		cfg.database.SetDatabaseDriver(t, expected)
+		require.Equal(t, expected, cfg.database.DatabaseDriver())
 	})
 
 	t.Run("SetDatabaseHost", func(t *testing.T) {
 		expected := "test-host"
-		cfg.SetDatabaseHost(t, expected)
-		require.Equal(t, expected, cfg.DatabaseHost())
+		cfg.database.SetDatabaseHost(t, expected)
+		require.Equal(t, expected, cfg.database.DatabaseHost())
 	})
 
 	t.Run("SetDatabaseName", func(t *testing.T) {
 		expected := "test-name"
-		cfg.SetDatabaseName(t, expected)
-		require.Equal(t, expected, cfg.DatabaseName())
+		cfg.database.SetDatabaseName(t, expected)
+		require.Equal(t, expected, cfg.database.DatabaseName())
 	})
 
 	t.Run("SetCIDR", func(t *testing.T) {
 		_, testCIDR, _ := net.ParseCIDR("192.168.1.0/24")
-		cfg.SetCIDR(t, testCIDR)
-		require.Equal(t, testCIDR, cfg.CIDR())
+		cfg.security.SetCIDR(t, testCIDR)
+		require.Equal(t, testCIDR, cfg.security.CIDR())
 	})
 }

--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -1,41 +1,43 @@
 package config
 
 import (
+	"fmt"
 	"net"
+	"net/url"
 	"time"
 )
 
 type Config struct {
-	os       operationSystem
-	app      application
-	server   server
-	metrics  metrics
-	database database
-	security security
+	os       OperationSystemConfig
+	app      ApplicationConfig
+	server   ServerConfig
+	metrics  MetricsConfig
+	database DatabaseConfig
+	security SecurityConfig
 }
 
-type operationSystem struct {
+type OperationSystemConfig struct {
 	timezone string
 }
 
-type application struct {
+type ApplicationConfig struct {
 	env             string
 	mode            string
 	shutdownTimeout time.Duration
 }
 
-type server struct {
+type ServerConfig struct {
 	host            string
 	port            int
 	shutdownTimeout time.Duration
 }
 
-type metrics struct {
+type MetricsConfig struct {
 	host string
 	port int
 }
 
-type database struct {
+type DatabaseConfig struct {
 	driver     string
 	host       string
 	port       int
@@ -43,92 +45,132 @@ type database struct {
 	password   string
 	name       string
 	sslMode    string
-	connection connection
+	connection DBConnectionConfig
 }
 
-type connection struct {
+type DBConnectionConfig struct {
 	maxOpenConns int
 	maxIdleConns int
 	maxLifetime  time.Duration
 	maxIdleTime  time.Duration
 }
 
-type security struct {
+type SecurityConfig struct {
 	allowedOrigins []string
 	cidr           *net.IPNet
 }
 
+// NewOSConfig は、OSの設定を返します。
+func NewOSConfig(cfg *Config) *OperationSystemConfig { return &cfg.os }
+
 // OSTimeZone は、OSのタイムゾーンを返します。
-func (c *Config) OSTimeZone() string { return c.os.timezone }
+func (o *OperationSystemConfig) OSTimeZone() string { return o.timezone }
 
-// ServerHost は、サーバーがリッスンするホスト名を返します。
-func (c *Config) ServerHost() string { return c.server.host }
-
-// ServerPort は、サーバーがリッスンするポート番号を返します。
-func (c *Config) ServerPort() int { return c.server.port }
-
-// ServerShutdownTimeout は、サーバー停止までの規定時間を返します。
-func (c *Config) ServerShutdownTimeout() time.Duration { return c.server.shutdownTimeout }
-
-// MetricsHost は、メトリクスサーバーがリッスンするホスト名を返します。
-func (c *Config) MetricsHost() string { return c.metrics.host }
-
-// MetricsPort は、メトリクスサーバーがリッスンするポート番号を返します。
-func (c *Config) MetricsPort() int { return c.metrics.port }
+// NewApplicationConfig は、アプリケーションの設定を返します。
+func NewApplicationConfig(cfg *Config) *ApplicationConfig { return &cfg.app }
 
 // AppEnv は、サーバーの環境を返します。
 //
 // 例: "local", "development", "staging", "production" など。
-func (c *Config) AppEnv() string { return c.app.env }
+func (a *ApplicationConfig) AppEnv() string { return a.env }
 
 // AppMode は、アプリケーションの環境を返します。
 //
 // この環境変数はアプリケーションがどのモードで動作しているかを示します。
 // 例: "development", "production" など。
-func (c *Config) AppMode() string { return c.app.mode }
+func (a *ApplicationConfig) AppMode() string { return a.mode }
 
 // AppShutdownTimeout は、アプリケーションのシャットダウンタイムアウトを返します。
-func (c *Config) AppShutdownTimeout() time.Duration { return c.app.shutdownTimeout }
+func (a *ApplicationConfig) AppShutdownTimeout() time.Duration { return a.shutdownTimeout }
+
+// IsAppProductionMode は、アプリケーションが本番環境モードかどうかを返します。
+func (a *ApplicationConfig) IsAppProductionMode() bool {
+	return a.mode == ProductionMode
+}
+
+// IsAppDevelopmentMode は、アプリケーションが開発環境モードかどうかを返します。
+func (a *ApplicationConfig) IsAppDevelopmentMode() bool {
+	return a.mode == DevelopmentMode
+}
+
+// NewServerConfig は、サーバーの設定を返します。
+func NewServerConfig(cfg *Config) *ServerConfig { return &cfg.server }
+
+// ServerHost は、サーバーがリッスンするホスト名を返します。
+func (s *ServerConfig) ServerHost() string { return s.host }
+
+// ServerPort は、サーバーがリッスンするポート番号を返します。
+func (s *ServerConfig) ServerPort() int { return s.port }
+
+// ServerShutdownTimeout は、サーバー停止までの規定時間を返します。
+func (s *ServerConfig) ServerShutdownTimeout() time.Duration { return s.shutdownTimeout }
+
+// NewMetricsConfig は、メトリクスの設定を返します。
+func NewMetricsConfig(cfg *Config) *MetricsConfig { return &cfg.metrics }
+
+// MetricsHost は、メトリクスサーバーがリッスンするホスト名を返します。
+func (m *MetricsConfig) MetricsHost() string { return m.host }
+
+// MetricsPort は、メトリクスサーバーがリッスンするポート番号を返します。
+func (m *MetricsConfig) MetricsPort() int { return m.port }
+
+// NewDatabaseConfig は、データベースの設定を返します。
+func NewDatabaseConfig(cfg *Config) *DatabaseConfig { return &cfg.database }
 
 // DatabaseDriver は、データベースのドライバー名を返します。
-func (c *Config) DatabaseDriver() string { return c.database.driver }
+func (d *DatabaseConfig) DatabaseDriver() string { return d.driver }
 
 // DatabaseHost は、データベースのホスト名を返します。
-func (c *Config) DatabaseHost() string { return c.database.host }
+func (d *DatabaseConfig) DatabaseHost() string { return d.host }
 
 // DatabasePort は、データベースのポート番号を返します。
-func (c *Config) DatabasePort() int { return c.database.port }
+func (d *DatabaseConfig) DatabasePort() int { return d.port }
 
 // DatabaseUser は、データベースのユーザー名を返します。
-func (c *Config) DatabaseUser() string { return c.database.user }
+func (d *DatabaseConfig) DatabaseUser() string { return d.user }
 
 // DatabasePassword は、データベースのパスワードを返します。
-func (c *Config) DatabasePassword() string { return c.database.password }
+func (d *DatabaseConfig) DatabasePassword() string { return d.password }
 
 // DatabaseName は、データベースの名前を返します。
-func (c *Config) DatabaseName() string { return c.database.name }
+func (d *DatabaseConfig) DatabaseName() string { return d.name }
 
 // DatabaseSSLMode は、データベースのSSLモードを返します。
-func (c *Config) DatabaseSSLMode() string { return c.database.sslMode }
+func (d *DatabaseConfig) DatabaseSSLMode() string { return d.sslMode }
+
+// DatabaseDSN は、データベースの接続URLを返します。
+func (d *DatabaseConfig) DatabaseDSN(o *OperationSystemConfig) string {
+	return fmt.Sprintf(
+		"postgres://%s:%s@%s:%d/%s?sslmode=%s&timezone=%s",
+		d.user,
+		d.password,
+		d.host,
+		d.port,
+		d.name,
+		d.sslMode,
+		url.QueryEscape(o.timezone),
+	)
+}
+
+// NewDBConnectionConfig は、データベース接続の設定を返します。
+func NewDBConnectionConfig(cfg *Config) *DBConnectionConfig { return &cfg.database.connection }
 
 // DBMaxOpenConns は、データベースの最大オープン接続数を返します。
-func (c *Config) DBMaxOpenConns() int { return c.database.connection.maxOpenConns }
+func (c *DBConnectionConfig) DBMaxOpenConns() int { return c.maxOpenConns }
 
 // DBMaxIdleConns は、データベースの最大アイドル接続数を返します。
-func (c *Config) DBMaxIdleConns() int { return c.database.connection.maxIdleConns }
+func (c *DBConnectionConfig) DBMaxIdleConns() int { return c.maxIdleConns }
 
 // DBConnMaxLifetime は、データベースの接続の最大寿命を返します。
-func (c *Config) DBConnMaxLifetime() time.Duration { return c.database.connection.maxLifetime }
+func (c *DBConnectionConfig) DBConnMaxLifetime() time.Duration { return c.maxLifetime }
 
 // DBConnMaxIdleTime は、データベースの接続の最大アイドル時間を返します。
-func (c *Config) DBConnMaxIdleTime() time.Duration { return c.database.connection.maxIdleTime }
+func (c *DBConnectionConfig) DBConnMaxIdleTime() time.Duration { return c.maxIdleTime }
+
+func NewSecurityConfig(cfg *Config) *SecurityConfig { return &cfg.security }
 
 // AllowedOrigins は、CORSを許可するオリジンのリストを返します。
-func (c *Config) AllowedOrigins() []string {
-	return c.security.allowedOrigins
-}
+func (s *SecurityConfig) AllowedOrigins() []string { return s.allowedOrigins }
 
 // CIDR は、セキュリティ設定で使用されるCIDRを返します。
-func (c *Config) CIDR() *net.IPNet {
-	return c.security.cidr
-}
+func (s *SecurityConfig) CIDR() *net.IPNet { return s.cidr }

--- a/internal/config/model_test.go
+++ b/internal/config/model_test.go
@@ -1,128 +1,261 @@
 package config
 
 import (
+	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
+func TestConstructor(t *testing.T) {
+	t.Parallel()
+	cfg := MockConfigForTest(t)
+
+	t.Run("NewOSConfig", func(t *testing.T) {
+		t.Parallel()
+		osCfg := NewOSConfig(cfg)
+		require.Equal(t, &cfg.os, osCfg)
+	})
+
+	t.Run("NewServerConfig", func(t *testing.T) {
+		t.Parallel()
+		serverCfg := NewServerConfig(cfg)
+		require.Equal(t, &cfg.server, serverCfg)
+	})
+
+	t.Run("NewMetricsConfig", func(t *testing.T) {
+		t.Parallel()
+		metricsCfg := NewMetricsConfig(cfg)
+		require.Equal(t, &cfg.metrics, metricsCfg)
+	})
+
+	t.Run("NewApplicationConfig", func(t *testing.T) {
+		t.Parallel()
+		appCfg := NewApplicationConfig(cfg)
+		require.Equal(t, &cfg.app, appCfg)
+	})
+
+	t.Run("NewDatabaseConfig", func(t *testing.T) {
+		t.Parallel()
+		dbCfg := NewDatabaseConfig(cfg)
+		require.Equal(t, &cfg.database, dbCfg)
+	})
+
+	t.Run("NewDBConnectionConfig", func(t *testing.T) {
+		t.Parallel()
+		dbConnCfg := NewDBConnectionConfig(cfg)
+		require.Equal(t, &cfg.database.connection, dbConnCfg)
+	})
+
+	t.Run("NewSecurityConfig", func(t *testing.T) {
+		t.Parallel()
+		securityCfg := NewSecurityConfig(cfg)
+		require.Equal(t, &cfg.security, securityCfg)
+	})
+}
+
 func TestGetterMethods(t *testing.T) {
 	t.Parallel()
 
 	cfg := MockConfigForTest(t)
 
-	t.Run("OSTimeZone", func(t *testing.T) {
+	t.Run("OperatingSystem", func(t *testing.T) {
 		t.Parallel()
-		require.Equal(t, expectedOSTimeZone, cfg.OSTimeZone())
+		os := cfg.os
+		t.Run("OSTimeZone", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedOSTimeZone, os.OSTimeZone())
+		})
 	})
 
-	t.Run("ServerHost", func(t *testing.T) {
+	t.Run("Server", func(t *testing.T) {
 		t.Parallel()
-		require.Equal(t, expectedHost, cfg.ServerHost())
+		server := cfg.server
+		t.Run("ServerHost", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedHost, server.ServerHost())
+		})
+
+		t.Run("ServerPort", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedPort, server.ServerPort())
+		})
+
+		t.Run("ServerShutdownTimeout", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedServerShutdownTimeout, server.ServerShutdownTimeout())
+		})
 	})
 
-	t.Run("ServerPort", func(t *testing.T) {
+	t.Run("Metrics", func(t *testing.T) {
 		t.Parallel()
-		require.Equal(t, expectedPort, cfg.ServerPort())
+		metrics := cfg.metrics
+
+		t.Run("MetricsHost", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedMetricsHost, metrics.MetricsHost())
+		})
+
+		t.Run("MetricsPort", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedMetricsPort, metrics.MetricsPort())
+		})
 	})
 
-	t.Run("ServerShutdownTimeout", func(t *testing.T) {
+	t.Run("Application", func(t *testing.T) {
 		t.Parallel()
-		require.Equal(t, expectedServerShutdownTimeout, cfg.ServerShutdownTimeout())
+		app := cfg.app
+		t.Run("AppEnv", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedApplicationEnv, app.AppEnv())
+		})
+
+		t.Run("AppMode", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedApplicationMode, app.AppMode())
+		})
+
+		t.Run("AppShutdownTimeout", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedAppShutdownTimeout, app.AppShutdownTimeout())
+		})
 	})
 
-	t.Run("MetricsHost", func(t *testing.T) {
+	t.Run("Database", func(t *testing.T) {
 		t.Parallel()
-		require.Equal(t, expectedMetricsHost, cfg.MetricsHost())
+		database := cfg.database
+		t.Run("DatabaseDriver", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedDBDriver, database.DatabaseDriver())
+		})
+
+		t.Run("DatabaseHost", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedDBHost, database.DatabaseHost())
+		})
+
+		t.Run("DatabasePort", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedDBPort, database.DatabasePort())
+		})
+
+		t.Run("DatabaseUser", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedDBUser, database.DatabaseUser())
+		})
+
+		t.Run("DatabasePassword", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedDBPassword, database.DatabasePassword())
+		})
+
+		t.Run("DatabaseName", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedDBName, database.DatabaseName())
+		})
+
+		t.Run("DatabaseSSLMode", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedDBSSLMode, database.DatabaseSSLMode())
+		})
 	})
 
-	t.Run("MetricsPort", func(t *testing.T) {
+	t.Run("DBConnection", func(t *testing.T) {
 		t.Parallel()
-		require.Equal(t, expectedMetricsPort, cfg.MetricsPort())
+		connection := cfg.database.connection
+		t.Run("DBMaxOpenConns", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedDBMaxOpenConns, connection.DBMaxOpenConns())
+		})
+
+		t.Run("DBMaxIdleConns", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedDBMaxIdleConns, connection.DBMaxIdleConns())
+		})
+
+		t.Run("DBConnMaxLifetime", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedDBMaxLifetime, connection.DBConnMaxLifetime())
+		})
+
+		t.Run("DBConnMaxIdleTime", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedDBMaxIdleTime, connection.DBConnMaxIdleTime())
+		})
 	})
 
-	t.Run("AppEnv", func(t *testing.T) {
+	t.Run("Security", func(t *testing.T) {
 		t.Parallel()
-		require.Equal(t, expectedApplicationEnv, cfg.AppEnv())
+		security := cfg.security
+		t.Run("AllowedOrigins", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(
+				t,
+				strings.Split(expectedAllowedOrigins, ","),
+				security.AllowedOrigins(),
+			)
+		})
+
+		t.Run("CIDR", func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, expectedCIDR, security.CIDR())
+		})
+	})
+}
+
+func TestIsAppProductionMode(t *testing.T) {
+	t.Parallel()
+	t.Run("本番環境モードの場合", func(t *testing.T) {
+		t.Parallel()
+		cfg := Config{}
+		cfg.app.mode = ProductionMode
+		require.True(t, cfg.app.IsAppProductionMode())
 	})
 
-	t.Run("AppMode", func(t *testing.T) {
+	t.Run("開発環境モードの場合", func(t *testing.T) {
 		t.Parallel()
-		require.Equal(t, expectedApplicationMode, cfg.AppMode())
+		cfg := Config{}
+		cfg.app.mode = DevelopmentMode
+		require.False(t, cfg.app.IsAppProductionMode())
+	})
+}
+
+func TestIsAppDevelopmentMode(t *testing.T) {
+	t.Parallel()
+	t.Run("開発環境モードの場合", func(t *testing.T) {
+		t.Parallel()
+		cfg := Config{}
+		cfg.app.mode = DevelopmentMode
+		require.True(t, cfg.app.IsAppDevelopmentMode())
 	})
 
-	t.Run("AppShutdownTimeout", func(t *testing.T) {
+	t.Run("本番環境モードの場合", func(t *testing.T) {
 		t.Parallel()
-		require.Equal(t, expectedAppShutdownTimeout, cfg.AppShutdownTimeout())
+		cfg := Config{}
+		cfg.app.mode = ProductionMode
+		require.False(t, cfg.app.IsAppDevelopmentMode())
 	})
+}
 
-	t.Run("DatabaseDriver", func(t *testing.T) {
-		t.Parallel()
-		require.Equal(t, expectedDBDriver, cfg.DatabaseDriver())
-	})
+func TestDatabaseURL(t *testing.T) {
+	t.Parallel()
 
-	t.Run("DatabaseHost", func(t *testing.T) {
-		t.Parallel()
-		require.Equal(t, expectedDBHost, cfg.DatabaseHost())
-	})
+	cfg := MockConfigForTest(t)
 
-	t.Run("DatabasePort", func(t *testing.T) {
+	t.Run("DatabaseURL", func(t *testing.T) {
 		t.Parallel()
-		require.Equal(t, expectedDBPort, cfg.DatabasePort())
-	})
-
-	t.Run("DatabaseUser", func(t *testing.T) {
-		t.Parallel()
-		require.Equal(t, expectedDBUser, cfg.DatabaseUser())
-	})
-
-	t.Run("DatabasePassword", func(t *testing.T) {
-		t.Parallel()
-		require.Equal(t, expectedDBPassword, cfg.DatabasePassword())
-	})
-
-	t.Run("DatabaseName", func(t *testing.T) {
-		t.Parallel()
-		require.Equal(t, expectedDBName, cfg.DatabaseName())
-	})
-
-	t.Run("DatabaseSSLMode", func(t *testing.T) {
-		t.Parallel()
-		require.Equal(t, expectedDBSSLMode, cfg.DatabaseSSLMode())
-	})
-
-	t.Run("DBMaxOpenConns", func(t *testing.T) {
-		t.Parallel()
-		require.Equal(t, expectedDBMaxOpenConns, cfg.DBMaxOpenConns())
-	})
-
-	t.Run("DBMaxIdleConns", func(t *testing.T) {
-		t.Parallel()
-		require.Equal(t, expectedDBMaxIdleConns, cfg.DBMaxIdleConns())
-	})
-
-	t.Run("DBConnMaxLifetime", func(t *testing.T) {
-		t.Parallel()
-		require.Equal(t, expectedDBMaxLifetime, cfg.DBConnMaxLifetime())
-	})
-
-	t.Run("DBConnMaxIdleTime", func(t *testing.T) {
-		t.Parallel()
-		require.Equal(t, expectedDBMaxIdleTime, cfg.DBConnMaxIdleTime())
-	})
-
-	t.Run("AllowedOrigins", func(t *testing.T) {
-		t.Parallel()
-		require.Equal(
-			t,
-			strings.Split(expectedAllowedOrigins, ","),
-			cfg.AllowedOrigins(),
+		expectedURL := fmt.Sprintf(
+			"postgres://%s:%s@%s:%d/%s?sslmode=%s&timezone=%s",
+			expectedDBUser,
+			expectedDBPassword,
+			expectedDBHost,
+			expectedDBPort,
+			expectedDBName,
+			expectedDBSSLMode,
+			url.QueryEscape(expectedOSTimeZone),
 		)
-	})
-
-	t.Run("CIDR", func(t *testing.T) {
-		t.Parallel()
-		require.Equal(t, expectedCIDR, cfg.CIDR())
+		require.Equal(t, expectedURL, cfg.database.DatabaseDSN(&cfg.os))
 	})
 }

--- a/internal/controller/httpstack/banner/banner.go
+++ b/internal/controller/httpstack/banner/banner.go
@@ -10,6 +10,6 @@ import (
 // New は、バナーの表示設定を行います。
 //
 // バナーは本番環境では非表示にする
-func New(e *echo.Echo, cfg *config.Config) {
-	e.HideBanner = cfg.IsAppProductionMode()
+func New(e *echo.Echo, appCfg *config.ApplicationConfig) {
+	e.HideBanner = appCfg.IsAppProductionMode()
 }

--- a/internal/controller/httpstack/banner/banner_test.go
+++ b/internal/controller/httpstack/banner/banner_test.go
@@ -14,7 +14,7 @@ func TestNew(t *testing.T) {
 	t.Run("本番モードの場合、バナーは非表示にする", func(t *testing.T) {
 		t.Parallel()
 		e := echo.New()
-		cfg := &config.Config{}
+		cfg := &config.ApplicationConfig{}
 		cfg.SetServerAppMode(t, config.ProductionMode)
 
 		New(e, cfg)
@@ -24,7 +24,7 @@ func TestNew(t *testing.T) {
 	t.Run("開発モードの場合、バナーは表示される", func(t *testing.T) {
 		t.Parallel()
 		e := echo.New()
-		cfg := &config.Config{}
+		cfg := &config.ApplicationConfig{}
 		cfg.SetServerAppMode(t, config.DevelopmentMode)
 
 		New(e, cfg)

--- a/internal/controller/httpstack/banner/srv_di.go
+++ b/internal/controller/httpstack/banner/srv_di.go
@@ -18,10 +18,10 @@ func Module() fx.Option {
 }
 
 // provideServeConfig は、バナー表示のサーバー設定を提供します。
-func provideServeConfig(cfg *config.Config) httpstack.ServeCfgOut {
+func provideServeConfig(appCfg *config.ApplicationConfig) httpstack.ServeCfgOut {
 	return httpstack.ServeCfgOut{
 		SrvCfg: func(e *echo.Echo) {
-			New(e, cfg)
+			New(e, appCfg)
 		},
 	}
 }

--- a/internal/controller/httpstack/banner/srv_di_test.go
+++ b/internal/controller/httpstack/banner/srv_di_test.go
@@ -17,8 +17,8 @@ func TestModule(t *testing.T) {
 func Test_provideServeConfig(t *testing.T) {
 	t.Parallel()
 
-	cfg := config.MockConfigForTest(t)
-	out := provideServeConfig(cfg)
+	appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
+	out := provideServeConfig(appCfg)
 	require.NotNil(t, out)
 	require.NotNil(t, out.SrvCfg)
 

--- a/internal/controller/httpstack/cors/cors.go
+++ b/internal/controller/httpstack/cors/cors.go
@@ -9,8 +9,8 @@ import (
 )
 
 // Middleware は、CORSミドルウェアを設定して返します。
-func Middleware(cfg *config.Config) echo.MiddlewareFunc {
-	return middleware.CORSWithConfig(buildCORSConfig(cfg.AllowedOrigins()))
+func Middleware(secCfg *config.SecurityConfig) echo.MiddlewareFunc {
+	return middleware.CORSWithConfig(buildCORSConfig(secCfg.AllowedOrigins()))
 }
 
 // buildCORSConfig は、CORSミドルウェアの設定を構築します。

--- a/internal/controller/httpstack/cors/cors_test.go
+++ b/internal/controller/httpstack/cors/cors_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestMiddleware(t *testing.T) {
 	t.Parallel()
-	cfg := config.MockConfigForTest(t)
-	mw := Middleware(cfg)
+	secCfg := config.NewSecurityConfig(config.MockConfigForTest(t))
+	mw := Middleware(secCfg)
 	require.NotNil(t, mw)
 }
 

--- a/internal/controller/httpstack/debugmode/debugmode.go
+++ b/internal/controller/httpstack/debugmode/debugmode.go
@@ -8,6 +8,6 @@ import (
 )
 
 // New は、開発モード向けのデバッグ支援機能を設定します。
-func New(e *echo.Echo, cfg *config.Config) {
-	e.Debug = cfg.IsAppDevelopmentMode()
+func New(e *echo.Echo, appCfg *config.ApplicationConfig) {
+	e.Debug = appCfg.IsAppDevelopmentMode()
 }

--- a/internal/controller/httpstack/debugmode/debugmode_test.go
+++ b/internal/controller/httpstack/debugmode/debugmode_test.go
@@ -14,20 +14,20 @@ func TestNew(t *testing.T) {
 	t.Run("開発モードの場合、Debugがtrueになること", func(t *testing.T) {
 		t.Parallel()
 		e := echo.New()
-		cfg := &config.Config{}
-		cfg.SetServerAppMode(t, config.DevelopmentMode)
+		appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
+		appCfg.SetServerAppMode(t, config.DevelopmentMode)
 
-		New(e, cfg)
+		New(e, appCfg)
 		require.True(t, e.Debug)
 	})
 
 	t.Run("開発モード以外の場合、Debugがfalseになること", func(t *testing.T) {
 		t.Parallel()
 		e := echo.New()
-		cfg := &config.Config{}
-		cfg.SetServerAppMode(t, config.ProductionMode)
+		appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
+		appCfg.SetServerAppMode(t, config.ProductionMode)
 
-		New(e, cfg)
+		New(e, appCfg)
 		require.False(t, e.Debug)
 	})
 }

--- a/internal/controller/httpstack/debugmode/srv_di.go
+++ b/internal/controller/httpstack/debugmode/srv_di.go
@@ -18,10 +18,10 @@ func Module() fx.Option {
 }
 
 // provideServeConfig は、デバッグモードのサーバー設定を提供します。
-func provideServeConfig(cfg *config.Config) httpstack.ServeCfgOut {
+func provideServeConfig(appCfg *config.ApplicationConfig) httpstack.ServeCfgOut {
 	return httpstack.ServeCfgOut{
 		SrvCfg: func(e *echo.Echo) {
-			New(e, cfg)
+			New(e, appCfg)
 		},
 	}
 }

--- a/internal/controller/httpstack/debugmode/srv_di_test.go
+++ b/internal/controller/httpstack/debugmode/srv_di_test.go
@@ -17,8 +17,8 @@ func TestModule(t *testing.T) {
 func Test_provideServeConfig(t *testing.T) {
 	t.Parallel()
 
-	cfg := config.MockConfigForTest(t)
-	out := provideServeConfig(cfg)
+	appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
+	out := provideServeConfig(appCfg)
 	require.NotNil(t, out)
 	require.NotNil(t, out.SrvCfg)
 

--- a/internal/controller/httpstack/defaultport/default_port.go
+++ b/internal/controller/httpstack/defaultport/default_port.go
@@ -10,6 +10,6 @@ import (
 // New は、ポート設定を初期化します。
 //
 // ポートは本番環境では非表示にします。
-func New(e *echo.Echo, cfg *config.Config) {
-	e.HidePort = cfg.IsAppProductionMode()
+func New(e *echo.Echo, appCfg *config.ApplicationConfig) {
+	e.HidePort = appCfg.IsAppProductionMode()
 }

--- a/internal/controller/httpstack/defaultport/default_port_test.go
+++ b/internal/controller/httpstack/defaultport/default_port_test.go
@@ -14,20 +14,20 @@ func TestNew(t *testing.T) {
 	t.Run("本番モードの場合、ポートは非表示にする", func(t *testing.T) {
 		t.Parallel()
 		e := echo.New()
-		cfg := &config.Config{}
-		cfg.SetServerAppMode(t, config.ProductionMode)
+		appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
+		appCfg.SetServerAppMode(t, config.ProductionMode)
 
-		New(e, cfg)
+		New(e, appCfg)
 		require.True(t, e.HidePort)
 	})
 
 	t.Run("開発モードの場合、ポートは表示される", func(t *testing.T) {
 		t.Parallel()
 		e := echo.New()
-		cfg := &config.Config{}
-		cfg.SetServerAppMode(t, config.DevelopmentMode)
+		appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
+		appCfg.SetServerAppMode(t, config.DevelopmentMode)
 
-		New(e, cfg)
-		require.False(t, e.HideBanner)
+		New(e, appCfg)
+		require.False(t, e.HidePort)
 	})
 }

--- a/internal/controller/httpstack/defaultport/srv_di.go
+++ b/internal/controller/httpstack/defaultport/srv_di.go
@@ -18,10 +18,10 @@ func Module() fx.Option {
 }
 
 // provideServeConfig は、ポート設定を提供します。
-func provideServeConfig(cfg *config.Config) httpstack.ServeCfgOut {
+func provideServeConfig(appCfg *config.ApplicationConfig) httpstack.ServeCfgOut {
 	return httpstack.ServeCfgOut{
 		SrvCfg: func(e *echo.Echo) {
-			New(e, cfg)
+			New(e, appCfg)
 		},
 	}
 }

--- a/internal/controller/httpstack/defaultport/srv_di_test.go
+++ b/internal/controller/httpstack/defaultport/srv_di_test.go
@@ -17,8 +17,8 @@ func TestModule(t *testing.T) {
 func Test_provideServeConfig(t *testing.T) {
 	t.Parallel()
 
-	cfg := config.MockConfigForTest(t)
-	out := provideServeConfig(cfg)
+	appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
+	out := provideServeConfig(appCfg)
 	require.NotNil(t, out)
 	require.NotNil(t, out.SrvCfg)
 

--- a/internal/controller/httpstack/ipextractor/ip_extractor.go
+++ b/internal/controller/httpstack/ipextractor/ip_extractor.go
@@ -7,26 +7,26 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func New(e *echo.Echo, cfg *config.Config) {
-	e.IPExtractor = NewIPExtractor(cfg)
+func New(e *echo.Echo, appCfg *config.ApplicationConfig, secCfg *config.SecurityConfig) {
+	e.IPExtractor = NewIPExtractor(appCfg, secCfg)
 }
 
 // NewIPExtractor は、EchoでクライアントのIPアドレスを抽出するためのインスタンスを生成します。
 //
 //	本番環境ではX-Forwarded-ForヘッダーからIPアドレスを抽出し、開発環境では直接抽出します。
 //	その他の環境では、本番に準じてX-Forwarded-Forヘッダーから抽出します。
-func NewIPExtractor(cfg *config.Config) echo.IPExtractor {
+func NewIPExtractor(appCfg *config.ApplicationConfig, secCfg *config.SecurityConfig) echo.IPExtractor {
 	switch {
-	case cfg.IsAppProductionMode():
+	case appCfg.IsAppProductionMode():
 		return echo.ExtractIPFromXFFHeader(
-			echo.TrustIPRange(cfg.CIDR()),
+			echo.TrustIPRange(secCfg.CIDR()),
 		)
-	case cfg.IsAppDevelopmentMode():
+	case appCfg.IsAppDevelopmentMode():
 		return echo.ExtractIPDirect()
 	default:
 		// 安全のため、本番に準じてIPアドレスを抽出する
 		return echo.ExtractIPFromXFFHeader(
-			echo.TrustIPRange(cfg.CIDR()),
+			echo.TrustIPRange(secCfg.CIDR()),
 		)
 	}
 }

--- a/internal/controller/httpstack/ipextractor/ip_extractor_test.go
+++ b/internal/controller/httpstack/ipextractor/ip_extractor_test.go
@@ -15,7 +15,10 @@ func TestNew(t *testing.T) {
 
 	e := &echo.Echo{}
 	cfg := config.MockConfigForTest(t)
-	New(e, cfg)
+	appCfg := config.NewApplicationConfig(cfg)
+	secCfg := config.NewSecurityConfig(cfg)
+
+	New(e, appCfg, secCfg)
 	require.NotNil(t, e.IPExtractor)
 }
 
@@ -30,12 +33,16 @@ func TestNewIPExtractor(t *testing.T) {
 		t.Parallel()
 
 		cfg := config.MockConfigForTest(t)
-		cfg.SetServerAppMode(t, config.ProductionMode)
-		cfg.SetCIDR(t, parsedCIDR)
-		require.Equal(t, config.ProductionMode, cfg.AppMode())
-		require.Equal(t, parsedCIDR.String(), cfg.CIDR().String())
 
-		actual := NewIPExtractor(cfg)
+		appCfg := config.NewApplicationConfig(cfg)
+		appCfg.SetServerAppMode(t, config.ProductionMode)
+
+		secCfg := config.NewSecurityConfig(cfg)
+		secCfg.SetCIDR(t, parsedCIDR)
+
+		require.Equal(t, config.ProductionMode, appCfg.AppMode())
+		require.Equal(t, parsedCIDR.String(), secCfg.CIDR().String())
+		actual := NewIPExtractor(appCfg, secCfg)
 		require.NotNil(t, actual)
 	})
 
@@ -43,17 +50,20 @@ func TestNewIPExtractor(t *testing.T) {
 		t.Parallel()
 
 		cfg := config.MockConfigForTest(t)
-		cfg.SetServerAppMode(t, config.DevelopmentMode)
-		cfg.SetCIDR(t, parsedCIDR)
-		require.Equal(t, config.DevelopmentMode, cfg.AppMode())
-		require.Equal(t, parsedCIDR.String(), cfg.CIDR().String())
+		appCfg := config.NewApplicationConfig(cfg)
+		appCfg.SetServerAppMode(t, config.DevelopmentMode)
 
-		actual := NewIPExtractor(cfg)
+		secCfg := config.NewSecurityConfig(cfg)
+		secCfg.SetCIDR(t, parsedCIDR)
+
+		require.Equal(t, config.DevelopmentMode, appCfg.AppMode())
+		require.Equal(t, parsedCIDR.String(), secCfg.CIDR().String())
+		actual := NewIPExtractor(appCfg, secCfg)
 		require.NotNil(t, actual)
 	})
 
 	t.Run("開発モードがない場合", func(t *testing.T) {
-		extractor := NewIPExtractor(&config.Config{})
+		extractor := NewIPExtractor(&config.ApplicationConfig{}, &config.SecurityConfig{})
 		require.NotNil(t, extractor)
 	})
 }

--- a/internal/controller/httpstack/ipextractor/srv_di.go
+++ b/internal/controller/httpstack/ipextractor/srv_di.go
@@ -18,10 +18,10 @@ func Module() fx.Option {
 }
 
 // provideServeConfig は、IP Extractor のサーバー設定を提供します。
-func provideServeConfig(cfg *config.Config) httpstack.ServeCfgOut {
+func provideServeConfig(appCfg *config.ApplicationConfig, secCfg *config.SecurityConfig) httpstack.ServeCfgOut {
 	return httpstack.ServeCfgOut{
 		SrvCfg: func(e *echo.Echo) {
-			New(e, cfg)
+			New(e, appCfg, secCfg)
 		},
 	}
 }

--- a/internal/controller/httpstack/ipextractor/srv_di_test.go
+++ b/internal/controller/httpstack/ipextractor/srv_di_test.go
@@ -18,7 +18,10 @@ func Test_provideServeConfig(t *testing.T) {
 	t.Parallel()
 
 	cfg := config.MockConfigForTest(t)
-	out := provideServeConfig(cfg)
+	appCfg := config.NewApplicationConfig(cfg)
+	secCfg := config.NewSecurityConfig(cfg)
+
+	out := provideServeConfig(appCfg, secCfg)
 	require.NotNil(t, out)
 	require.NotNil(t, out.SrvCfg)
 

--- a/internal/controller/httpstack/recovery/recover.go
+++ b/internal/controller/httpstack/recovery/recover.go
@@ -18,24 +18,24 @@ const (
 )
 
 // Middleware は、Echoフレームワークのミドルウェアで、パニックからのリカバリを行います。
-func Middleware(logger *zap.Logger, cfg *config.Config) echo.MiddlewareFunc {
-	cnf := newRecoverConfig(logger, cfg)
+func Middleware(logger *zap.Logger, appCfg *config.ApplicationConfig) echo.MiddlewareFunc {
+	cnf := newRecoverConfig(logger, appCfg)
 	cnf.LogErrorFunc = newRecoverLogErrorFunc(logger)
 
 	return middleware.RecoverWithConfig(cnf)
 }
 
 // newRecoverConfig は、環境設定に基づいてリカバリミドルウェアの設定を生成します。
-func newRecoverConfig(logger *zap.Logger, cfg *config.Config) middleware.RecoverConfig {
+func newRecoverConfig(logger *zap.Logger, appCfg *config.ApplicationConfig) middleware.RecoverConfig {
 	switch {
-	case cfg.IsAppDevelopmentMode():
+	case appCfg.IsAppDevelopmentMode():
 		return developmentConfig()
-	case cfg.IsAppProductionMode():
+	case appCfg.IsAppProductionMode():
 		return productionConfig()
 	default:
 		logger.Warn(
 			"Unknown environment, using production config for recover middleware",
-			zap.String("env", cfg.AppMode()),
+			zap.String("env", appCfg.AppMode()),
 		)
 		return productionConfig()
 	}

--- a/internal/controller/httpstack/recovery/recover_test.go
+++ b/internal/controller/httpstack/recovery/recover_test.go
@@ -18,10 +18,10 @@ import (
 func TestMiddleware(t *testing.T) {
 	t.Parallel()
 
-	cfg := config.MockConfigForTest(t)
+	appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
 	logger := zap.NewNop()
 
-	require.NotNil(t, Middleware(logger, cfg))
+	require.NotNil(t, Middleware(logger, appCfg))
 }
 
 func Test_newRecoverLogErrorFunc(t *testing.T) {
@@ -66,36 +66,33 @@ func Test_newRecoverConfig(t *testing.T) {
 	t.Run("開発モードの場合、developmentConfigを返す", func(t *testing.T) {
 		t.Parallel()
 
-		cfg := config.MockConfigForTest(t)
-		cfg.SetServerAppMode(t, config.DevelopmentMode)
+		appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
+		appCfg.SetServerAppMode(t, config.DevelopmentMode)
 
 		expected := developmentConfig()
-		actual := newRecoverConfig(logger, cfg)
-
+		actual := newRecoverConfig(logger, appCfg)
 		require.Equal(t, expected, actual)
 	})
 
 	t.Run("本番モードの場合、productionConfigを返す", func(t *testing.T) {
 		t.Parallel()
 
-		cfg := config.MockConfigForTest(t)
-		cfg.SetServerAppMode(t, config.ProductionMode)
+		appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
+		appCfg.SetServerAppMode(t, config.ProductionMode)
 
 		expected := productionConfig()
-		actual := newRecoverConfig(logger, cfg)
-
+		actual := newRecoverConfig(logger, appCfg)
 		require.Equal(t, expected, actual)
 	})
 
 	t.Run("不明なモードの場合、warningを出してproductionConfigを返す", func(t *testing.T) {
 		t.Parallel()
 
-		cfg := config.MockConfigForTest(t)
-		cfg.SetServerAppMode(t, "unknown-mode")
+		appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
+		appCfg.SetServerAppMode(t, "unknown-mode")
 
 		expected := productionConfig()
-		actual := newRecoverConfig(logger, cfg)
-
+		actual := newRecoverConfig(logger, appCfg)
 		require.Equal(t, expected, actual)
 	})
 }

--- a/internal/controller/httpstack/security/security.go
+++ b/internal/controller/httpstack/security/security.go
@@ -9,12 +9,12 @@ import (
 )
 
 // Middleware は、セキュリティミドルウェアを構築します。
-func Middleware(cfg *config.Config) echo.MiddlewareFunc {
-	return middleware.SecureWithConfig(buildSecureConfig(cfg))
+func Middleware(appCfg *config.ApplicationConfig) echo.MiddlewareFunc {
+	return middleware.SecureWithConfig(buildSecureConfig(appCfg))
 }
 
 // buildSecureConfig は、セキュリティ設定を構築します。
-func buildSecureConfig(cfg *config.Config) middleware.SecureConfig {
+func buildSecureConfig(appCfg *config.ApplicationConfig) middleware.SecureConfig {
 	scfg := middleware.SecureConfig{
 		XSSProtection:      "",
 		ContentTypeNosniff: "nosniff",
@@ -22,7 +22,7 @@ func buildSecureConfig(cfg *config.Config) middleware.SecureConfig {
 		ReferrerPolicy:     "no-referrer",
 	}
 
-	if cfg.IsAppProductionMode() {
+	if appCfg.IsAppProductionMode() {
 		scfg.HSTSExcludeSubdomains = false
 		scfg.HSTSMaxAge = 31536000
 	}

--- a/internal/controller/httpstack/security/security_test.go
+++ b/internal/controller/httpstack/security/security_test.go
@@ -13,10 +13,10 @@ func TestBuildSecureConfig(t *testing.T) {
 	t.Parallel()
 	t.Run("本番モード", func(t *testing.T) {
 		t.Parallel()
-		cfg := config.MockConfigForTest(t)
-		cfg.SetServerAppMode(t, config.ProductionMode)
+		appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
+		appCfg.SetServerAppMode(t, config.ProductionMode)
 
-		actual := buildSecureConfig(cfg)
+		actual := buildSecureConfig(appCfg)
 
 		expected := middleware.SecureConfig{
 			XSSProtection:         "",
@@ -32,10 +32,10 @@ func TestBuildSecureConfig(t *testing.T) {
 
 	t.Run("非本番モード", func(t *testing.T) {
 		t.Parallel()
-		cfg := config.MockConfigForTest(t)
-		cfg.SetServerAppMode(t, config.DevelopmentMode)
+		appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
+		appCfg.SetServerAppMode(t, config.DevelopmentMode)
 
-		actual := buildSecureConfig(cfg)
+		actual := buildSecureConfig(appCfg)
 
 		expected := middleware.SecureConfig{
 			XSSProtection:      "",
@@ -51,7 +51,7 @@ func TestBuildSecureConfig(t *testing.T) {
 func TestMiddleware(t *testing.T) {
 	t.Parallel()
 
-	cfg := config.MockConfigForTest(t)
+	appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
 
-	require.NotNil(t, Middleware(cfg))
+	require.NotNil(t, Middleware(appCfg))
 }

--- a/internal/controller/server/server.go
+++ b/internal/controller/server/server.go
@@ -20,13 +20,16 @@ func New() *echo.Echo {
 
 // ServeHTTP は、HTTPサーバーを起動します。
 func ServeHTTP(
-	lc fx.Lifecycle, e *echo.Echo, cfg *config.Config, z *zap.Logger,
+	lc fx.Lifecycle, e *echo.Echo, z *zap.Logger,
+	appCfg *config.ApplicationConfig,
+	secCfg *config.SecurityConfig,
+	srvCfg *config.ServerConfig,
 	// 下記はサーバー機能の拡張が適用されたことを示すトークン
 	_ *httpstack.AppliedServerExtends,
 ) {
 	lc.Append(fx.Hook{
 		OnStart: func(_ context.Context) error {
-			addr := cfg.ServerPort()
+			addr := srvCfg.ServerPort()
 			go func() {
 				if err := e.Start(":" + strconv.Itoa(addr)); err != nil {
 					z.Error("failed to start http server", zap.Error(err))
@@ -34,14 +37,14 @@ func ServeHTTP(
 			}()
 			z.Info("http started",
 				zap.String("port", strconv.Itoa(addr)),
-				zap.Strings("allowed origins", cfg.AllowedOrigins()),
-				zap.String("cidr", cfg.CIDR().IP.String()),
-				zap.String("mode", cfg.AppMode()),
+				zap.Strings("allowed origins", secCfg.AllowedOrigins()),
+				zap.String("cidr", secCfg.CIDR().IP.String()),
+				zap.String("mode", appCfg.AppMode()),
 			)
 			return nil
 		},
 		OnStop: func(ctx context.Context) error {
-			shutdownTime := cfg.ServerShutdownTimeout()
+			shutdownTime := srvCfg.ServerShutdownTimeout()
 			ctx, cancel := context.WithTimeout(ctx, shutdownTime)
 			defer cancel()
 			z.Info("http stopping")

--- a/internal/di/config.go
+++ b/internal/di/config.go
@@ -9,6 +9,17 @@ import (
 // ConfigModule は、アプリケーションの設定をDI用に提供するfx.Moduleです。
 func ConfigModule() fx.Option {
 	return fx.Module("config",
-		fx.Provide(config.SetUpConfig),
+		fx.Provide(
+			config.SetUpConfig,
+		),
+		fx.Provide(
+			config.NewOSConfig,
+			config.NewApplicationConfig,
+			config.NewDatabaseConfig,
+			config.NewDBConnectionConfig,
+			config.NewMetricsConfig,
+			config.NewSecurityConfig,
+			config.NewServerConfig,
+		),
 	)
 }

--- a/internal/infrastructure/rdb/driver/connection.go
+++ b/internal/infrastructure/rdb/driver/connection.go
@@ -24,17 +24,19 @@ type DBTX interface {
 }
 
 // NewDB は Postgres のDB接続を初期化して返します。
-func NewDB(cfg *config.Config) (*sql.DB, error) {
-	db, err := sql.Open(cfg.DatabaseDriver(), cfg.DatabaseDSN())
+func NewDB(
+	dbCfg *config.DatabaseConfig, osCfg *config.OperationSystemConfig, dbConnCfg *config.DBConnectionConfig,
+) (*sql.DB, error) {
+	db, err := sql.Open(dbCfg.DatabaseDriver(), dbCfg.DatabaseDSN(osCfg))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open DB: %w", err)
 	}
 
 	// 接続プール設定
-	db.SetMaxOpenConns(cfg.DBMaxOpenConns())
-	db.SetMaxIdleConns(cfg.DBMaxIdleConns())
-	db.SetConnMaxLifetime(cfg.DBConnMaxLifetime())
-	db.SetConnMaxIdleTime(cfg.DBConnMaxIdleTime())
+	db.SetMaxOpenConns(dbConnCfg.DBMaxOpenConns())
+	db.SetMaxIdleConns(dbConnCfg.DBMaxIdleConns())
+	db.SetConnMaxLifetime(dbConnCfg.DBConnMaxLifetime())
+	db.SetConnMaxIdleTime(dbConnCfg.DBConnMaxIdleTime())
 
 	// 疎通確認
 	if err := db.PingContext(context.Background()); err != nil {

--- a/internal/infrastructure/rdb/driver/connection_test.go
+++ b/internal/infrastructure/rdb/driver/connection_test.go
@@ -18,9 +18,12 @@ func TestNewDB(t *testing.T) {
 			t.Parallel()
 
 			cfg := config.MockConfigForTest(t)
-			cfg.SetDatabaseHost(t, "localhost")
+			dbCfg := config.NewDatabaseConfig(cfg)
+			dbCfg.SetDatabaseHost(t, "localhost")
+			osCfg := config.NewOSConfig(cfg)
+			dbConnCfg := config.NewDBConnectionConfig(cfg)
 
-			db, err := NewDB(cfg)
+			db, err := NewDB(dbCfg, osCfg, dbConnCfg)
 			require.NoError(t, err)
 			require.NotNil(t, db)
 
@@ -39,9 +42,12 @@ func TestNewDB(t *testing.T) {
 		t.Run("DSNが無効", func(t *testing.T) {
 			t.Parallel()
 			cfg := config.MockConfigForTest(t)
-			cfg.SetDatabaseDriver(t, "invalid_driver")
+			dbCfg := config.NewDatabaseConfig(cfg)
+			dbCfg.SetDatabaseDriver(t, "invalid_driver")
+			osCfg := config.NewOSConfig(cfg)
+			dbConnCfg := config.NewDBConnectionConfig(cfg)
 
-			db, err := NewDB(cfg)
+			db, err := NewDB(dbCfg, osCfg, dbConnCfg)
 			require.Error(t, err)
 			require.Nil(t, db)
 		})
@@ -49,9 +55,12 @@ func TestNewDB(t *testing.T) {
 		t.Run("Pingに失敗", func(t *testing.T) {
 			t.Parallel()
 			cfg := config.MockConfigForTest(t)
-			cfg.SetDatabaseName(t, "nonexistentdb")
+			dbCfg := config.NewDatabaseConfig(cfg)
+			dbCfg.SetDatabaseName(t, "nonexistentdb")
+			osCfg := config.NewOSConfig(cfg)
+			dbConnCfg := config.NewDBConnectionConfig(cfg)
 
-			db, err := NewDB(cfg)
+			db, err := NewDB(dbCfg, osCfg, dbConnCfg)
 			require.Error(t, err)
 			require.Nil(t, db)
 		})

--- a/internal/infrastructure/rdb/driver/driver_test.go
+++ b/internal/infrastructure/rdb/driver/driver_test.go
@@ -12,8 +12,11 @@ import (
 
 func TestResolveConn(t *testing.T) {
 	cfg := config.MockConfigForTest(t)
-	cfg.SetDatabaseHost(t, "localhost")
-	db, err := sql.Open("pgx", cfg.DatabaseDSN())
+	dbCfg := config.NewDatabaseConfig(cfg)
+	osCfg := config.NewOSConfig(cfg)
+	dbCfg.SetDatabaseHost(t, "localhost")
+
+	db, err := sql.Open("pgx", dbCfg.DatabaseDSN(osCfg))
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := db.Close()

--- a/internal/infrastructure/rdb/driver/transaction_test.go
+++ b/internal/infrastructure/rdb/driver/transaction_test.go
@@ -13,7 +13,10 @@ import (
 
 func TestNewTransactionManager(t *testing.T) {
 	cfg := config.MockConfigForTest(t)
-	db, err := sql.Open("pgx", cfg.DatabaseDSN())
+	dbCfg := config.NewDatabaseConfig(cfg)
+	osCfg := config.NewOSConfig(cfg)
+
+	db, err := sql.Open("pgx", dbCfg.DatabaseDSN(osCfg))
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := db.Close()
@@ -26,8 +29,11 @@ func TestNewTransactionManager(t *testing.T) {
 
 func TestTxManager_Do(t *testing.T) {
 	cfg := config.MockConfigForTest(t)
-	cfg.SetDatabaseHost(t, "localhost")
-	db, err := sql.Open("pgx", cfg.DatabaseDSN())
+	dbCfg := config.NewDatabaseConfig(cfg)
+	osCfg := config.NewOSConfig(cfg)
+	dbCfg.SetDatabaseHost(t, "localhost")
+
+	db, err := sql.Open("pgx", dbCfg.DatabaseDSN(osCfg))
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := db.Close()

--- a/internal/infrastructure/rdb/rdbtest/test_instance.go
+++ b/internal/infrastructure/rdb/rdbtest/test_instance.go
@@ -35,14 +35,17 @@ func NewTestInstances(t *testing.T) (
 	t.Helper()
 
 	cfg := config.MockConfigForTest(t)
+	dbCfg := config.NewDatabaseConfig(cfg)
+	osCfg := config.NewOSConfig(cfg)
+	dbConnCfg := config.NewDBConnectionConfig(cfg)
 
-	db, err := rdbdriver.NewDB(cfg)
+	db, err := rdbdriver.NewDB(dbCfg, osCfg, dbConnCfg)
 	require.NoError(t, err)
 
 	nopLogger := zap.NewNop()
 	innerTxm := rdbdriver.NewTransactionManager(cfg, db)
 
-	location, err := time.LoadLocation(cfg.OSTimeZone())
+	location, err := time.LoadLocation(osCfg.OSTimeZone())
 	require.NoError(t, err)
 
 	txm := &testTxManager{

--- a/internal/infrastructure/rdb/rdbtest/test_instance_test.go
+++ b/internal/infrastructure/rdb/rdbtest/test_instance_test.go
@@ -23,7 +23,11 @@ func TestNewTestInstances(t *testing.T) {
 func Test_testTxManager_Do(t *testing.T) {
 	t.Parallel()
 	cfg := config.MockConfigForTest(t)
-	db, err := rdbdriver.NewDB(cfg)
+	dbCfg := config.NewDatabaseConfig(cfg)
+	osCfg := config.NewOSConfig(cfg)
+	dbConnCfg := config.NewDBConnectionConfig(cfg)
+
+	db, err := rdbdriver.NewDB(dbCfg, osCfg, dbConnCfg)
 	require.NoError(t, err)
 	innerTxm := rdbdriver.NewTransactionManager(cfg, db)
 

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -75,12 +75,12 @@ func NewDevelopmentLogger() *zap.Logger {
 }
 
 // New は、指定された設定に基づいて新しいZapロガーを生成します。
-func New(cfg *config.Config) (*zap.Logger, error) {
-	if cfg.IsAppProductionMode() {
+func New(appCfg *config.ApplicationConfig) (*zap.Logger, error) {
+	if appCfg.IsAppProductionMode() {
 		return NewProductionLogger(), nil
 	}
-	if cfg.IsAppDevelopmentMode() {
+	if appCfg.IsAppDevelopmentMode() {
 		return NewDevelopmentLogger(), nil
 	}
-	return nil, fmt.Errorf("unknown app mode: %s", cfg.AppMode())
+	return nil, fmt.Errorf("unknown app mode: %s", appCfg.AppMode())
 }

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -10,28 +10,28 @@ import (
 
 func TestNew(t *testing.T) {
 	t.Run("production mode", func(t *testing.T) {
-		cfg := &config.Config{}
-		cfg.SetServerAppMode(t, "production")
+		appCfg := config.NewApplicationConfig(&config.Config{})
+		appCfg.SetServerAppMode(t, "production")
 
-		logger, err := New(cfg)
+		logger, err := New(appCfg)
 		require.NoError(t, err)
 		require.NotNil(t, logger)
 	})
 
 	t.Run("development mode", func(t *testing.T) {
-		cfg := &config.Config{}
-		cfg.SetServerAppMode(t, "development")
+		appCfg := config.NewApplicationConfig(&config.Config{})
+		appCfg.SetServerAppMode(t, "development")
 
-		logger, err := New(cfg)
+		logger, err := New(appCfg)
 		require.NoError(t, err)
 		require.NotNil(t, logger)
 	})
 
 	t.Run("unknown mode", func(t *testing.T) {
-		cfg := &config.Config{}
-		cfg.SetServerAppMode(t, "unknown")
+		appCfg := config.NewApplicationConfig(&config.Config{})
+		appCfg.SetServerAppMode(t, "unknown")
 
-		logger, err := New(cfg)
+		logger, err := New(appCfg)
 		require.Error(t, err)
 		require.Nil(t, logger)
 	})


### PR DESCRIPTION
# 概要

構成情報の依存性注入をより柔軟に行えるよう、従来の巨大な Config 構造体を分割し、より小さく焦点の定まった設定構造体へリファクタリングしております。

# 変更内容

- 内部で使用していた設定用の構造体を `ApplicationConfig`, `DatabaseConfig`, `SecurityConfig` などの公開型へ切り出し、各種コンストラクタ関数を追加いたしました。
- これまで `Config` 全体を受け取っていた箇所を、必要とする特定の設定型のみを受け取る形に修正いたしました。
- `IsAppProductionMode()`, `IsAppDevelopmentMode()`, `DatabaseDSN()` などのメソッドを、それぞれ対応する設定型へ移動いたしました。

# 動作確認方法

1. `make serve` を実行してください。
2. アプリケーションが正常に起動し、設定値が想定どおりに反映されていることをご確認ください。