### PR TITLE
Refactor: domain 層のレビュー指摘対応（命名・検証ロジック・契約コメント）

### DIFF
--- a/internal/domain/prefecture/error.go
+++ b/internal/domain/prefecture/error.go
@@ -6,8 +6,8 @@ import (
 )
 
 var (
-	errInvalid               = xerrors.Wrap(apperror.ErrValidation, "invalid prefecture")
-	ErrInvalidID             = xerrors.Wrap(errInvalid, "id failed")
-	ErrInvalidPrefectureName = xerrors.Wrap(errInvalid, "prefecture name failed")
-	ErrInvalidCode           = xerrors.Wrap(errInvalid, "code failed")
+	errInvalid     = xerrors.Wrap(apperror.ErrValidation, "invalid prefecture")
+	ErrInvalidID   = xerrors.Wrap(errInvalid, "id failed")
+	ErrInvalidName = xerrors.Wrap(errInvalid, "name failed")
+	ErrInvalidCode = xerrors.Wrap(errInvalid, "code failed")
 )

--- a/internal/domain/prefecture/prefecture_domain.go
+++ b/internal/domain/prefecture/prefecture_domain.go
@@ -10,10 +10,10 @@ import (
 )
 
 const (
-	MinPrefectureNameLength = 1
-	MaxPrefectureNameLength = 100
-	MinCode                 = 1
-	MaxCode                 = 47
+	minNameLength = 1
+	maxNameLength = 100
+	minCode       = 1
+	maxCode       = 47
 )
 
 type Prefectures []*Prefecture
@@ -33,13 +33,13 @@ func New(
 	if id.IsNil() {
 		return nil, xerrors.Wrap(ErrInvalidID, "id is required")
 	}
-	if ok, msg := stringkit.ValidateInRange(name, MinPrefectureNameLength, MaxPrefectureNameLength); !ok {
-		return nil, xerrors.Wrap(ErrInvalidPrefectureName, msg)
+	if ok, msg := stringkit.ValidateInRange(name, minNameLength, maxNameLength); !ok {
+		return nil, xerrors.Wrap(ErrInvalidName, msg)
 	}
-	if code < MinCode || MaxCode < code {
+	if code < minCode || maxCode < code {
 		return nil, xerrors.Wrap(
 			ErrInvalidCode,
-			fmt.Sprintf("code must be between %d and %d, got %d", MinCode, MaxCode, code),
+			fmt.Sprintf("code must be between %d and %d, got %d", minCode, maxCode, code),
 		)
 	}
 

--- a/internal/domain/prefecture/prefecture_domain_test.go
+++ b/internal/domain/prefecture/prefecture_domain_test.go
@@ -49,25 +49,25 @@ func TestNew(t *testing.T) {
 			require.ErrorIs(t, err, ErrInvalidID)
 		})
 
-		t.Run("無効な都道府県名の場合、ErrInvalidPrefectureNameエラーが返される", func(t *testing.T) {
+		t.Run("無効な都道府県名の場合、ErrInvalidNameエラーが返される", func(t *testing.T) {
 			t.Parallel()
 
 			t.Run("文字数が最小値未満の場合", func(t *testing.T) {
 				t.Parallel()
 
-				invalidName := strings.Repeat("字", MinPrefectureNameLength-1)
+				invalidName := strings.Repeat("字", minNameLength-1)
 				res, err := New(expectedUUID, invalidName, expectedCode)
 				require.Nil(t, res)
-				require.ErrorIs(t, err, ErrInvalidPrefectureName)
+				require.ErrorIs(t, err, ErrInvalidName)
 			})
 
 			t.Run("文字数が最大値超過の場合", func(t *testing.T) {
 				t.Parallel()
 
-				invalidName := strings.Repeat("字", MaxPrefectureNameLength+1)
+				invalidName := strings.Repeat("字", maxNameLength+1)
 				res, err := New(expectedUUID, invalidName, expectedCode)
 				require.Nil(t, res)
-				require.ErrorIs(t, err, ErrInvalidPrefectureName)
+				require.ErrorIs(t, err, ErrInvalidName)
 			})
 		})
 
@@ -77,7 +77,7 @@ func TestNew(t *testing.T) {
 			t.Run("コードが最小値未満の場合", func(t *testing.T) {
 				t.Parallel()
 
-				invalidCode := MinCode - 1
+				invalidCode := minCode - 1
 				res, err := New(expectedUUID, expectedName, invalidCode)
 				require.Nil(t, res)
 				require.ErrorIs(t, err, ErrInvalidCode)
@@ -86,7 +86,7 @@ func TestNew(t *testing.T) {
 			t.Run("コードが最大値超過の場合", func(t *testing.T) {
 				t.Parallel()
 
-				invalidCode := MaxCode + 1
+				invalidCode := maxCode + 1
 				res, err := New(expectedUUID, expectedName, invalidCode)
 				require.Nil(t, res)
 				require.ErrorIs(t, err, ErrInvalidCode)

--- a/internal/domain/prefecture/prefecture_repository.go
+++ b/internal/domain/prefecture/prefecture_repository.go
@@ -8,10 +8,10 @@ import (
 )
 
 type Repository interface {
-	// FindByID は、IDから都道府県を取得します。
+	// FindByID は、IDから都道府県を取得します。存在しない場合は NotFound を返します。
 	FindByID(ctx context.Context, id uuid.UUID) (*Prefecture, error)
-	// FindByIDs は、複数IDから都道府県一覧を取得します。
+	// FindByIDs は、複数IDから都道府県一覧を取得します。見つからないIDは結果から除外した部分一覧を返します（NotFound は返しません）。
 	FindByIDs(ctx context.Context, ids []uuid.UUID) (Prefectures, error)
-	// FindByName は、都道府県名から都道府県を取得します。
+	// FindByName は、都道府県名から都道府県を取得します。存在しない場合は NotFound を返します。
 	FindByName(ctx context.Context, name string) (*Prefecture, error)
 }

--- a/internal/domain/user/constant.go
+++ b/internal/domain/user/constant.go
@@ -1,16 +1,16 @@
 package user
 
 const (
-	minLength           = 1
-	maxFirstNameLength  = 100
-	maxLastNameLength   = 100
-	maxPasswordLength   = 255
-	maxEmailLength      = 100
-	maxPhoneLength      = 20
-	maxCityLength       = 100
-	maxStreetLength     = 255
-	maxBuildingLength   = 255
-	maxPostalCodeLength = 8
+	minLength             = 1
+	maxFirstNameLength    = 100
+	maxLastNameLength     = 100
+	maxPasswordHashLength = 255
+	maxEmailLength        = 100
+	maxPhoneLength        = 20
+	maxCityLength         = 100
+	maxStreetLength       = 255
+	maxBuildingLength     = 255
+	maxPostalCodeLength   = 8
 
 	MaxRawPasswordLength = 64
 	MinRawPasswordLength = 8

--- a/internal/domain/user/error.go
+++ b/internal/domain/user/error.go
@@ -6,22 +6,23 @@ import (
 )
 
 var (
-	errInvalid               = xerrors.Wrap(apperror.ErrValidation, "invalid user")
-	ErrInvalidID             = xerrors.Wrap(errInvalid, "id failed")
-	ErrInvalidFirstName      = xerrors.Wrap(errInvalid, "first name failed")
-	ErrInvalidLastName       = xerrors.Wrap(errInvalid, "last name failed")
-	ErrInvalidPasswordHash   = xerrors.Wrap(errInvalid, "password hash failed")
-	ErrInvalidEmail          = xerrors.Wrap(errInvalid, "email failed")
-	ErrInvalidPhone          = xerrors.Wrap(errInvalid, "phone failed")
-	ErrInvalidPrefectureID   = xerrors.Wrap(errInvalid, "prefecture id failed")
-	ErrInvalidPrefectureName = xerrors.Wrap(errInvalid, "prefecture name failed")
-	ErrInvalidCity           = xerrors.Wrap(errInvalid, "city failed")
-	ErrInvalidStreet         = xerrors.Wrap(errInvalid, "street failed")
-	ErrInvalidBuilding       = xerrors.Wrap(errInvalid, "building failed")
-	ErrInvalidPostalCode     = xerrors.Wrap(errInvalid, "postal code failed")
-	ErrInvalidUpdatedAt      = xerrors.Wrap(errInvalid, "updated at failed")
-	ErrInvalidDeletedAt      = xerrors.Wrap(errInvalid, "deleted at failed")
+	errInvalid             = xerrors.Wrap(apperror.ErrValidation, "invalid user")
+	ErrInvalidID           = xerrors.Wrap(errInvalid, "id failed")
+	ErrInvalidFirstName    = xerrors.Wrap(errInvalid, "first name failed")
+	ErrInvalidLastName     = xerrors.Wrap(errInvalid, "last name failed")
+	ErrInvalidPasswordHash = xerrors.Wrap(errInvalid, "password hash failed")
+	ErrInvalidEmail        = xerrors.Wrap(errInvalid, "email failed")
+	ErrInvalidPhone        = xerrors.Wrap(errInvalid, "phone failed")
+	ErrInvalidPrefectureID = xerrors.Wrap(errInvalid, "prefecture id failed")
+	ErrInvalidCity         = xerrors.Wrap(errInvalid, "city failed")
+	ErrInvalidStreet       = xerrors.Wrap(errInvalid, "street failed")
+	ErrInvalidBuilding     = xerrors.Wrap(errInvalid, "building failed")
+	ErrInvalidPostalCode   = xerrors.Wrap(errInvalid, "postal code failed")
+	ErrInvalidUpdatedAt    = xerrors.Wrap(errInvalid, "updated at failed")
+	ErrInvalidDeletedAt    = xerrors.Wrap(errInvalid, "deleted at failed")
 
+	// ErrInvalidRawPassword は、RawPassword 値オブジェクト固有の検証エラーです。
+	// User フィールド検証群（errInvalid 系）とは別系統で、errInvalid を経由しません。
 	ErrInvalidRawPassword = xerrors.Wrap(apperror.ErrValidation, "invalid raw password")
 
 	// ErrAlreadyDeleted は、既に論理削除済みのユーザーを再度削除しようとした場合のエラーです。

--- a/internal/domain/user/raw_password.go
+++ b/internal/domain/user/raw_password.go
@@ -11,7 +11,7 @@ type RawPassword struct {
 	value string
 }
 
-// NewRawPassword は、パスワードの検証と生成を行います。
+// NewRawPassword は、与えられた文字列を検証し、有効な場合に RawPassword を構築します。
 func NewRawPassword(v string) (RawPassword, error) {
 	if !stringkit.InRange(v, MinRawPasswordLength, MaxRawPasswordLength) {
 		return RawPassword{}, xerrors.Wrap(
@@ -25,3 +25,9 @@ func NewRawPassword(v string) (RawPassword, error) {
 func (p RawPassword) Value() string {
 	return p.value
 }
+
+// String は、平文パスワードが fmt 経由で露出しないよう秘匿した文字列を返します。
+func (p RawPassword) String() string { return "[REDACTED]" }
+
+// GoString は、%#v 経由でも平文パスワードが露出しないよう秘匿した文字列を返します。
+func (p RawPassword) GoString() string { return "[REDACTED]" }

--- a/internal/domain/user/raw_password_test.go
+++ b/internal/domain/user/raw_password_test.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -43,5 +44,30 @@ func TestNewRawPassword(t *testing.T) {
 			assert.Empty(t, actual)
 			require.ErrorIs(t, err, ErrInvalidRawPassword)
 		})
+	})
+}
+
+func TestRawPassword_Redaction(t *testing.T) {
+	t.Parallel()
+
+	secret := "validPassword123"
+	p, err := NewRawPassword(secret)
+	require.NoError(t, err)
+
+	t.Run("fmt動詞経由で平文が露出せずREDACTEDになる", func(t *testing.T) {
+		t.Parallel()
+
+		// %v / %s / %+v / %#v いずれでも平文を出さない（String / GoString による秘匿）
+		for _, verb := range []string{"%v", "%s", "%+v", "%#v"} {
+			out := fmt.Sprintf(verb, p)
+			assert.NotContains(t, out, secret, verb)
+			assert.Contains(t, out, "[REDACTED]", verb)
+		}
+	})
+
+	t.Run("Valueは平文を返す", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, secret, p.Value())
 	})
 }

--- a/internal/domain/user/user_domain.go
+++ b/internal/domain/user/user_domain.go
@@ -62,12 +62,10 @@ func New(
 		return nil, xerrors.Wrap(ErrInvalidUpdatedAt, "updatedAt must be after or equal to createdAt")
 	}
 
-	if deletedAt != nil && deletedAt.Before(createdAt) {
-		return nil, xerrors.Wrap(ErrInvalidDeletedAt, "deletedAt must be after or equal to createdAt")
-	}
-
-	if deletedAt != nil && deletedAt.Before(updatedAt) {
-		return nil, xerrors.Wrap(ErrInvalidDeletedAt, "deletedAt must be after or equal to updatedAt")
+	if deletedAt != nil {
+		if err := validateDeletedAt(*deletedAt, createdAt, updatedAt); err != nil {
+			return nil, err
+		}
 	}
 
 	return &User{
@@ -138,8 +136,9 @@ func (u *User) FullName() string { return u.firstName + " " + u.lastName }
 func (u *User) UpdateProfile(
 	firstName, lastName, email, phone string,
 	prefectureID uuid.UUID,
-	postalCode, city, street string,
+	city, street string,
 	building *string,
+	postalCode string,
 	updatedAt time.Time,
 ) error {
 	if err := u.ensureNotDeleted(); err != nil {
@@ -188,14 +187,11 @@ func (u *User) MarkAsDeleted(deletedAt time.Time) error {
 	if err := u.ensureNotDeleted(); err != nil {
 		return err
 	}
-	if deletedAt.Before(u.createdAt) {
-		return xerrors.Wrap(ErrInvalidDeletedAt, "deletedAt must be after or equal to createdAt")
-	}
-	if deletedAt.Before(u.updatedAt) {
-		return xerrors.Wrap(ErrInvalidDeletedAt, "deletedAt must be after or equal to updatedAt")
+	if err := validateDeletedAt(deletedAt, u.createdAt, u.updatedAt); err != nil {
+		return err
 	}
 
-	u.deletedAt = ptr.Copy(&deletedAt)
+	u.deletedAt = &deletedAt
 	// 論理削除も更新操作のため、updatedAt を削除時刻（usecase が clock から取得した現在時刻）に追従させる。
 	u.updatedAt = deletedAt
 	return nil
@@ -209,10 +205,24 @@ func (u *User) ensureNotDeleted() error {
 	return nil
 }
 
-// ensureUpdatedAt は、更新日時が createdAt 以降であることを検証します。
+// ensureUpdatedAt は、更新日時が createdAt 以降かつ現在の updatedAt 以降（単調非減少）であることを検証します。
 func (u *User) ensureUpdatedAt(updatedAt time.Time) error {
 	if updatedAt.Before(u.createdAt) {
 		return xerrors.Wrap(ErrInvalidUpdatedAt, "updatedAt must be after or equal to createdAt")
+	}
+	if updatedAt.Before(u.updatedAt) {
+		return xerrors.Wrap(ErrInvalidUpdatedAt, "updatedAt must be after or equal to current updatedAt")
+	}
+	return nil
+}
+
+// validateDeletedAt は、削除日時が createdAt / updatedAt 以降であることを検証します。
+func validateDeletedAt(deletedAt, createdAt, updatedAt time.Time) error {
+	if deletedAt.Before(createdAt) {
+		return xerrors.Wrap(ErrInvalidDeletedAt, "deletedAt must be after or equal to createdAt")
+	}
+	if deletedAt.Before(updatedAt) {
+		return xerrors.Wrap(ErrInvalidDeletedAt, "deletedAt must be after or equal to updatedAt")
 	}
 	return nil
 }
@@ -259,7 +269,7 @@ func validateProfileFields(
 
 // validatePasswordHash は、パスワードハッシュの不変条件を検証します。
 func validatePasswordHash(passwordHash string) error {
-	if ok, msg := stringkit.ValidateInRange(passwordHash, minLength, maxPasswordLength); !ok {
+	if ok, msg := stringkit.ValidateInRange(passwordHash, minLength, maxPasswordHashLength); !ok {
 		return xerrors.Wrap(ErrInvalidPasswordHash, msg)
 	}
 	return nil

--- a/internal/domain/user/user_domain_test.go
+++ b/internal/domain/user/user_domain_test.go
@@ -225,7 +225,7 @@ func TestNew(t *testing.T) {
 					id,
 					firstName,
 					lastName,
-					strings.Repeat("a", maxPasswordLength+1),
+					strings.Repeat("a", maxPasswordHashLength+1),
 					email,
 					phone,
 					prefectureID,
@@ -925,6 +925,21 @@ func newValidUser(t *testing.T) (*User, time.Time) {
 	return u, base
 }
 
+// newUserWithUpdatedAt は、createdAt=base・updatedAt=base+offset のユーザーを生成します（単調性検証用）。
+func newUserWithUpdatedAt(t *testing.T, offset time.Duration) (*User, time.Time) {
+	t.Helper()
+	base := time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC)
+	u, err := New(
+		uuid.NewTestFromSalt(t, "user"),
+		"John", "Doe", "hashed_password", "john@example.com", "1234567890",
+		uuid.NewTestFromSalt(t, "prefecture"),
+		"Shibuya", "1-2-3", ptr.To("Building A"), "150-0001",
+		base, base.Add(offset), nil,
+	)
+	require.NoError(t, err)
+	return u, base
+}
+
 func TestUser_UpdateProfile(t *testing.T) {
 	t.Parallel()
 
@@ -936,7 +951,7 @@ func TestUser_UpdateProfile(t *testing.T) {
 		newUpdatedAt := base.Add(time.Hour)
 
 		err := u.UpdateProfile("Jane", "Smith", "jane@example.com", "0987654321",
-			newPrefID, "200-0002", "Minato", "4-5-6", ptr.To("Tower"), newUpdatedAt)
+			newPrefID, "Minato", "4-5-6", ptr.To("Tower"), "200-0002", newUpdatedAt)
 		require.NoError(t, err)
 
 		assert.Equal(t, "Jane", u.firstName)
@@ -952,7 +967,7 @@ func TestUser_UpdateProfile(t *testing.T) {
 		u, base := newValidUser(t)
 
 		err := u.UpdateProfile("", "Smith", "jane@example.com", "0987654321",
-			newPrefID, "200-0002", "Minato", "4-5-6", nil, base.Add(time.Hour))
+			newPrefID, "Minato", "4-5-6", nil, "200-0002", base.Add(time.Hour))
 		require.ErrorIs(t, err, ErrInvalidFirstName)
 	})
 
@@ -961,7 +976,17 @@ func TestUser_UpdateProfile(t *testing.T) {
 		u, base := newValidUser(t)
 
 		err := u.UpdateProfile("Jane", "Smith", "jane@example.com", "0987654321",
-			newPrefID, "200-0002", "Minato", "4-5-6", nil, base.Add(-time.Hour))
+			newPrefID, "Minato", "4-5-6", nil, "200-0002", base.Add(-time.Hour))
+		require.ErrorIs(t, err, ErrInvalidUpdatedAt)
+	})
+
+	t.Run("異常系_updatedAtが現在のupdatedAtより前の場合_エラーを返す", func(t *testing.T) {
+		t.Parallel()
+		u, base := newUserWithUpdatedAt(t, 2*time.Hour)
+
+		// createdAt 以降だが現在の updatedAt(base+2h) より前の時刻は単調性違反で拒否される
+		err := u.UpdateProfile("Jane", "Smith", "jane@example.com", "0987654321",
+			newPrefID, "Minato", "4-5-6", nil, "200-0002", base.Add(time.Hour))
 		require.ErrorIs(t, err, ErrInvalidUpdatedAt)
 	})
 
@@ -971,7 +996,7 @@ func TestUser_UpdateProfile(t *testing.T) {
 		require.NoError(t, u.MarkAsDeleted(base.Add(time.Hour)))
 
 		err := u.UpdateProfile("Jane", "Smith", "jane@example.com", "0987654321",
-			newPrefID, "200-0002", "Minato", "4-5-6", nil, base.Add(2*time.Hour))
+			newPrefID, "Minato", "4-5-6", nil, "200-0002", base.Add(2*time.Hour))
 		require.ErrorIs(t, err, ErrAlreadyDeleted)
 	})
 }
@@ -1003,6 +1028,15 @@ func TestUser_ChangePassword(t *testing.T) {
 		u, base := newValidUser(t)
 
 		err := u.ChangePassword("new_hashed_password", base.Add(-time.Hour))
+		require.ErrorIs(t, err, ErrInvalidUpdatedAt)
+	})
+
+	t.Run("異常系_updatedAtが現在のupdatedAtより前の場合_エラーを返す", func(t *testing.T) {
+		t.Parallel()
+		u, base := newUserWithUpdatedAt(t, 2*time.Hour)
+
+		// createdAt 以降だが現在の updatedAt(base+2h) より前の時刻は単調性違反で拒否される
+		err := u.ChangePassword("new_hashed_password", base.Add(time.Hour))
 		require.ErrorIs(t, err, ErrInvalidUpdatedAt)
 	})
 

--- a/internal/domain/user/user_repository.go
+++ b/internal/domain/user/user_repository.go
@@ -8,14 +8,17 @@ import (
 )
 
 type Repository interface {
-	// FindByActive は、アクティブ状態に基づいてユーザーの情報ページング付きで取得します。
+	// FindByActive は、ユーザーの情報を、ページング付きで取得します。
+	// active=nil で全件（削除済み含む）、true でアクティブのみ、false で削除済みのみを対象とします。
 	FindByActive(ctx context.Context, active *bool, limit, offset int32) (Users, error)
 	// FindByID は、IDから単一ユーザーを取得します。存在しない場合は NotFound を返します。
 	FindByID(ctx context.Context, id uuid.UUID) (*User, error)
 	// Create は、ユーザーを作成します。
 	Create(ctx context.Context, user *User) error
 	// Update は、ユーザーの mutable フィールドと updatedAt / deletedAt を更新します。
+	// 更新対象が存在しない場合は NotFound を返します。
 	Update(ctx context.Context, user *User) error
-	// CountByActive は、アクティブ状態に基づいてユーザーの総件数を返します。
+	// CountByActive は、ユーザーの総件数を返します。
+	// active=nil で全件（削除済み含む）、true でアクティブのみ、false で削除済みのみを対象とします。
 	CountByActive(ctx context.Context, active *bool) (int64, error)
 }

--- a/internal/infrastructure/rdb/repository/user/user_repository_detail_test.go
+++ b/internal/infrastructure/rdb/repository/user/user_repository_detail_test.go
@@ -69,7 +69,7 @@ func Test_repository_Update(t *testing.T) {
 			require.NoError(t, err)
 
 			err = u.UpdateProfile("UpdatedFirst", u.LastName(), u.Email(), u.Phone(),
-				u.PrefectureID(), u.PostalCode(), u.City(), u.Street(), u.Building(), time.Now())
+				u.PrefectureID(), u.City(), u.Street(), u.Building(), u.PostalCode(), time.Now())
 			require.NoError(t, err)
 			require.NoError(t, repo.Update(ctx, u))
 
@@ -101,7 +101,7 @@ func Test_repository_Update(t *testing.T) {
 
 			// 別ユーザーのメールアドレスへ更新 → unique 制約違反
 			err = target.UpdateProfile(target.FirstName(), target.LastName(), other.Email(), target.Phone(),
-				target.PrefectureID(), target.PostalCode(), target.City(), target.Street(), target.Building(), time.Now())
+				target.PrefectureID(), target.City(), target.Street(), target.Building(), target.PostalCode(), time.Now())
 			require.NoError(t, err)
 
 			err = repo.Update(ctx, target)

--- a/internal/usecase/user/user_usecase.go
+++ b/internal/usecase/user/user_usecase.go
@@ -260,10 +260,10 @@ func (u *usecase) UpdateUser(ctx context.Context, id uuid.UUID, dto *MutableFiel
 			dto.Email,
 			dto.Phone,
 			pftDomain.ID(),
-			dto.PostalCode,
 			dto.City,
 			dto.Street,
 			dto.Building,
+			dto.PostalCode,
 			now,
 		); err != nil {
 			return err
@@ -365,10 +365,10 @@ func (u *usecase) UpdateUserPartially(ctx context.Context, id uuid.UUID, dto *Pa
 			ptr.Deref(dto.Email, userEntity.Email()),
 			ptr.Deref(dto.Phone, userEntity.Phone()),
 			prefectureID,
-			ptr.Deref(dto.PostalCode, userEntity.PostalCode()),
 			ptr.Deref(dto.City, userEntity.City()),
 			ptr.Deref(dto.Street, userEntity.Street()),
 			building,
+			ptr.Deref(dto.PostalCode, userEntity.PostalCode()),
 			now,
 		); err != nil {
 			return err


### PR DESCRIPTION
# 概要

full-verify が検出した domain 層（internal/domain/**）のレビュー指摘 全14件を重大度順に適用しました（保留 0、mock は生成物のため対象外）。命名・可視性の是正、検証ロジックの整理、層境界の契約コメント明記が主で、公開 API への影響は UpdateProfile の引数順統一に限られます。

## 変更内容

**prefecture (c08dc15)**
- `ErrInvalidPrefectureName` → `ErrInvalidName` 改名（パッケージ名との stutter 解消）
- 検証定数4件（min/maxNameLength・min/maxCode）を非公開化
- Repository に NotFound 契約・FindByIDs の部分一覧挙動をコメント明記

**user 検証ロジック (5681c40)**
- High: `UpdateProfile` の住所系引数順を `New`/`validateProfileFields`（city,street,building,postalCode）へ統一し取り違え footgun を解消（usecase 2箇所・テスト追従）
- `validateDeletedAt` 抽出で New/MarkAsDeleted の重複を解消
- `ensureUpdatedAt` に updatedAt 単調非減少の検証を追加し MarkAsDeleted と対称化（挙動変更・回帰テスト付与）
- `maxPasswordLength` → `maxPasswordHashLength` 改名、`ptr.Copy(&deletedAt)` 簡略化

**user 命名・契約 (e2fe3d2)**
- デッドコード `ErrInvalidPrefectureName` 削除
- `RawPassword` に `String()`/`GoString()` を実装し fmt 経由の平文露出を遮断（回帰テスト付与）
- Repository の `active *bool` 3状態（nil=全件/true=アクティブ/false=削除済み）・Update の NotFound 契約を明記、脱字・godoc 是正

## 動作確認方法

1. `make test`（domain / usecase 緑）
2. `make lint`（0 issues）
3. 単調性・秘匿は退行注入で FAIL する回帰テストにて実効性を確認済み