### PR TITLE
CI: auto-generate-docs の Detect changes で coverage 揺れを除外

### DIFF
--- a/.github/workflows/auto-generate-docs.yaml
+++ b/.github/workflows/auto-generate-docs.yaml
@@ -92,15 +92,36 @@ jobs:
 
       - name: Detect changes
         id: diff
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
         run: |
+          # ノイズ（カバレッジカウントの揺れ / SchemaSpy 生成日時）を除外して、
+          # 意味のある生成物に差分があるかをまず判定する。
           if ! git diff --quiet -- . \
+            ':(exclude)docs/coverage/index.html' \
             ':(exclude)docs/db-schema/index.html' \
             ':(exclude)docs/db-schema/info-html.txt'
           then
             echo "has_diff=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_diff=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
+
+          # 上記が無差分でも、coverage に差があり、かつ今回の push に .go の変更が含まれていれば
+          # 意味のあるカバレッジ更新とみなして PR を作成する。
+          if ! git diff --quiet -- docs/coverage/index.html; then
+            if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+              # 新規ブランチ作成等で前回 tip が取得できない場合は安全側で trigger する。
+              echo "has_diff=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            if git diff --name-only "$BEFORE_SHA..$AFTER_SHA" -- '*.go' | grep -q .; then
+              echo "has_diff=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+
+          echo "has_diff=false" >> $GITHUB_OUTPUT
 
       - name: Create PR
         if: steps.diff.outputs.has_diff == 'true'


### PR DESCRIPTION
# 概要

`auto-generate-docs.yaml` の `Detect changes` が `docs/coverage/index.html` のカバレッジカウンタ揺れだけで発火し、意味のない docs sync PR（例: #274）を作成していたのを抑止する。`.go` 変更時には引き続きカバレッジ更新を PR 化する。

## 変更内容

- `.github/workflows/auto-generate-docs.yaml`
  - `Detect changes` の `git diff --quiet` 除外対象に `docs/coverage/index.html` を追加
  - `coverage に差分あり、かつ push に .go の変更を含む` 場合のみ trigger する後段分岐を追加
  - `github.event.before` / `github.sha` を `env` 経由で渡し、`0000...`（新規ブランチ）の安全側フォールバックを実装

## 動作確認方法

- [x] `release/v1.2.0` への docs / README のみの push で docs sync PR が従来どおり作成されること
- [x] `.go` のみを編集した push で coverage 更新を含む docs sync PR が作成されること
- [x] coverage の揺れしか発生しない push では PR が作成されないこと（今回の修正の目的）