### PR TITLE
pre-push に生成物ドリフト検知ゲートを追加

### DIFF
--- a/.lefthook.yaml
+++ b/.lefthook.yaml
@@ -15,6 +15,6 @@ pre-commit:
 pre-push:
   commands:
     gen-go-check:
-      run: make gen-bundle-oapi gen-go-code && git diff --exit-code -- '*.gen.go' '*_mock.go' openapi/openapi.gen.yaml
+      run: make gen-bundle-oapi gen-go-code && git diff --exit-code -- '*.gen.go' '*/mock/mock_*.go' '*_mock.go' openapi/openapi.gen.yaml
     tidy-check:
       run: go mod tidy && git diff --exit-code go.mod go.sum

--- a/.lefthook.yaml
+++ b/.lefthook.yaml
@@ -11,3 +11,10 @@ pre-commit:
       run: make check-migration-up-version check-migration-down-version
     migration-check-gap:
       run: make check-migration-up-gap check-migration-down-gap
+
+pre-push:
+  commands:
+    gen-go-check:
+      run: make gen-bundle-oapi gen-go-code && git diff --exit-code -- '*.gen.go' '*_mock.go' openapi/openapi.gen.yaml
+    tidy-check:
+      run: go mod tidy && git diff --exit-code go.mod go.sum


### PR DESCRIPTION
# 概要

再生成し忘れ・`go mod tidy` 忘れを push 前に手元で検知する pre-push フックを追加しました。CI 往復前に潰せるようにします。

## 変更内容

- `.lefthook.yaml` に `pre-push` を追加:
  - **gen-go-check**: `make gen-bundle-oapi gen-go-code` → 生成物パス（`*.gen.go` / `*_mock.go` / `openapi.gen.yaml`）に限定して `git diff --exit-code`
  - **tidy-check**: `go mod tidy` → `git diff --exit-code go.mod go.sum`
- sqlc/DB 生成物（DB 必須）・image・security スキャンは CI 専用のまま

## 動作確認方法

1. `lefthook install` で pre-push を登録
2. `lefthook run pre-push` および実 push で両チェック pass（exit 0）を確認済み
3. diff を生成物パスに限定し、無関係な未コミット変更での誤検知が起きないことを確認