### PR TITLE
Docs: v1.2.0 リリースノートを追加

### DIFF
--- a/.github/release/v1.2.0.md
+++ b/.github/release/v1.2.0.md
@@ -1,0 +1,161 @@
+<!-- markdownlint-disable MD041 -->
+## 概要
+
+`v1.1.0` を起点とするマイナーリリースです。本リリースの目玉は users 詳細系
+API（取得詳細 / 更新 / 部分更新 / 論理削除 / パスワード変更）の追加で、
+Onion Architecture の全層（domain → usecase → infrastructure → controller）に
+わたって実装しました。あわせて、mise を SSOT としたツール／ランタイム
+バージョン管理への移行、Trivy・CodeQL・生成物ドリフト検知などのセキュリティ／
+CI 強化、AI 支援開発を支える多数のスキル整備、テスト品質の底上げを行っています。
+
+変更規模は以下です。
+
+- `180` コミット
+- `499` ファイル変更
+- `+27,920 / -6,522`
+
+## 変更内容
+
+### 新機能・改善
+
+#### users 詳細系 API の追加
+
+- ユーザーの取得詳細 / 更新（PUT）/ 部分更新（PATCH）/ 論理削除（DELETE）の
+  エンドポイントを追加し、Onion の全層へ実装しました。
+  - domain: 更新・論理削除の振る舞いを追加
+  - usecase: 取得詳細・更新・削除のユースケースを追加
+  - infrastructure: `FindByID` / `Update` を追加（ユーザー更新用 SQL を含む）
+  - controller: 詳細系エンドポイントを追加
+- パスワード変更を専用エンドポイント `/v1/users/me/password`（自己変更）へ
+  分離しました。現パスワード検証を行い、検証失敗は `422` で返します。
+- users 詳細系エンドポイントに `BearerAuth` を必須化しました。
+- UUID 変換規約・エラー／境界／テスト方針をドキュメント化し、リクエスト用 UUID
+  生成は `testuuid` テストヘルパーへ共有化しました。
+
+#### ツールチェーン・ランタイム基盤の刷新
+
+- ツール／ランタイムのバージョン管理を `mise.toml` を SSOT とする構成へ移行し、
+  `sync-versions` を Go 実装化しました。Go バージョンマネージャは mise を primary に
+  切り替え（goenv はフォールバック）、`gen-versions-check` ワークフローと関連メタ
+  機構を撤去しました。
+- Go を `1.26.4` にアップグレードし、主要ライブラリを一括更新しました。
+  - `jackc/pgx/v5` v5.9.1 → v5.10.0
+  - `labstack/echo/v4` v4.15.1 → v4.15.2 / `labstack/gommon` v0.4.2 → v0.5.0
+  - `getkin/kin-openapi` v0.135.0 → v0.140.0
+  - `go.opentelemetry.io/otel` 系 v1.43.0 → v1.44.0
+  - `go.uber.org/zap` v1.27.1 → v1.28.0
+  - `cockroachdb/errors` v1.12.0 → v1.13.0、`caarlos0/env/v11` v11.4.0 → v11.4.1、
+    `oapi-codegen/runtime` v1.4.0 → v1.4.1
+  - `golang.org/x/crypto` / `x/net` / `x/sys` / `x/text` を最新マイナーへ追従
+- `govulncheck` / `gopls` の backend を aqua から go へ切り替え、`tools.yaml` の
+  各種開発ツールを最新化しました。
+
+#### セキュリティ・CI 強化
+
+- Trivy による依存スキャンを追加しました（ローカル `make trivy-fs` + CI ワークフロー、
+  リリースゲート / SARIF / 週次実行）。
+- CodeQL に push ベースライン・週次 schedule・`setup-go` を追加しました。
+- pre-push フックに生成物ドリフト検知ゲートを追加しました（mockgen 出力の
+  取りこぼし修正を含む）。
+- Markdown lint ツールチェーンを追加しました。
+
+#### AI 支援開発スキルの整備
+
+- コミット分割・PR 作成フローを `commit` / `submit-pr` スキルへ集約しました。
+- アーキ検査 `arch-check`、ドリフト検出 `back-prop` を per-layer 構成
+  （domain / usecase / controller / infra / pkg）で追加しました。
+- spec を lean A 2 層構成（domain / usecase）とする `new-spec` / `verify-spec` /
+  `scaffold` 系スキルと lifecycle ドキュメントを追加しました。
+- 別モデル subAgent によるローカル敵対的レビュー構成 `local-review` を追加しました。
+- このほか `go-upgrade` / `tools-upgrade` / `new-env` / `tool-map` /
+  `readme-review` / `portal-manifest-sync` / `canonicalize-doc` / `sync-readme` /
+  `release-notes` などを追加しました。
+
+#### テスト品質の向上
+
+- 全テストの終端値検証を `assert` 併用へ統一しました（前提・エラー系は `require`
+  を維持）。AGENTS.md の Assertion Rules を明確化し、`genctxkey` テスト
+  テンプレートも assert 方針へ揃えました。
+- di の lifecycle / extension / grow 領域・ルート合成テストを、fx グラフ解決を
+  伴う意味のある契約検証へ格上げしました。
+- job core の mock 起動テスト、uri ミドルウェアの実挙動（末尾スラッシュ除去）
+  テスト、testkit ヘルパーの契約検証テストを追加しました。
+- logging レスポンスログ・user ドメインテストの並列競合／共有ポインタ競合を
+  直列化で解消しました。
+
+#### ドキュメント整備
+
+- ドキュメントポータルの manifest に manual-worthy な README 17 ペアを追加し、
+  borderline だった 7 件を補強して manual-worthy 化しました。
+- `controller/conv` パッケージ README（EN/JA）、user / prefecture / healthcheck /
+  user-search の既存実装 spec を追加しました。
+
+#### その他の改善
+
+- IP レートリミット Middleware を関連 config・DI 配線ごと削除し、ドキュメントの
+  該当記述も整理（`429` の説明を更新）しました。
+- OpenAPI の `paths` を URL ミラー規約へ統一し、leaf の二重ネストを解消しました。
+- 自明な what コメントの整理、godoc 規約の統一など細部の可読性を改善しました。
+
+## 動作確認手順
+
+1. `mise install`（または `make install-tools`）でツール／ランタイムを同期
+2. `go version` が `1.26.4` を返すことを確認
+3. `make gen-api`
+4. `make gen-query`
+5. `make lint`
+6. `make test`（カバレッジがベースラインを下回らないこと）
+7. `make trivy-fs` が依存スキャンを実行できることを確認
+8. users 詳細系 API を起動して確認
+   - `GET /v1/users/{id}`（BearerAuth 必須）で詳細が取得できる
+   - `PUT` / `PATCH` で更新・部分更新ができ、存在しないユーザーは `404` を返す
+   - `DELETE` で論理削除され、`updatedAt` が削除時刻へ更新される
+   - `PATCH /v1/users/me/password` で現パスワード検証が行われ、誤りは `422` を返す
+
+## 影響（想定されるメリット／注意点）
+
+- ✅ users 詳細系 API の追加により、ユーザー管理機能が CRUD ＋ 自己パスワード変更
+  まで揃いました。
+- ✅ mise SSOT 化により、ローカル／CI のツール・ランタイムバージョンが一元管理され、
+  ドリフトが起きにくくなります。
+- ✅ Trivy / CodeQL / 生成物ドリフト検知の追加で、依存脆弱性・コードスキャン・
+  生成物の取りこぼしを CI で継続的に検知できます。
+- ✅ スキル群の整備により、AI 支援によるスキャフォールド・レビュー・ドキュメント
+  同期の再現性が向上します。
+- ⚠️ Go を `1.26.4` に引き上げているため、ローカル／CI ともにツールチェーンの更新が
+  必要です。バージョン管理は mise を primary としているため、`mise install` の
+  実行を推奨します。
+- ⚠️ OpenAPI に変更があります（users 詳細系の追加、パスワード変更エンドポイントの
+  分離、詳細系の認証必須化、ユーザー作成 API の `allOf` + `additionalProperties:false`
+  非互換の修正）。既存クライアントは再生成・追従が必要です。
+- ⚠️ IP レートリミット Middleware を削除したため、当該機能に依存していた構成は
+  挙動が変わります。
+
+## 追加ライブラリ
+
+- なし（直接依存の追加はなく、既存依存のバージョン更新が中心。kin-openapi 更新に
+  伴い `santhosh-tekuri/jsonschema/v6` などの indirect 依存が入れ替わっています）
+
+## 不具合修正
+
+- ユーザー作成 API の破壊（`allOf` + `additionalProperties:false` の非互換）を
+  修正しました。
+- パスワード変更のレビュー指摘に対応しました（`422` 化・現パスワード検証・DTO 整理・
+  パスワードハッシュ計算順序の是正）。
+- 論理削除済みユーザーへの更新をドメインで明示的に拒否し、users 詳細系
+  エンドポイントの論理削除セマンティクスを是正しました。
+- 影響行数 0 → `NotFound` 判定を `pgerror` に集約し、存在しないユーザーへの Update で
+  `NotFound` を返すようにしました。
+- `healthcheck` usecase の `time.Now()` を `clock.Clock` 経由へ置換しました。
+- pre-push の生成物ドリフト検知が mockgen 出力を取りこぼす問題、Trivy / CodeQL
+  ワークフローのローカルレビュー指摘、`auth_test.go` の gosec G124 false positive、
+  di/job mermaid label のエスケープなどを修正しました。
+
+## 補足・備考
+
+- 本リリースには OpenAPI の破壊的変更を含みます（上記「影響」を参照）。クライアント
+  コードの再生成・追従をお願いします。
+- ツール／ランタイムのバージョン管理は `mise.toml` を SSOT としています。goenv は
+  フォールバック扱いで、将来的に廃止予定です。
+- `release/v1.2.0` ブランチを起点に、通常のリリースフロー（feature → release →
+  production）に従って取り込み予定です。


### PR DESCRIPTION
# 概要

v1.1.0 → v1.2.0 のマイナーリリースに向けたリリースノート `.github/release/v1.2.0.md` を追加します。

## 変更内容

- ドキュメント
  - `.github/release/v1.2.0.md` を新規追加（v1.1.0 → v1.2.0 の変更要約）
    - users 詳細系 API（取得詳細 / 更新 / 部分更新 / 論理削除 / パスワード変更）の追加
    - mise を SSOT としたツール／ランタイムバージョン管理への移行
    - Trivy / CodeQL / 生成物ドリフト検知などのセキュリティ・CI 強化
    - AI 支援開発スキルの整備、テスト品質の向上
    - OpenAPI の破壊的変更・追加ライブラリ・不具合修正の記載

## 動作確認方法

1. `.github/release/v1.2.0.md` の内容が canonical な v1.1.0 形式に沿っていることを確認
2. `make md-lint` がクリーンであることを確認（実行済み: 0 errors）