### PR TITLE
Feat: 自動生成されたドキュメントの更新をPRとして作成するように変更

### DIFF
--- a/.github/workflows/auto-generate-docs.yaml
+++ b/.github/workflows/auto-generate-docs.yaml
@@ -1,9 +1,9 @@
-name: Generate Docs on Merge
+name: Auto-generate Docs Pull Request
 
 on:
   push:
-    # branches:
-    #   - release/**
+    branches:
+      - release/** 
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,6 +16,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     env:
       ENV: ci
@@ -43,6 +44,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -95,8 +97,9 @@ jobs:
         if: steps.diff.outputs.has_diff == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "chore: auto update docs"
-          branch: auto/docs-update
+          commit-message: "chore: auto update docs [skip ci]"
+          branch: auto/docs-update/${{ github.ref_name }}
+          base: ${{ github.ref_name }}
           title: "chore: auto update docs"
           body: |
             Auto-generated docs update.

--- a/.github/workflows/auto-generate-docs.yaml
+++ b/.github/workflows/auto-generate-docs.yaml
@@ -2,11 +2,8 @@ name: Generate Docs on Merge
 
 on:
   push:
-    branches:
-      - production
-      - staging
-      - develop
-      - release/**
+    # branches:
+    #   - release/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -93,12 +90,14 @@ jobs:
             echo "has_diff=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Commit & Push
+      - name: Create PR
+        id: cpr
         if: steps.diff.outputs.has_diff == 'true'
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-
-          git add .
-          git commit -m "chore: auto update docs [skip ci]"
-          git push
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: auto update docs"
+          branch: auto/docs-update
+          title: "chore: auto update docs"
+          body: |
+            Auto-generated docs update.
+          delete-branch: true


### PR DESCRIPTION
## Pull request overview

自動生成ドキュメント更新の反映方法を、直接 push ではなく「更新用ブランチを作成して PR を起票する」運用に切り替えるための GitHub Actions ワークフロー変更です。

**Changes:**
- ドキュメント更新時の「Commit & Push」を廃止し、`peter-evans/create-pull-request` による PR 作成に変更
- ワークフローの push トリガーからブランチ制限を外す（コメントアウト）



