### PR TITLE
Trivy スキャンの設定適正化とリリースゲート/SARIF/週次実行を追加

### DIFF
--- a/.github/workflows/README.ja.md
+++ b/.github/workflows/README.ja.md
@@ -9,7 +9,7 @@
 | グループ | 発火タイミング | 目的 |
 | --- | --- | --- |
 | CI チェック | 全 PR | lint / test / 生成物整合性が失敗したらマージブロック |
-| セキュリティ | 全 PR（および default ブランチ push） | コード / 依存 / イメージ / Go ランタイムの脆弱性を surface |
+| セキュリティ | 全 PR + 週次スケジュール（Trivy） | コード / 依存 / イメージ / Go ランタイムの脆弱性を surface |
 | デプロイ | `production` / `staging` / `develop` への push | 成果物ビルド、マイグレーション実行、アプリ / docs portal をデプロイ |
 | ドキュメント | `release/*` への push | OpenAPI / ER / portal ドキュメントを再生成し auto-sync PR を作成 |
 
@@ -56,5 +56,5 @@
 
 - `auto-generate-docs.yaml` は `auto/docs-update/<base>-<run-id>` というブランチ名で auto-PR を作成。再帰実行を避けるため自己ブランチでは workflow をスキップ
 - デプロイ系 workflow の target ブランチ（`production` / `staging` / `develop`）はすべてブランチ保護を有効化。マージは必ず PR レビュー経由
-- セキュリティスキャンは全 PR で実行。CodeQL / Trivy で high-severity が出るとブランチ保護ルールでマージブロック
+- セキュリティスキャンは全 PR で実行（Trivy の FS / image スキャンは新規公表 CVE 検知のため週次 `schedule` でも実行）。CodeQL / Trivy で high-severity が出るとブランチ保護ルールでマージブロック
 - `auto-generate-docs.yaml` の `Detect changes` ステップはカバレッジ HTML / SchemaSpy のタイムスタンプ揺れを除外し、無意味な PR が発火しないよう設計

--- a/.github/workflows/README.ja.md
+++ b/.github/workflows/README.ja.md
@@ -34,7 +34,8 @@
 |ワークフロー|ファイル|説明|
 |---|---|---|
 |Code Security Scan|`code-ql.yaml`|CodeQL によるセキュリティ脆弱性分析|
-|Dependency Vulnerability Scan|`trivy-fs.yaml`|Trivy による OS / ライブラリ脆弱性スキャン|
+|Dependency Vulnerability Scan|`trivy-fs.yaml`|Trivy によるライブラリ脆弱性スキャン(開発者向け)|
+|Release Dependency Vulnerability Scan|`trivy-release-gate.yaml`|develop/staging/production 向け PR での Trivy 依存スキャン|
 |Docker Image Scan|`image-scan.yaml`|Docker イメージビルド + SBOM 生成 + Trivy スキャン|
 |Go Vulnerability Analysis|`vulnerability-check.yaml`|govulncheck による Go パッケージ脆弱性検出|
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,7 +9,7 @@ This directory contains GitHub Actions workflow definitions for CI/CD. Workflows
 | Group | When it runs | What it does |
 | --- | --- | --- |
 | CI Checks | every pull request | Block merge if lint / test / generated-artifact consistency fails |
-| Security | every PR (and push to default) | Surface vulnerabilities in code, dependencies, images, and Go runtime |
+| Security | every PR + weekly schedule (Trivy) | Surface vulnerabilities in code, dependencies, images, and Go runtime |
 | Deployment | push to `production` / `staging` / `develop` | Build artifacts, run migration, deploy app or docs portal |
 | Documentation | push to `release/*` | Regenerate OpenAPI / ER / portal docs and open an auto-sync PR |
 
@@ -56,5 +56,5 @@ This directory contains GitHub Actions workflow definitions for CI/CD. Workflows
 
 - `auto-generate-docs.yaml` opens an auto-PR whose branch is named `auto/docs-update/<base>-<run-id>`; the workflow skips itself on that branch to avoid recursion.
 - All deployment workflows require their target branch (`production` / `staging` / `develop`) to be branch-protected; merges must flow through PR review.
-- Security scans run on every PR; if a high-severity CodeQL or Trivy finding appears, the corresponding branch-protection rule blocks merge.
+- Security scans run on every PR (Trivy FS / image scans also run weekly via `schedule` to catch newly disclosed CVEs); if a high-severity CodeQL or Trivy finding appears, the corresponding branch-protection rule blocks merge.
 - The `Detect changes` step in `auto-generate-docs.yaml` excludes coverage HTML and SchemaSpy timestamp churn so cosmetic regenerations do not open noise PRs.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -34,7 +34,8 @@ This directory contains GitHub Actions workflow definitions for CI/CD. Workflows
 |Workflow|File|Description|
 |---|---|---|
 |Code Security Scan|`code-ql.yaml`|CodeQL analysis for security vulnerabilities|
-|Dependency Vulnerability Scan|`trivy-fs.yaml`|Trivy filesystem scan for OS/library vulnerabilities|
+|Dependency Vulnerability Scan|`trivy-fs.yaml`|Trivy filesystem scan for library vulnerabilities (developer-facing)|
+|Release Dependency Vulnerability Scan|`trivy-release-gate.yaml`|Trivy filesystem scan on PRs into develop/staging/production|
 |Docker Image Scan|`image-scan.yaml`|Build image, generate SBOM, run Trivy scan|
 |Go Vulnerability Analysis|`vulnerability-check.yaml`|govulncheck for actionable Go vulnerabilities|
 

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
       pull-requests: write
 
     steps:
@@ -227,6 +228,7 @@ jobs:
           output: trivy-image-scan.sarif
 
       - name: Upload Trivy image SARIF to code scanning
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-image-scan.sarif

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -6,6 +6,8 @@ on:
       - production
       - staging
       - develop
+  schedule:
+    - cron: '0 0 * * 1'
   workflow_dispatch:
 
 concurrency:
@@ -206,11 +208,30 @@ jobs:
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ steps.meta.outputs.image }}
+          scanners: 'vuln'
           format: table
-          ignore-unfixed: true
+          ignore-unfixed: false
           vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
+          severity: 'CRITICAL,HIGH,MEDIUM'
           output: trivy-image-scan.txt
+
+      - name: Trivy image scan (SARIF)
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ${{ steps.meta.outputs.image }}
+          scanners: 'vuln'
+          format: sarif
+          ignore-unfixed: false
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          output: trivy-image-scan.sarif
+
+      - name: Upload Trivy image SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-image-scan.sarif
+          category: trivy-image
+
       - name: Upload Trivy report artifact
         uses: actions/upload-artifact@v7
         with:
@@ -309,3 +330,15 @@ jobs:
                 body,
               });
             }
+
+      - name: Trivy image scan (gate - fixable CRITICAL/HIGH)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ${{ steps.meta.outputs.image }}
+          scanners: 'vuln'
+          format: table
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'

--- a/.github/workflows/trivy-fs.yaml
+++ b/.github/workflows/trivy-fs.yaml
@@ -167,6 +167,7 @@ jobs:
             }
 
       - name: Trivy FS scan (SARIF)
+        if: always()
         uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: fs
@@ -178,6 +179,8 @@ jobs:
           output: trivy-fs.sarif
 
       - name: Upload Trivy FS SARIF to code scanning
+        if: always()
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-fs.sarif

--- a/.github/workflows/trivy-release-gate.yaml
+++ b/.github/workflows/trivy-release-gate.yaml
@@ -1,14 +1,11 @@
-name: Dependency Vulnerability Scan Workflow
+name: Release Dependency Vulnerability Scan Workflow
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/trivy-fs.yaml'
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-  schedule:
-    - cron: '0 0 * * 1'
+    branches:
+      - develop
+      - staging
+      - production
   workflow_dispatch:
 
 permissions:
@@ -22,40 +19,50 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  trivy-fs:
+  trivy-fs-release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Trivy FS scan (JSON)
+      - name: Trivy FS scan (JSON, include unfixed)
         uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: fs
           scanners: 'vuln'
           format: json
-          ignore-unfixed: true
+          ignore-unfixed: false
           vuln-type: 'library'
           severity: 'CRITICAL,HIGH,MEDIUM'
-          output: trivy-fs.json
+          output: trivy-fs-release.json
 
       - name: Create Trivy summary (Markdown)
         id: summarize
         run: |
           set -euo pipefail
-          
+
           # total vulnerability count
           COUNT=$(jq '
             .Results
             | map(.Vulnerabilities // [])
             | flatten
             | length
-          ' trivy-fs.json)
-          
+          ' trivy-fs-release.json)
+
+          # unfixed count
+          UNFIXED=$(jq '
+            .Results
+            | map(.Vulnerabilities // [])
+            | flatten
+            | map(select((.FixedVersion // "") == ""))
+            | length
+          ' trivy-fs-release.json)
+
           echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+          echo "unfixed=${UNFIXED}" >> "$GITHUB_OUTPUT"
 
           if [ "$COUNT" -eq 0 ]; then
-            echo "No vulnerabilities found." > trivy-fs-summary.md
+            echo "No vulnerabilities found." > trivy-fs-release-summary.md
             exit 0
           fi
 
@@ -67,19 +74,19 @@ jobs:
             | sort_by(.Severity) | reverse
             | .[]
             | "- [\(.Severity)] \(.PkgName // "unknown") `\(.InstalledVersion // "?")` → `\(.FixedVersion // "none")` (\(.VulnerabilityID))"
-          ' trivy-fs.json > trivy-fs-summary.md
+          ' trivy-fs-release.json > trivy-fs-release-summary.md
 
         shell: bash
 
-      - name: Upload Trivy FS report
+      - name: Upload Trivy FS release report
         uses: actions/upload-artifact@v7
         with:
-          name: trivy-fs
+          name: trivy-fs-release
           path: |
-            trivy-fs.json
-            trivy-fs-summary.md
+            trivy-fs-release.json
+            trivy-fs-release-summary.md
 
-      - name: Comment Trivy FS result on PR
+      - name: Comment Trivy FS release result on PR
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/github-script@v8
         with:
@@ -87,8 +94,9 @@ jobs:
           script: |
             const fs = require('fs');
 
-            const marker = '<!-- trivy-fs-result -->';
+            const marker = '<!-- trivy-fs-release-result -->';
             const count = Number('${{ steps.summarize.outputs.count }}' || '0');
+            const unfixed = Number('${{ steps.summarize.outputs.unfixed }}' || '0');
 
             const updatedAtJST = new Date().toLocaleString('ja-JP', {
               timeZone: 'Asia/Tokyo',
@@ -121,16 +129,17 @@ jobs:
             };
 
             const title = (count === 0)
-              ? '✅ Trivy FS: PASS (no vulnerabilities)'
-              : `🚨 Trivy FS: FOUND (${count})`;
+              ? '✅ Release Dependency Scan: PASS (no vulnerabilities)'
+              : `🚨 Release Dependency Scan: FOUND (${count})`;
 
-            const summary = read('trivy-fs-summary.md');
+            const summary = read('trivy-fs-release-summary.md');
 
             const body = [
               marker,
               `## ${title}`,
               '',
               `- Total vulnerabilities: **${count}**`,
+              `- Unfixed (no patch): **${unfixed}**`,
               `- 🔖 Commit: [\`${shortSha}\`](${commitUrl})`,
               `- 🕒 UpdatedAt: ${updatedAtJST} (JST)`,
               '',
@@ -165,20 +174,3 @@ jobs:
                 body,
               });
             }
-
-      - name: Trivy FS scan (SARIF)
-        uses: aquasecurity/trivy-action@0.35.0
-        with:
-          scan-type: fs
-          scanners: 'vuln'
-          format: sarif
-          ignore-unfixed: true
-          vuln-type: 'library'
-          severity: 'CRITICAL,HIGH,MEDIUM'
-          output: trivy-fs.sarif
-
-      - name: Upload Trivy FS SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-fs.sarif
-          category: trivy-fs

--- a/.github/workflows/trivy-release-gate.yaml
+++ b/.github/workflows/trivy-release-gate.yaml
@@ -11,7 +11,6 @@ on:
 permissions:
   contents: read
   security-events: write
-  actions: read
   pull-requests: write
 
 concurrency:


### PR DESCRIPTION
# 概要

Trivy 脆弱性スキャンの設定値を適正化し、依存更新 PR で確実に走るようトリガを修正しました。あわせてリリース昇格向けの依存スキャン新設・image スキャンのゲート化・SARIF 連携・週次定期実行を追加しています。

## 変更内容

- **`trivy-fs.yaml`**: `scanners` 明示 / fs の `vuln-type` を `library` / paths に `go.mod`・`go.sum` 追加 / 週次 schedule / SARIF アップロード
- **`image-scan.yaml`**: severity 統一 / `ignore-unfixed:false` で全件可視化 / 修正版のある CRITICAL/HIGH で PR チェックを落とすゲート追加（PR 限定） / SARIF / 週次 schedule
- **`trivy-release-gate.yaml`（新規）**: develop/staging/production 向け PR で依存スキャン（`ignore-unfixed:false`・報告のみ）
- **`README.md` / `README.ja.md`**: ワークフロー一覧を更新

## 動作確認方法

1. 全 workflow の YAML 妥当性を確認済み
2. `make lint` / `test` / `sql-lint` / migration-check すべて成功
3. 実挙動は本 PR の Actions（`trivy-fs` は go.mod 変更で起動、`image-scan` は対象ブランチ向け PR で起動）で確認