### PR TITLE
CodeQL に push ベースライン・週次 schedule・setup-go を追加

### DIFF
--- a/.github/workflows/README.ja.md
+++ b/.github/workflows/README.ja.md
@@ -29,7 +29,7 @@
 |Generated OpenAPI Artifacts|`gen-oapi-artifacts-check.yaml`|OpenAPI バンドルとドキュメントの一致検証|
 |Application Boot|`app-di-startup-check.yaml`|DB 付きでアプリケーションが正常に起動するか検証|
 
-### セキュリティ（Pull Request）
+### セキュリティ
 
 |ワークフロー|ファイル|説明|
 |---|---|---|

--- a/.github/workflows/README.ja.md
+++ b/.github/workflows/README.ja.md
@@ -9,7 +9,7 @@
 | グループ | 発火タイミング | 目的 |
 | --- | --- | --- |
 | CI チェック | 全 PR | lint / test / 生成物整合性が失敗したらマージブロック |
-| セキュリティ | 全 PR + 週次スケジュール（Trivy） | コード / 依存 / イメージ / Go ランタイムの脆弱性を surface |
+| セキュリティ | 全 PR + 週次スケジュール（Trivy / CodeQL）+ push ベースライン（CodeQL） | コード / 依存 / イメージ / Go ランタイムの脆弱性を surface |
 | デプロイ | `production` / `staging` / `develop` への push | 成果物ビルド、マイグレーション実行、アプリ / docs portal をデプロイ |
 | ドキュメント | `release/*` への push | OpenAPI / ER / portal ドキュメントを再生成し auto-sync PR を作成 |
 
@@ -56,5 +56,5 @@
 
 - `auto-generate-docs.yaml` は `auto/docs-update/<base>-<run-id>` というブランチ名で auto-PR を作成。再帰実行を避けるため自己ブランチでは workflow をスキップ
 - デプロイ系 workflow の target ブランチ（`production` / `staging` / `develop`）はすべてブランチ保護を有効化。マージは必ず PR レビュー経由
-- セキュリティスキャンは全 PR で実行（Trivy の FS / image スキャンは新規公表 CVE 検知のため週次 `schedule` でも実行）。CodeQL / Trivy で high-severity が出るとブランチ保護ルールでマージブロック
+- セキュリティスキャンは全 PR で実行（Trivy の FS / image と CodeQL は新規公表 CVE / クエリ検知のため週次 `schedule` でも実行。CodeQL は code scanning ベースライン維持のため `release/*` とデプロイ系ブランチへの push でも実行）。CodeQL / Trivy で high-severity が出るとブランチ保護ルールでマージブロック
 - `auto-generate-docs.yaml` の `Detect changes` ステップはカバレッジ HTML / SchemaSpy のタイムスタンプ揺れを除外し、無意味な PR が発火しないよう設計

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,7 +9,7 @@ This directory contains GitHub Actions workflow definitions for CI/CD. Workflows
 | Group | When it runs | What it does |
 | --- | --- | --- |
 | CI Checks | every pull request | Block merge if lint / test / generated-artifact consistency fails |
-| Security | every PR + weekly schedule (Trivy) | Surface vulnerabilities in code, dependencies, images, and Go runtime |
+| Security | every PR + weekly schedule (Trivy / CodeQL) + push baseline (CodeQL) | Surface vulnerabilities in code, dependencies, images, and Go runtime |
 | Deployment | push to `production` / `staging` / `develop` | Build artifacts, run migration, deploy app or docs portal |
 | Documentation | push to `release/*` | Regenerate OpenAPI / ER / portal docs and open an auto-sync PR |
 
@@ -56,5 +56,5 @@ This directory contains GitHub Actions workflow definitions for CI/CD. Workflows
 
 - `auto-generate-docs.yaml` opens an auto-PR whose branch is named `auto/docs-update/<base>-<run-id>`; the workflow skips itself on that branch to avoid recursion.
 - All deployment workflows require their target branch (`production` / `staging` / `develop`) to be branch-protected; merges must flow through PR review.
-- Security scans run on every PR (Trivy FS / image scans also run weekly via `schedule` to catch newly disclosed CVEs); if a high-severity CodeQL or Trivy finding appears, the corresponding branch-protection rule blocks merge.
+- Security scans run on every PR (Trivy FS / image and CodeQL also run weekly via `schedule` to catch newly disclosed CVEs / queries; CodeQL additionally runs on push to `release/*` and the deploy branches to keep a code-scanning baseline); if a high-severity CodeQL or Trivy finding appears, the corresponding branch-protection rule blocks merge.
 - The `Detect changes` step in `auto-generate-docs.yaml` excludes coverage HTML and SchemaSpy timestamp churn so cosmetic regenerations do not open noise PRs.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -29,7 +29,7 @@ This directory contains GitHub Actions workflow definitions for CI/CD. Workflows
 |Generated OpenAPI Artifacts|`gen-oapi-artifacts-check.yaml`|Verify OpenAPI bundle and docs match committed artifacts|
 |Application Boot|`app-di-startup-check.yaml`|Verify application starts successfully with DB|
 
-### Security (Pull Request)
+### Security
 
 |Workflow|File|Description|
 |---|---|---|

--- a/.github/workflows/code-ql.yaml
+++ b/.github/workflows/code-ql.yaml
@@ -26,10 +26,9 @@ permissions:
   contents: read
   security-events: write
   actions: read
-  pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/code-ql.yaml
+++ b/.github/workflows/code-ql.yaml
@@ -1,12 +1,25 @@
 name: Code Security Scan Workflow
 
 on:
+  push:
+    branches:
+      - 'release/*'
+      - develop
+      - staging
+      - production
+    paths:
+      - '.github/workflows/code-ql.yaml'
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
   pull_request:
     paths:
       - '.github/workflows/code-ql.yaml'
       - '**/*.go'
       - 'go.mod'
       - 'go.sum'
+  schedule:
+    - cron: '0 0 * * 1'
   workflow_dispatch:
 
 permissions:
@@ -25,6 +38,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4


### PR DESCRIPTION
# 概要

CodeQL の設定を強化しました。default/統合ブランチの code scanning ベースライン作成、新規クエリ / CVE 検知のための週次実行、go.mod 準拠ビルドの決定論化を追加しています。

## 変更内容

- **`code-ql.yaml`**: `push`（`release/*` + develop/staging/production）と週次 `schedule` トリガーを追加 / `autobuild` 前に `actions/setup-go`（`go-version-file: go.mod`・cache）を追加
- **`README.md` / `README.ja.md`**: トリガ表・補足に CodeQL の push / schedule を反映

## 動作確認方法

1. YAML 妥当性確認済み
2. `make lint` / `test` / `sql-lint` / migration-check 通過
3. マージ後、`release/*` への push で CodeQL ベースライン解析が走り Security タブに反映されることを確認

補足: GitHub の CodeQL "default setup" は OFF（advanced 運用）である前提です。