### PR TITLE
Docs: 既存実装（user/prefecture/healthcheck/user-search）の spec を追加

### DIFF
--- a/docs/spec/healthcheck/usecase.md
+++ b/docs/spec/healthcheck/usecase.md
@@ -1,0 +1,69 @@
+# Health Check — Usecase Spec
+
+> 既存実装（`internal/usecase/healthcheck`）を spec 化したもの。手書き実装から逆生成した現状仕様。
+> domain 集約を持たないシステム系 usecase。永続化集約ではなく system query（DB 死活）を参照するため domain.md は持たない。
+
+## Overview
+
+ヘルスチェックユースケースは、アプリケーションとデータベースの健全性を確認する。アプリケーション時刻（`clock`）と DB 死活情報（system query）を取得し、健全性ステータス（`ok` / `unhealthy`、将来的に `degraded`）を含む DTO を返す。DB チェックに失敗した場合は `unhealthy` とエラーを返す。
+
+ドメイン集約を介さず system query を直接参照する点で通常の集約系 usecase と異なる（read-only・トランザクション不要）。
+
+## Interface
+
+```yaml
+package: internal/usecase/healthcheck
+name: Usecase
+methods:
+  - name: CheckHealth
+    signature: CheckHealth(ctx context.Context) (DTO, error)
+```
+
+## DTOs
+
+```yaml
+- name: DTO
+  description: システムの健全性を表す。Status は定数 Ok="ok" / Unhealthy="unhealthy" / Degraded="degraded" のいずれか。
+  fields:
+    - name: Status
+      type: string
+    - name: ApplicationTime
+      type: time.Time
+    - name: DBHealthCheck
+      type: query.DBHealth
+- name: query.DBHealth
+  description: DB 死活情報（query サブパッケージで定義、system query が返す）。
+  fields:
+    - name: Ready
+      type: bool
+    - name: ResponsedAt
+      type: time.Time
+    - name: Latency
+      type: time.Duration
+```
+
+## Dependencies
+
+```yaml
+- tracer            # observability.TracerFactory -> LayerTracer
+- clock             # boundary/clock.Clock
+- db_system_query   # healthcheck/query.DBSystemQuery（DB 死活を確認する system query）
+```
+
+## Workflow
+
+### CheckHealth
+
+```yaml
+tx_required: false
+steps:
+  - clock.Now でアプリケーション時刻を取得
+  - db_system_query.CheckDBHealth で DB 死活情報を取得
+  - エラー時は Status=Unhealthy + ApplicationTime のみ設定した DTO とエラーを返す
+  - 正常時は Status=Ok + ApplicationTime + DBHealthCheck を設定した DTO を返す
+calls:
+  - clock.Now
+  - db_system_query.CheckDBHealth
+errors:
+  - db_system_query.CheckDBHealth のエラーをそのまま伝播（DTO は Unhealthy）
+```

--- a/docs/spec/prefecture/domain.md
+++ b/docs/spec/prefecture/domain.md
@@ -1,0 +1,59 @@
+# Prefecture — Domain Spec
+
+> 既存実装（`internal/domain/prefecture`）を spec 化したもの。手書き実装から逆生成した現状仕様。
+> `prefecture` は単独の usecase パッケージを持たず、`user` usecase 等の依存集約として参照される（usecase spec は持たない）。
+
+## Overview
+
+都道府県集約は、都道府県の ID・名称・コードを保持する参照系のエンティティ。`user` 集約は都道府県を ID 参照（`prefectureID`）で保持し、表示名やコードはこの集約から解決する。生成時に ID・名称長・コード範囲を検証する。
+
+## Entity
+
+```yaml
+package: internal/domain/prefecture
+struct: Prefecture
+fields:
+  - name: id
+    type: uuid.UUID
+    required: true        # IsNil の場合は ErrInvalidID
+  - name: name
+    type: string
+    required: true
+    min_length: 1         # MinPrefectureNameLength
+    max_length: 100       # MaxPrefectureNameLength
+  - name: code
+    type: int
+    required: true
+    min: 1                # MinCode
+    max: 47               # MaxCode（都道府県数）
+```
+
+## Cross-field Invariants
+
+- なし（各フィールドは独立して検証され、複数フィールド間の整合条件はない）
+
+## Behavior Methods
+
+```yaml
+# 状態遷移メソッドは未実装（getter のみ）。
+```
+
+## Value Objects
+
+```yaml
+# 値オブジェクトは利用しない。
+```
+
+## Repository Methods
+
+```yaml
+- name: FindByID
+  signature: FindByID(ctx context.Context, id uuid.UUID) (*Prefecture, error)
+  behavior: ID から都道府県を 1 件取得する。
+- name: FindByIDs
+  signature: FindByIDs(ctx context.Context, ids []uuid.UUID) (Prefectures, error)
+  behavior: 複数 ID から都道府県一覧を取得する（user 一覧の都道府県名解決で N+1 を回避する用途）。
+- name: FindByName
+  signature: FindByName(ctx context.Context, name string) (*Prefecture, error)
+  behavior: 都道府県名から都道府県を 1 件取得する（user 作成時の名前→ID 解決で使用）。
+```

--- a/docs/spec/user-search/usecase.md
+++ b/docs/spec/user-search/usecase.md
@@ -1,0 +1,104 @@
+# User Search — Usecase Spec
+
+> 既存実装（`internal/usecase/user/search`）を spec 化したもの。手書き実装から逆生成した現状仕様。
+> user 集約の query 側（CQRS の Query）。集約を直接生成せず QueryService 経由で読み取り DTO を返すため domain.md は持たない（参照する集約は `user`、spec は `docs/spec/user/domain.md`）。
+
+## Overview
+
+ユーザー検索ユースケースは、キーワードとアクティブ状態でユーザーを検索する read-only な Query サービス。`UserQueryService`（QueryService boundary）を介して検索結果 DTO を直接返す。CQRS の軽量分離方針に従い、ドメインエンティティへの変換は行わず QueryService の結果（`UserSearchResults`）をそのまま返す。トランザクションは不要。
+
+キーワードは `tools/search.ParseSearchTokens` でトークン分割してから QueryService に渡す（アプリケーションポリシー）。
+
+## Interface
+
+```yaml
+package: internal/usecase/user/search
+name: Usecase
+methods:
+  - name: ListUsersByKeyword
+    signature: ListUsersByKeyword(ctx context.Context, filter *SearchParams, page *paging.Paging) (query.UserSearchResults, error)
+  - name: CountUsersByKeyword
+    signature: CountUsersByKeyword(ctx context.Context, filter *SearchParams) (int64, error)
+```
+
+## DTOs
+
+```yaml
+- name: SearchParams
+  description: ユーザー検索の入力パラメータ。
+  fields:
+    - name: Keyword
+      type: "*string"
+    - name: Active
+      type: "*bool"
+# 以下は query サブパッケージ（internal/usecase/user/search/query）で定義される QueryService の入出力型。
+- name: query.UserSearchFilter
+  description: QueryService に渡す検索条件。usecase 側で SearchParams + トークン分割から構築。
+  fields:
+    - name: Active
+      type: "*bool"
+    - name: Keywords
+      type: "[]string"
+- name: query.UserSearchResult
+  description: 検索結果 1 件分の DTO（QueryService が返す）。
+  fields:
+    - name: FirstName
+      type: string
+    - name: LastName
+      type: string
+    - name: Email
+      type: string
+    - name: Phone
+      type: string
+    - name: PostalCode
+      type: string
+    - name: PrefectureName
+      type: string
+    - name: City
+      type: string
+    - name: Street
+      type: string
+    - name: Building
+      type: "*string"
+    - name: RegisteredAt
+      type: time.Time
+    - name: DeletedAt
+      type: "*time.Time"
+```
+
+## Dependencies
+
+```yaml
+- tracer              # observability.TracerFactory -> LayerTracer
+- user_query_service  # user/search/query.UserQueryService（キーワード検索の QueryService boundary）
+```
+
+## Workflow
+
+### ListUsersByKeyword
+
+```yaml
+tx_required: false
+steps:
+  - tools/search.ParseSearchTokens で filter.Keyword をトークン分割
+  - Active + Keywords から query.UserSearchFilter を構築
+  - user_query_service.FindByFilter でページング付き（limit/offset）に検索結果を取得して返す
+calls:
+  - user_query_service.FindByFilter
+errors:
+  - user_query_service.FindByFilter のエラーをそのまま伝播
+```
+
+### CountUsersByKeyword
+
+```yaml
+tx_required: false
+steps:
+  - tools/search.ParseSearchTokens で filter.Keyword をトークン分割
+  - Active + Keywords から query.UserSearchFilter を構築
+  - user_query_service.CountByFilter で検索条件に一致する総件数を取得して返す
+calls:
+  - user_query_service.CountByFilter
+errors:
+  - user_query_service.CountByFilter のエラーをそのまま伝播
+```

--- a/docs/spec/user/domain.md
+++ b/docs/spec/user/domain.md
@@ -1,0 +1,121 @@
+# User — Domain Spec
+
+> 既存実装（`internal/domain/user`）を spec 化したもの。手書き実装から逆生成した現状仕様であり、未実装機能（更新 / 論理削除など）は含まない。
+
+## Overview
+
+ユーザー集約は、アカウントの基本情報（氏名・認証情報・連絡先）と住所情報（都道府県・市区町村・番地・建物・郵便番号）を保持するドメインの中核エンティティ。生成時に全フィールドの形式・長さ・必須を検証し、不変条件を満たさない `User` は構築できない。
+
+都道府県は ID 参照（`prefectureID`）のみを保持し、表示名は別集約（`prefecture`）から解決する。パスワードは平文を保持せず、検証済みのハッシュ（`passwordHash`）のみを保持する。平文パスワードは値オブジェクト `RawPassword` で長さ検証されたうえで、外側のレイヤーでハッシュ化される。
+
+## Entity
+
+```yaml
+package: internal/domain/user
+struct: User
+fields:
+  - name: id
+    type: uuid.UUID
+    required: true        # IsNil の場合は ErrInvalidID
+  - name: firstName
+    type: string
+    required: true
+    min_length: 1
+    max_length: 100
+  - name: lastName
+    type: string
+    required: true
+    min_length: 1
+    max_length: 100
+  - name: passwordHash
+    type: string
+    required: true
+    min_length: 1
+    max_length: 255
+  - name: email
+    type: string
+    required: true
+    min_length: 1
+    max_length: 100
+  - name: phone
+    type: string
+    required: true
+    min_length: 1
+    max_length: 20
+  - name: prefectureID
+    type: uuid.UUID
+    required: true        # IsNil の場合は ErrInvalidPrefectureID
+  - name: city
+    type: string
+    required: true
+    min_length: 1
+    max_length: 100
+  - name: street
+    type: string
+    required: true
+    min_length: 1
+    max_length: 255
+  - name: building
+    type: "*string"
+    required: false       # nil 許容。非 nil の場合のみ長さ検証
+    min_length: 1
+    max_length: 255
+  - name: postalCode
+    type: string
+    required: true
+    min_length: 1
+    max_length: 8
+  - name: createdAt
+    type: time.Time
+    required: true
+  - name: updatedAt
+    type: time.Time
+    required: true
+  - name: deletedAt
+    type: "*time.Time"
+    required: false       # nil 許容（未削除を表す）
+```
+
+## Cross-field Invariants
+
+- `updatedAt >= createdAt`（更新日時は作成日時以降）。違反時 `ErrInvalidUpdatedAt`
+- `deletedAt != nil` のとき `deletedAt >= createdAt`。違反時 `ErrInvalidDeletedAt`
+- `deletedAt != nil` のとき `deletedAt >= updatedAt`。違反時 `ErrInvalidDeletedAt`
+
+## Behavior Methods
+
+```yaml
+# 現状、状態遷移メソッドは未実装（getter のみ）。
+# 以下は単純フィールド getter ではない派生メソッド。
+- name: FullName
+  signature: FullName() string
+  description: firstName + " " + lastName を連結したフルネームを返す派生値。
+```
+
+## Value Objects
+
+```yaml
+- name: RawPassword
+  underlying_type: string
+  validation: 長さが MinRawPasswordLength(8) 以上 MaxRawPasswordLength(64) 以下。違反時 ErrInvalidRawPassword
+  factory: NewRawPassword
+  methods:
+    - name: Value
+      returns: string
+```
+
+## Repository Methods
+
+```yaml
+- name: FindByActive
+  signature: FindByActive(ctx context.Context, active *bool, limit, offset int32) (Users, error)
+  behavior: |
+    アクティブ状態（active）に基づきユーザー一覧をページング付き（limit / offset）で取得する。
+    active=nil は全件、true はアクティブのみ、false は削除済みのみを想定。
+- name: Create
+  signature: Create(ctx context.Context, user *User) error
+  behavior: ユーザーを 1 件永続化する。
+- name: CountByActive
+  signature: CountByActive(ctx context.Context, active *bool) (int64, error)
+  behavior: アクティブ状態（active）に基づきユーザーの総件数を返す。
+```

--- a/docs/spec/user/usecase.md
+++ b/docs/spec/user/usecase.md
@@ -1,0 +1,126 @@
+# User — Usecase Spec
+
+> 既存実装（`internal/usecase/user`）を spec 化したもの。手書き実装から逆生成した現状仕様であり、未実装機能（取得詳細 / 更新 / 部分更新 / 削除）は含まない。
+
+## Overview
+
+ユーザーユースケースは、ユーザー一覧取得・作成・件数取得を提供するアプリケーションサービス。ドメインの `user.Repository` と `prefecture.Repository` をオーケストレーションし、ドメインエンティティを外側に晒さず DTO（`MutableFields`）へ変換して返す。
+
+都道府県は ID 参照のみを保持する設計のため、一覧・作成ともに `prefecture.Repository` から都道府県名を解決して DTO に詰める。作成時はトランザクション境界内で都道府県解決・エンティティ生成・永続化を行う。パスワードは `RawPassword` で検証後、`security.Encrypter` でハッシュ化してからエンティティに渡す。
+
+## Interface
+
+```yaml
+package: internal/usecase/user
+name: Usecase
+methods:
+  - name: ListUsers
+    signature: ListUsers(ctx context.Context, active *bool, page *paging.Paging) ([]MutableFields, error)
+  - name: CreateUser
+    signature: CreateUser(ctx context.Context, dto *CreateParamsDTO) (MutableFields, error)
+  - name: CountUsers
+    signature: CountUsers(ctx context.Context, active *bool) (int64, error)
+```
+
+## DTOs
+
+```yaml
+- name: MutableFields
+  description: ユーザー取得結果の DTO。
+  fields:
+    - name: FirstName
+      type: string
+    - name: LastName
+      type: string
+    - name: Email
+      type: string
+    - name: Phone
+      type: string
+    - name: PostalCode
+      type: string
+    - name: PrefectureName
+      type: string          # prefecture.Repository から解決した都道府県名
+    - name: City
+      type: string
+    - name: Street
+      type: string
+    - name: Building
+      type: "*string"
+    - name: DeletedAt
+      type: "*time.Time"
+- name: CreateParamsDTO
+  description: ユーザー作成に必要なパラメータ。MutableFields を埋め込む。
+  fields:
+    - name: UserID
+      type: uuid.UUID
+    - name: RawPassword
+      type: string
+    - name: MutableFields
+      type: MutableFields   # embedded
+```
+
+## Dependencies
+
+```yaml
+- tracer            # observability.TracerFactory -> LayerTracer（メソッドごとに span）
+- tx_manager        # boundary/tx.Manager
+- clock             # boundary/clock.Clock
+- encrypter         # boundary/security.Encrypter
+- user_repository   # domain/user.Repository
+- prefecture_repository  # domain/prefecture.Repository
+```
+
+## Workflow
+
+### ListUsers
+
+```yaml
+tx_required: false
+steps:
+  - userRepo.FindByActive で active / ページング条件に基づきユーザー一覧を取得
+  - 取得した各ユーザーの prefectureID を集約し、pftRepo.FindByIDs で都道府県をまとめて解決（N+1 回避、子 span で計測）
+  - prefectureID -> Prefecture のマップを構築
+  - 各ユーザーを MutableFields へ変換し、都道府県名を埋める
+calls:
+  - user_repository.FindByActive
+  - prefecture_repository.FindByIDs
+errors:
+  - userRepo / pftRepo のエラーをそのまま伝播
+```
+
+### CreateUser
+
+```yaml
+tx_required: true
+steps:
+  - clock.Now で現在時刻を取得
+  - user.NewRawPassword で平文パスワードを検証
+  - encrypter.Hash でパスワードハッシュを生成
+  - トランザクション内で
+      - pftRepo.FindByName で都道府県を名前解決
+      - user.New でエンティティ生成（不変条件検証）
+      - userRepo.Create で永続化
+  - 生成したエンティティと都道府県名から MutableFields を構築して返す
+calls:
+  - clock.Now
+  - user.NewRawPassword
+  - encrypter.Hash
+  - tx_manager.Do            # トランザクション境界。内部で以下を実行
+  - prefecture_repository.FindByName
+  - user.New
+  - user_repository.Create
+errors:
+  - NewRawPassword / Hash / FindByName / user.New / Create のエラーを伝播
+```
+
+### CountUsers
+
+```yaml
+tx_required: false
+steps:
+  - userRepo.CountByActive で active 条件に基づく総件数を取得して返す
+calls:
+  - user_repository.CountByActive
+errors:
+  - userRepo のエラーをそのまま伝播
+```


### PR DESCRIPTION
# 概要

既存の手書き実装（domain 集約・usecase）を lean A 構成の spec として `docs/spec/` 配下に整備する。コードは変更せず、現状の実装を逆生成して spec 化したもの（未実装機能は含まない）。後続の機能追加（scaffold 入力）の基盤となる。

## 変更内容

- `docs/spec/user/{domain,usecase}.md`: User 集約（entity/VO/Repository IF）と usecase（ListUsers/CreateUser/CountUsers）の spec
- `docs/spec/prefecture/domain.md`: Prefecture 集約（user usecase の依存集約）の domain spec
- `docs/spec/healthcheck/usecase.md`: ヘルスチェック usecase の spec（domain なし）
- `docs/spec/user-search/usecase.md`: ユーザー検索 usecase の spec（domain なし）
- いずれも `verify-spec` で violations 0 を確認済み

## 動作確認方法

- ドキュメントのみ（コード変更なし）
- `verify-spec` で format / 派生元（SQL・migrations）/ cross-spec 参照整合を確認済み