### PR TITLE
Refactor: apperror sentinel コメントの HTTP ステータス束縛を解消

### DIFF
--- a/internal/apperror/apperror.go
+++ b/internal/apperror/apperror.go
@@ -4,24 +4,24 @@ package apperror
 import "go-boilerplate/pkg/xerrors"
 
 var (
-	// 引数が無効な場合に使用します。400 Bad Request に対応します。
+	// 引数が無効な場合に使用します。
 	ErrInvalidArgument = xerrors.New("invalid argument")
-	// 認証に失敗した場合に使用します。401 Unauthorized に対応します。
+	// 認証に失敗した場合に使用します。
 	ErrUnauthenticated = xerrors.New("unauthenticated")
-	// 権限がない場合に使用します。403 Forbidden に対応します。
+	// 権限がない場合に使用します。
 	ErrPermissionDenied = xerrors.New("permission denied")
-	// 対象が見つからない場合に使用します。404 Not Found に対応します。
+	// 対象が見つからない場合に使用します。
 	ErrNotFound = xerrors.New("not found")
-	// 競合が発生した場合に使用します。409 Conflict に対応します。
+	// 競合が発生した場合に使用します。
 	ErrConflict = xerrors.New("conflict")
-	// 検証が失敗した場合に使用します。422 Unprocessable Entity に対応します。
+	// 検証が失敗した場合に使用します。
 	ErrValidation = xerrors.New("validation error")
-	// リクエストが多すぎる場合に使用します。429 Too Many Requests に対応します。
+	// リクエストが多すぎる場合に使用します。
 	ErrTooManyRequests = xerrors.New("too many requests")
-	// サーバ内部で予期しないエラーが発生した場合に使用します。500 Internal Server Error に対応します。
+	// サーバ内部で予期しないエラーが発生した場合に使用します。
 	ErrInternal = xerrors.New("internal error")
-	// 実装されていない操作が呼び出された場合に使用します。501 Not Implemented に対応します。
+	// 実装されていない操作が呼び出された場合に使用します。
 	ErrUnimplemented = xerrors.New("unimplemented")
-	// 一時的に利用できない状態を示します（リトライで解消される可能性がある場合）。503 Service Unavailable に対応します。
+	// 一時的に利用できない状態を示します（リトライで解消される可能性がある場合）。
 	ErrUnavailable = xerrors.New("service unavailable")
 )


### PR DESCRIPTION
# 概要

`internal/apperror/apperror.go` の各 sentinel エラー変数のコメントが、特定の HTTP ステータス（「400 Bad Request に対応します」等）へ 1:1 で束縛していた点を解消します。

`apperror` はパッケージ doc / README で「HTTP を知らない（プロトコル非依存）」と宣言していますが、コメントが HTTP マッピングを埋め込んでおり自己矛盾していました。さらに同じマッピングが apperror のコメント／README の Mapping Table／`controller/error/response/http_error.go` の `lookupErrorMetaByAppError` の 3 箇所に重複していました。

full-verify レビューの Low 指摘（apperror 単独 mod）への対応です。

## 変更内容

- 10 個の sentinel コメントから HTTP ステータス語を除去し、プロトコル非依存な意味のみを記述
- HTTP との対応は Controller 層の `lookupErrorMetaByAppError`（switch）を正準とする方針を維持（コメントへの参照誘導は追加せず、コメント最小方針に準拠）
- エラー値・挙動の変更なし（コメントのみ）

## 動作確認方法

1. `make lint` → 0 issues
2. `go build ./internal/apperror/...` / `go vet ./internal/apperror/...` 緑
3. 挙動不変のため既存テストへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)