### PR TITLE
Feature/fix doc portal

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,7 +57,7 @@ services:
     ports:
       - "8082:80"
     volumes:
-      - .:/usr/share/nginx/html/:ro
+      - ./docs/portal:/usr/share/nginx/html:ro
     profiles:
       - development
       - tools

--- a/docker/document/config/default.conf
+++ b/docker/document/config/default.conf
@@ -9,8 +9,8 @@ server {
         application/javascript js jsx;
     }
 
-    location = / {
-        try_files /docs/portal/index.html =404;
+    location /portal/ {
+        try_files $uri $uri/ /portal/index.html;
     }
 
     location / {


### PR DESCRIPTION
## Pull request overview

This PR aims to fix/adjust how the documentation portal is served in local Docker (nginx) and to change the docs auto-generation workflow to open a PR instead of committing directly to the pushed branch.

**Changes:**
- Update nginx routing to serve the docs portal under `/portal/`.
- Narrow the docs_viewer nginx volume mount (from repo root to `./docs/portal`).
- Update the auto-generate-docs GitHub Actions workflow to use `peter-evans/create-pull-request` and remove branch restrictions.

### Reviewed changes

Copilot reviewed 3 out of 3 changed files in this pull request and generated 4 comments.

| File | Description |
| ---- | ----------- |
| docker/document/config/default.conf | Changes nginx routes to serve the portal under `/portal/`. |
| docker-compose.yaml | Changes docs_viewer mount to only expose `docs/portal` to nginx. |
| .github/workflows/auto-generate-docs.yaml | Stops direct push commits; opens a PR for generated docs updates and changes triggering behavior. |



