### PR TITLE
Refactor: CI ワークフロー群の full-verify 指摘対応（High〜Low 全帯）

### DIFF
--- a/.github/actions/setup-postgres/action.yaml
+++ b/.github/actions/setup-postgres/action.yaml
@@ -89,6 +89,8 @@ runs:
         MAX_ATTEMPTS: ${{ inputs.max_attempts }}
         SLEEP_SECONDS: ${{ inputs.sleep_seconds }}
       run: |
+        command -v pg_isready >/dev/null 2>&1 && command -v psql >/dev/null 2>&1 \
+          || { echo "psql client not found; set install_psql=true"; exit 1; }
         echo "Waiting for Postgres... host=${HOST} port=${PORT} db=${DB}"
         for i in $(seq 1 "${MAX_ATTEMPTS}"); do
           if pg_isready -h "${HOST}" -p "${PORT}" -U "${PGUSER}" -d "${DB}"; then

--- a/.github/actions/setup-postgres/action.yaml
+++ b/.github/actions/setup-postgres/action.yaml
@@ -84,8 +84,8 @@ runs:
         MAX_ATTEMPTS: ${{ inputs.max_attempts }}
         SLEEP_SECONDS: ${{ inputs.sleep_seconds }}
       run: |
-        command -v pg_isready >/dev/null 2>&1 && command -v psql >/dev/null 2>&1 \
-          || { echo "psql client not found; set install_psql=true"; exit 1; }
+        command -v pg_isready >/dev/null 2>&1 \
+          || { echo "pg_isready not found; set install_psql=true"; exit 1; }
         echo "Waiting for Postgres... host=${HOST} port=${PORT} db=${DB}"
         for i in $(seq 1 "${MAX_ATTEMPTS}"); do
           if pg_isready -h "${HOST}" -p "${PORT}" -U "${PGUSER}" -d "${DB}"; then
@@ -108,6 +108,8 @@ runs:
         DB: ${{ inputs.db }}
         INIT_SQL: ${{ inputs.init_sql }}
       run: |
+        command -v psql >/dev/null 2>&1 \
+          || { echo "psql not found; set install_psql=true"; exit 1; }
         test -f "${INIT_SQL}" || { echo "init_sql not found: ${INIT_SQL}"; exit 1; }
         psql -h "${HOST}" -p "${PORT}" -U "${PGUSER}" -d "${DB}" \
           -v ON_ERROR_STOP=1 \

--- a/.github/actions/setup-postgres/action.yaml
+++ b/.github/actions/setup-postgres/action.yaml
@@ -7,23 +7,23 @@ inputs:
     required: false
     default: "18"
   host:
-    required: false
     description: Postgres host address
+    required: false
     default: localhost
   port:
-    required: false
     description: Postgres port
+    required: false
     default: "5432"
   user:
-    required: false
     description: Postgres user
+    required: false
     default: postgres
   db:
-    required: true
     description: Postgres database name
-  password:
     required: true
+  password:
     description: Postgres password
+    required: true
   init_sql:
     required: false
     description: Path to SQL file to initialize the database
@@ -66,16 +66,11 @@ runs:
         sudo apt-get install -y "postgresql-client-${PG_VERSION}"
         echo "/usr/lib/postgresql/${PG_VERSION}/bin" >> "$GITHUB_PATH"
 
-    - name: Postgres Client Version
+    - name: Print client versions
       if: ${{ inputs.install_psql == 'true' }}
       shell: bash
       run: |
         psql --version
-
-    - name: PG_DUMP Version
-      if: ${{ inputs.install_psql == 'true' }}
-      shell: bash
-      run: |
         pg_dump --version
 
     - name: Wait for database
@@ -97,7 +92,7 @@ runs:
             echo "Postgres is ready."
             exit 0
           fi
-          sleep "${SLEEP_SECONDS}"
+          [ "$i" -lt "${MAX_ATTEMPTS}" ] && sleep "${SLEEP_SECONDS}"
         done
         echo "Postgres did not become ready in time."
         exit 1

--- a/.github/actions/setup-postgres/action.yaml
+++ b/.github/actions/setup-postgres/action.yaml
@@ -60,9 +60,11 @@ runs:
     - name: Install psql client(${{ inputs.pg_version }})
       if: ${{ inputs.install_psql == 'true' }}
       shell: bash
+      env:
+        PG_VERSION: ${{ inputs.pg_version }}
       run: |
-        sudo apt-get install -y postgresql-client-${{ inputs.pg_version }}
-        echo "/usr/lib/postgresql/${{ inputs.pg_version }}/bin" >> "$GITHUB_PATH"
+        sudo apt-get install -y "postgresql-client-${PG_VERSION}"
+        echo "/usr/lib/postgresql/${PG_VERSION}/bin" >> "$GITHUB_PATH"
 
     - name: Postgres Client Version
       if: ${{ inputs.install_psql == 'true' }}
@@ -80,14 +82,20 @@ runs:
       shell: bash
       env:
         PGPASSWORD: ${{ inputs.password }}
+        HOST: ${{ inputs.host }}
+        PORT: ${{ inputs.port }}
+        PGUSER: ${{ inputs.user }}
+        DB: ${{ inputs.db }}
+        MAX_ATTEMPTS: ${{ inputs.max_attempts }}
+        SLEEP_SECONDS: ${{ inputs.sleep_seconds }}
       run: |
-        echo "Waiting for Postgres... host=${{ inputs.host }} port=${{ inputs.port }} db=${{ inputs.db }}"
-        for i in $(seq 1 ${{ inputs.max_attempts }}); do
-          if pg_isready -h "${{ inputs.host }}" -p "${{ inputs.port }}" -U "${{ inputs.user }}" -d "${{ inputs.db }}"; then
+        echo "Waiting for Postgres... host=${HOST} port=${PORT} db=${DB}"
+        for i in $(seq 1 "${MAX_ATTEMPTS}"); do
+          if pg_isready -h "${HOST}" -p "${PORT}" -U "${PGUSER}" -d "${DB}"; then
             echo "Postgres is ready."
             exit 0
           fi
-          sleep "${{ inputs.sleep_seconds }}"
+          sleep "${SLEEP_SECONDS}"
         done
         echo "Postgres did not become ready in time."
         exit 1
@@ -97,8 +105,13 @@ runs:
       shell: bash
       env:
         PGPASSWORD: ${{ inputs.password }}
+        HOST: ${{ inputs.host }}
+        PORT: ${{ inputs.port }}
+        PGUSER: ${{ inputs.user }}
+        DB: ${{ inputs.db }}
+        INIT_SQL: ${{ inputs.init_sql }}
       run: |
-        test -f "${{ inputs.init_sql }}" || (echo "init_sql not found: ${{ inputs.init_sql }}" && exit 1)
-        psql -h "${{ inputs.host }}" -p "${{ inputs.port }}" -U "${{ inputs.user }}" -d "${{ inputs.db }}" \
+        test -f "${INIT_SQL}" || { echo "init_sql not found: ${INIT_SQL}"; exit 1; }
+        psql -h "${HOST}" -p "${PORT}" -U "${PGUSER}" -d "${DB}" \
           -v ON_ERROR_STOP=1 \
-          -f "${{ inputs.init_sql }}"
+          -f "${INIT_SQL}"

--- a/.github/actions/upsert-pr-comment/action.yaml
+++ b/.github/actions/upsert-pr-comment/action.yaml
@@ -90,7 +90,7 @@ runs:
           parts.push(main, '', commitLine, '', updatedLine);
           const body = parts.join('\n');
 
-          const { data: comments } = await github.rest.issues.listComments({
+          const comments = await github.paginate(github.rest.issues.listComments, {
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: pr,

--- a/.github/actions/upsert-pr-comment/action.yaml
+++ b/.github/actions/upsert-pr-comment/action.yaml
@@ -1,0 +1,116 @@
+name: Upsert PR comment
+description: マーカーで既存コメントを検出し update / create する（PR コメントの upsert）
+
+inputs:
+  github-token:
+    required: true
+    description: コメント投稿に使う GITHUB_TOKEN
+  marker:
+    required: true
+    description: 同一コメント検出用の HTML コメントマーカー
+  body-file:
+    required: true
+    description: 本文として読み込むファイルパス
+  title:
+    required: false
+    default: ""
+    description: 本文先頭へ付与する見出し（任意）
+  details-summary:
+    required: false
+    default: ""
+    description: 指定時は本文をコードブロック付き details で畳む際の summary 文言
+  max-length:
+    required: false
+    default: "45000"
+    description: 本文の最大文字数（超過分は truncate）
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/github-script@v8
+      env:
+        MARKER: ${{ inputs.marker }}
+        BODY_FILE: ${{ inputs.body-file }}
+        TITLE: ${{ inputs.title }}
+        DETAILS_SUMMARY: ${{ inputs.details-summary }}
+        MAX_LENGTH: ${{ inputs.max-length }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const fs = require('fs');
+
+          const marker = process.env.MARKER;
+          const bodyFile = process.env.BODY_FILE;
+          const title = process.env.TITLE || '';
+          const detailsSummary = process.env.DETAILS_SUMMARY || '';
+          const maxLength = Number(process.env.MAX_LENGTH || '45000');
+
+          const pr = context.payload.pull_request?.number;
+          if (!pr) {
+            core.setFailed('Not a PR context');
+            return;
+          }
+          if (!fs.existsSync(bodyFile)) {
+            core.setFailed(`${bodyFile} not found`);
+            return;
+          }
+
+          let content = fs.readFileSync(bodyFile, 'utf8').trimEnd();
+          if (content.length > maxLength) {
+            content = content.slice(0, maxLength) + '\n... (truncated)';
+          }
+
+          const updatedAtJST = new Date().toLocaleString('ja-JP', {
+            timeZone: 'Asia/Tokyo',
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+          });
+
+          const headSha =
+            (context.payload.pull_request?.head?.sha)
+            || process.env.GITHUB_SHA
+            || context.sha;
+          const shortSha = headSha.slice(0, 7);
+
+          const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
+          const commitUrl = `${repoUrl}/commit/${headSha}`;
+          const commitLine = `🔖 Commit: [\`${shortSha}\`](${commitUrl})`;
+          const updatedLine = `🕒 UpdatedAt: ${updatedAtJST} (JST)`;
+
+          const main = detailsSummary
+            ? [`<details><summary>${detailsSummary}</summary>`, '', '```', content, '```', '', '</details>'].join('\n')
+            : content;
+
+          const parts = [marker];
+          if (title) parts.push(title, '');
+          parts.push(main, '', commitLine, '', updatedLine);
+          const body = parts.join('\n');
+
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr,
+            per_page: 100,
+          });
+
+          const existing = comments.find(c => (c.body || '').includes(marker));
+
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body,
+            });
+          }

--- a/.github/workflows/app-di-startup-check.yaml
+++ b/.github/workflows/app-di-startup-check.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/app-di-startup-check.yaml'
-      - 'cmd/server/**.go'
+      - 'cmd/**.go'
       - 'internal/**.go'
       - 'go.mod'
       - 'go.sum'
@@ -51,10 +51,13 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # コンパイルと実行を分離し、ビルド失敗を即時に顕在化させる
+      - name: Build server
+        run: go build -o ./bin/server ./cmd/
+
       - name: Start server
         run: |
-          # 例: cobra で `serve` コマンドがある前提
-          go run ./cmd/ serve &
+          ./bin/server serve > server.log 2>&1 &
           echo $! > server.pid
 
       - name: Wait for /ready endpoint
@@ -71,8 +74,8 @@ jobs:
           done
 
           echo "Readiness check failed"
-          echo "Server logs (if any):"
-          # fx を zap で標準出力に出していればログがここに出る
+          echo "Server logs:"
+          cat server.log || true
           exit 1
 
       - name: Stop server

--- a/.github/workflows/app-di-startup-check.yaml
+++ b/.github/workflows/app-di-startup-check.yaml
@@ -51,7 +51,6 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      # コンパイルと実行を分離し、ビルド失敗を即時に顕在化させる
       - name: Build server
         run: go build -o ./bin/server ./cmd/
 

--- a/.github/workflows/app-di-startup-check.yaml
+++ b/.github/workflows/app-di-startup-check.yaml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   app-boot-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     env:

--- a/.github/workflows/auto-generate-docs.yaml
+++ b/.github/workflows/auto-generate-docs.yaml
@@ -96,9 +96,10 @@ jobs:
           BEFORE_SHA: ${{ github.event.before }}
           AFTER_SHA: ${{ github.sha }}
         run: |
+          git add -A
           # ノイズ（カバレッジカウントの揺れ / SchemaSpy 生成日時）を除外して、
           # 意味のある生成物に差分があるかをまず判定する。
-          if ! git diff --quiet -- . \
+          if ! git diff --cached --quiet -- . \
             ':(exclude)docs/coverage/index.html' \
             ':(exclude)docs/db-schema/index.html' \
             ':(exclude)docs/db-schema/info-html.txt'
@@ -109,7 +110,7 @@ jobs:
 
           # 上記が無差分でも、coverage に差があり、かつ今回の push に .go の変更が含まれていれば
           # 意味のあるカバレッジ更新とみなして PR を作成する。
-          if ! git diff --quiet -- docs/coverage/index.html; then
+          if ! git diff --cached --quiet -- docs/coverage/index.html; then
             if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
               # 新規ブランチ作成等で前回 tip が取得できない場合は安全側で trigger する。
               echo "has_diff=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -28,7 +28,6 @@ jobs:
       - name: Fetch & Checkout repository
         uses: actions/checkout@v6
         with:
-          # git describe --tags でリリースバージョンを採るためタグと全履歴を取得
           fetch-depth: 0
 
       - name: Setup Go

--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -7,10 +7,6 @@ on:
       - staging
       - develop
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   packages: write
@@ -23,6 +19,16 @@ jobs:
       deployments: write
       packages: write
       id-token: write
+    concurrency:
+      group: ${{ github.workflow }}-build-${{ github.ref }}-${{ matrix.target }}
+      cancel-in-progress: true
+    strategy:
+      matrix:
+        include:
+          - target: runtime
+            suffix: ""
+          - target: migration
+            suffix: "-migration"
 
     steps:
       - name: Fetch & Checkout repository
@@ -42,28 +48,10 @@ jobs:
           VERSION=$(git describe --tags --abbrev=0 --first-parent 2>/dev/null || echo "none")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Get revision (commit SHA)
-        id: meta_revision
-        run: |
-          echo "revision=${GITHUB_SHA}" >> $GITHUB_OUTPUT
-
       - name: Get build date
         id: meta_date
         run: |
           echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
-
-      - name: Generate image tags
-        id: meta_tags
-        run: |
-          VERSION="${{ steps.meta_version.outputs.version }}"
-          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
-          if [[ "$VERSION" == "none" ]]; then
-            IMAGE_TAG=$SHORT_SHA
-          else
-            IMAGE_TAG=${VERSION}-${SHORT_SHA}
-          fi
-          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
-          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Define registry
         id: meta_registry
@@ -71,6 +59,24 @@ jobs:
           echo "Note: Please modify this section according to your environment"
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           echo "registry=ghcr.io/$OWNER" >> $GITHUB_OUTPUT
+
+      - name: Generate image tags
+        id: meta_tags
+        env:
+          VERSION: ${{ steps.meta_version.outputs.version }}
+          REGISTRY: ${{ steps.meta_registry.outputs.registry }}
+          SUFFIX: ${{ matrix.suffix }}
+        run: |
+          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          {
+            echo "tags<<EOF"
+            echo "${REGISTRY}/app:${SHORT_SHA}${SUFFIX}"
+            if [[ "$VERSION" != "none" ]]; then
+              echo "${REGISTRY}/app:${VERSION}-${SHORT_SHA}${SUFFIX}"
+              echo "${REGISTRY}/app:${VERSION}${SUFFIX}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -85,48 +91,21 @@ jobs:
         run: |
           go mod vendor
 
-      - name: Build and push Runtime image
+      - name: Build and push image (${{ matrix.target }})
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/server/Dockerfile
-          target: runtime
+          target: ${{ matrix.target }}
           push: true
-          tags: |
-            ${{ steps.meta_registry.outputs.registry }}/app:${{ steps.meta_tags.outputs.short_sha }}
-            ${{ steps.meta_registry.outputs.registry }}/app:${{ steps.meta_tags.outputs.image_tag }}
-            ${{ steps.meta_registry.outputs.registry }}/app:${{ steps.meta_version.outputs.version }}
+          tags: ${{ steps.meta_tags.outputs.tags }}
           build-args: |
             VERSION=${{ steps.meta_version.outputs.version }}
-            REVISION=${{ steps.meta_revision.outputs.revision }}
+            REVISION=${{ github.sha }}
             BUILD_DATE=${{ steps.meta_date.outputs.build_date }}
           labels: |
             org.opencontainers.image.version=${{ steps.meta_version.outputs.version }}
-            org.opencontainers.image.revision=${{ steps.meta_revision.outputs.revision }}
-            org.opencontainers.image.created=${{ steps.meta_date.outputs.build_date }}
-            org.opencontainers.image.source=${{ github.repository }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: false
-
-      - name: Build and push Migration image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/server/Dockerfile
-          target: migration
-          push: true
-          tags: |
-            ${{ steps.meta_registry.outputs.registry }}/app:${{ steps.meta_tags.outputs.short_sha }}-migration
-            ${{ steps.meta_registry.outputs.registry }}/app:${{ steps.meta_tags.outputs.image_tag }}-migration
-            ${{ steps.meta_registry.outputs.registry }}/app:${{ steps.meta_version.outputs.version }}-migration
-          build-args: |
-            VERSION=${{ steps.meta_version.outputs.version }}
-            REVISION=${{ steps.meta_revision.outputs.revision }}
-            BUILD_DATE=${{ steps.meta_date.outputs.build_date }}
-          labels: |
-            org.opencontainers.image.version=${{ steps.meta_version.outputs.version }}
-            org.opencontainers.image.revision=${{ steps.meta_revision.outputs.revision }}
+            org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.meta_date.outputs.build_date }}
             org.opencontainers.image.source=${{ github.repository }}
           cache-from: type=gha
@@ -137,6 +116,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name }}
+    concurrency:
+      group: ${{ github.workflow }}-deploy-${{ github.ref }}
+      cancel-in-progress: false
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -68,14 +68,15 @@ jobs:
           SUFFIX: ${{ matrix.suffix }}
         run: |
           SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          DELIM="EOF_$(openssl rand -hex 8)"
           {
-            echo "tags<<EOF"
+            echo "tags<<${DELIM}"
             echo "${REGISTRY}/app:${SHORT_SHA}${SUFFIX}"
             if [[ "$VERSION" != "none" ]]; then
               echo "${REGISTRY}/app:${VERSION}-${SHORT_SHA}${SUFFIX}"
               echo "${REGISTRY}/app:${VERSION}${SUFFIX}"
             fi
-            echo "EOF"
+            echo "${DELIM}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
@@ -108,8 +109,8 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.meta_date.outputs.build_date }}
             org.opencontainers.image.source=${{ github.repository }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target }}
           provenance: false
 
   deploy:

--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -84,7 +84,6 @@ jobs:
 
       - name: Generate vendor
         run: |
-          go mod tidy
           go mod vendor
 
       - name: Build and push Runtime image

--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -27,6 +27,9 @@ jobs:
     steps:
       - name: Fetch & Checkout repository
         uses: actions/checkout@v6
+        with:
+          # git describe --tags でリリースバージョンを採るためタグと全履歴を取得
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v6

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -32,6 +32,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -15,6 +15,11 @@ permissions:
   pages: write
   id-token: write
 
+# Pages デプロイは追い越し防止のため直列化（公式テンプレート準拠・キャンセルしない）
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build:
 

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -15,7 +15,6 @@ permissions:
   pages: write
   id-token: write
 
-# Pages デプロイは追い越し防止のため直列化（公式テンプレート準拠・キャンセルしない）
 concurrency:
   group: "pages"
   cancel-in-progress: false

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -6,8 +6,6 @@ on:
       - production
     paths:
       - "docs/**"
-      - "scripts/gen-docs-json.cjs"
-      - "scripts/gen-portal-docs.cjs"
       - ".github/workflows/deploy-docs.yaml"
 
 permissions:

--- a/.github/workflows/gen-db-artifacts-check.yaml
+++ b/.github/workflows/gen-db-artifacts-check.yaml
@@ -86,7 +86,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # 未追跡（新規生成）ファイルも検知するため index に取り込んでから差分を取る
           git add -A
           files="$(git diff --cached --name-only)"
           if [ -n "$files" ]; then

--- a/.github/workflows/gen-db-artifacts-check.yaml
+++ b/.github/workflows/gen-db-artifacts-check.yaml
@@ -114,6 +114,7 @@ jobs:
           fi
       - name: Comment changed files on PR
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gen-db-artifacts-check.yaml
+++ b/.github/workflows/gen-db-artifacts-check.yaml
@@ -189,7 +189,7 @@ jobs:
                 ].join('\n');
 
             // 既存コメントがあれば更新（スパム防止）
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,

--- a/.github/workflows/gen-db-artifacts-check.yaml
+++ b/.github/workflows/gen-db-artifacts-check.yaml
@@ -5,7 +5,7 @@ on:
     paths:
       - '.github/workflows/gen-db-artifacts-check.yaml'
       - 'database/**/*.sql'
-      - 'docker/db/**/*.sql'
+      - 'docker/database/**/*.sql'
       - '.makefiles/**/*.mk'
   workflow_dispatch:
 
@@ -86,7 +86,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          files="$(git diff --name-only)"
+          # 未追跡（新規生成）ファイルも検知するため index に取り込んでから差分を取る
+          git add -A
+          files="$(git diff --cached --name-only)"
           if [ -n "$files" ]; then
             echo "has_diff=true" >> "$GITHUB_OUTPUT"
             printf "%s\n" "$files" > /tmp/changed_files.txt
@@ -94,7 +96,7 @@ jobs:
             echo "has_diff=false" >> "$GITHUB_OUTPUT"
             : > /tmp/changed_files.txt
           fi
-      # PR の source（database/**/*.sql / docker/db/**/*.sql）が触られているかを判定。
+      # PR の source（database/**/*.sql / docker/database/**/*.sql）が触られているかを判定。
       # 触られていない場合は generator 側（sqlc）のドリフトの可能性が高い。
       - name: Detect source modifications in this PR
         id: source_mod
@@ -106,7 +108,7 @@ jobs:
           head_sha="${{ github.event.pull_request.head.sha }}"
           git fetch --no-tags --depth=200 origin "${{ github.event.pull_request.base.ref }}" || true
           changed="$(git diff --name-only "$base_sha" "$head_sha" || true)"
-          if echo "$changed" | grep -qE '^(database|docker/db)/.*\.sql$'; then
+          if echo "$changed" | grep -qE '^(database|docker/database)/.*\.sql$'; then
             echo "source_modified=true" >> "$GITHUB_OUTPUT"
           else
             echo "source_modified=false" >> "$GITHUB_OUTPUT"
@@ -158,7 +160,7 @@ jobs:
 
             const diffTitle = sourceModified
               ? '## 🧾 Differences in database output have been detected (list of modified files)'
-              : '## ⚠️ DB 生成物のドリフトを検知（本 PR で `database/` / `docker/db/` 配下の `.sql` は触られていません）';
+              : '## ⚠️ DB 生成物のドリフトを検知（本 PR で `database/` / `docker/database/` 配下の `.sql` は触られていません）';
             const diffAction = sourceModified
               ? 'Please run the database generation command locally (e.g., `make gen` / `make gen-query`) and commit the changes.'
               : '本 PR では SQL source が変更されていないため、generator 側（sqlc バージョン差 / base 側の古い生成物 等）のドリフトの可能性があります。`make gen-query` をローカル実行してコミットするか、`auto-generate-docs` 経由で base 側を更新してから rebase / merge してください。';

--- a/.github/workflows/gen-go-artifacts-check.yaml
+++ b/.github/workflows/gen-go-artifacts-check.yaml
@@ -40,7 +40,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          files="$(git diff --name-only)"
+          # 未追跡（新規生成）ファイルも検知するため index に取り込んでから差分を取る
+          git add -A
+          files="$(git diff --cached --name-only)"
           if [ -n "$files" ]; then
             echo "has_diff=true" >> "$GITHUB_OUTPUT"
             printf "%s\n" "$files" > /tmp/changed_files.txt

--- a/.github/workflows/gen-go-artifacts-check.yaml
+++ b/.github/workflows/gen-go-artifacts-check.yaml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Comment changed files on PR
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gen-go-artifacts-check.yaml
+++ b/.github/workflows/gen-go-artifacts-check.yaml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   generate-go-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write
@@ -63,7 +64,7 @@ jobs:
           git fetch --no-tags --depth=200 origin "${{ github.event.pull_request.base.ref }}" || true
           changed="$(git diff --name-only "$base_sha" "$head_sha" || true)"
           # 生成物自身は source から除外
-          if echo "$changed" | grep -E '\.go$' | grep -vE '\.gen\.go$|_mock\.go$|/mock_.+\.go$' | grep -q .; then
+          if echo "$changed" | grep -E '\.go$' | grep -vE '\.gen\.go$|\.sql\.go$|_mock\.go$|/mock_.+\.go$' | grep -q .; then
             echo "source_modified=true" >> "$GITHUB_OUTPUT"
           else
             echo "source_modified=false" >> "$GITHUB_OUTPUT"
@@ -145,7 +146,7 @@ jobs:
                   updatedLine,
                 ].join('\n');
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,

--- a/.github/workflows/gen-go-artifacts-check.yaml
+++ b/.github/workflows/gen-go-artifacts-check.yaml
@@ -40,7 +40,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # 未追跡（新規生成）ファイルも検知するため index に取り込んでから差分を取る
           git add -A
           files="$(git diff --cached --name-only)"
           if [ -n "$files" ]; then

--- a/.github/workflows/gen-oapi-artifacts-check.yaml
+++ b/.github/workflows/gen-oapi-artifacts-check.yaml
@@ -4,10 +4,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/gen-oapi-artifacts-check.yaml'
-      - '**/*.go'
       - 'openapi/**/*.yaml'
       - '.makefiles/**/*.mk'
-      - 'scripts/**/*.sh'
   workflow_dispatch:
 
 concurrency:
@@ -43,7 +41,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          files="$(git diff --name-only)"
+          # 未追跡（新規生成）ファイルも検知するため index に取り込んでから差分を取る
+          git add -A
+          files="$(git diff --cached --name-only)"
           if [ -n "$files" ]; then
             echo "has_diff=true" >> "$GITHUB_OUTPUT"
             printf "%s\n" "$files" > /tmp/changed_files.txt

--- a/.github/workflows/gen-oapi-artifacts-check.yaml
+++ b/.github/workflows/gen-oapi-artifacts-check.yaml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Comment generated status on PR (diff/no-diff)
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gen-oapi-artifacts-check.yaml
+++ b/.github/workflows/gen-oapi-artifacts-check.yaml
@@ -41,7 +41,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # 未追跡（新規生成）ファイルも検知するため index に取り込んでから差分を取る
           git add -A
           files="$(git diff --cached --name-only)"
           if [ -n "$files" ]; then

--- a/.github/workflows/gen-oapi-artifacts-check.yaml
+++ b/.github/workflows/gen-oapi-artifacts-check.yaml
@@ -24,12 +24,6 @@ jobs:
       - name: Fetch & Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
-
       - name: Run OpenAPI Bundle
         run: make gen-bundle-oapi
 
@@ -112,8 +106,8 @@ jobs:
                 ? '## 🧾 Differences in OpenAPI generated output have been detected (list of modified files)'
                 : '## ⚠️ OpenAPI 生成物のドリフトを検知（本 PR で `openapi/` 配下は触られていません）';
               const action = sourceModified
-                ? 'Please run `make gen-api` locally and commit the changes.'
-                : '本 PR では `openapi/` 配下が変更されていないため、generator 側のドリフト（非決定的出力 / 依存バージョン差 / base 側の古い生成物 等）の可能性があります。`make gen-api` をローカル実行してコミットするか、`auto-generate-docs` 経由で base 側を更新してから rebase / merge してください。';
+                ? 'Please run `make gen-bundle-oapi && make gen-api-docs` locally and commit the changes.'
+                : '本 PR では `openapi/` 配下が変更されていないため、generator 側のドリフト（非決定的出力 / 依存バージョン差 / base 側の古い生成物 等）の可能性があります。`make gen-bundle-oapi && make gen-api-docs` をローカル実行してコミットするか、`auto-generate-docs` 経由で base 側を更新してから rebase / merge してください。';
               body = [
                 marker,
                 title,
@@ -139,7 +133,7 @@ jobs:
               ].join('\n');
             }
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Prepare vendor
         run: |
-          go mod tidy
           go mod vendor
 
       - name: Set up Docker Buildx

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -119,6 +119,7 @@ jobs:
 
       - name: Comment SBOM Summary on PR
         if: ${{ github.event_name == 'pull_request' }}
+        continue-on-error: true
         uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -168,6 +169,7 @@ jobs:
 
       - name: Comment Trivy result on PR
         if: ${{ github.event_name == 'pull_request' }}
+        continue-on-error: true
         uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -120,84 +120,11 @@ jobs:
 
       - name: Comment SBOM Summary on PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v8
+        uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-
-            const marker = '<!-- sbom-summary-spdx -->';
-            const path = 'sbom-summary.md';
-
-            const updatedAtJST = new Date().toLocaleString('ja-JP', {
-              timeZone: 'Asia/Tokyo',
-              year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-            });
-
-            const headSha =
-              (context.payload.pull_request?.head?.sha)
-              || process.env.GITHUB_SHA
-              || context.sha;
-            const shortSha = headSha.slice(0, 7);
-
-            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            const commitUrl = `${repoUrl}/commit/${headSha}`;
-
-            // 例: 🔖 Commit: [`1a2b3c4`](https://github.com/.../commit/1a2b3c4...)
-            const commitLine = `🔖 Commit: [\`${shortSha}\`](${commitUrl})`;
-            const updatedLine = `🕒 UpdatedAt: ${updatedAtJST} (JST)`;
-
-            if (!fs.existsSync(path)) {
-              core.setFailed('sbom-summary.md not found');
-              process.exit(1);
-            }
-
-            const pr = context.payload.pull_request?.number;
-            if (!pr) {
-              core.setFailed('Not a PR context');
-              process.exit(1);
-            }
-
-            // sbom-summary.md を読み込んで、先頭にマーカーを付与（同一コメント検出用）
-            const summary = fs.readFileSync(path, 'utf8').trimEnd();
-            const body = [
-              marker,
-              summary,
-              '',
-              commitLine,
-              '',
-              updatedLine,
-            ].join('\n');
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr,
-              per_page: 100,
-            });
-
-            const existing = comments.find(c => (c.body || '').includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr,
-                body,
-              });
-            }
+          marker: '<!-- sbom-summary-spdx -->'
+          body-file: sbom-summary.md
 
       - name: Upload SBOM summary artifact
         uses: actions/upload-artifact@v7
@@ -242,96 +169,13 @@ jobs:
 
       - name: Comment Trivy result on PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v8
+        uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-
-            const marker = '<!-- trivy-image-scan -->';
-            const path = 'trivy-image-scan.txt';
-
-            const updatedAtJST = new Date().toLocaleString('ja-JP', {
-              timeZone: 'Asia/Tokyo',
-              year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-            });
-
-            const headSha =
-              (context.payload.pull_request?.head?.sha)
-              || process.env.GITHUB_SHA
-              || context.sha;
-            const shortSha = headSha.slice(0, 7);
-
-            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            const commitUrl = `${repoUrl}/commit/${headSha}`;
-
-            const pr = context.payload.pull_request?.number;
-            if (!pr) {
-              core.setFailed('Not a PR context');
-              process.exit(1);
-            }
-
-            if (!fs.existsSync(path)) {
-              core.setFailed(`${path} not found`);
-              process.exit(1);
-            }
-
-            const read = fs.readFileSync(path, 'utf8').trimEnd();
-
-            const trimLog = (txt) => {
-              const MAX = 45000; // コメント上限対策（安全側）
-              if (txt.length <= MAX) return txt;
-              return txt.slice(0, MAX) + '\n... (truncated)';
-            };
-
-            const commitLine = `🔖 Commit: [\`${shortSha}\`](${commitUrl})`;
-            const updatedLine = `🕒 UpdatedAt: ${updatedAtJST} (JST)`;
-
-            const body = [
-              marker,
-              '## Trivy Image Scan (table)',
-              '',
-              commitLine,
-              updatedLine,
-              '',
-              '<details><summary>Image Scan Results</summary>',
-              '',
-              '```',
-              trimLog(read),
-              '```',
-              '',
-              '</details>',
-            ].join('\n');
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr,
-              per_page: 100,
-            });
-
-            const existing = comments.find(c => (c.body || '').includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr,
-                body,
-              });
-            }
+          marker: '<!-- trivy-image-scan -->'
+          body-file: trivy-image-scan.txt
+          title: '## Trivy Image Scan (table)'
+          details-summary: 'Image Scan Results'
 
       - name: Trivy image scan (gate - fixable CRITICAL/HIGH)
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/job-boot-check.yaml
+++ b/.github/workflows/job-boot-check.yaml
@@ -5,9 +5,9 @@ on:
     paths:
       - '.github/workflows/job-boot-check.yaml'
       - 'cmd/**.go'
-      - 'internal/cli/job/**.go'
-      - 'internal/di/**.go'
-      - 'internal/controller/job/**.go'
+      - 'internal/**.go'
+      - 'env/.env.ci'
+      - 'env/.env'
       - 'go.mod'
       - 'go.sum'
   workflow_dispatch:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -52,7 +52,6 @@ jobs:
         shell: bash
         run: |
           set +e
-          mkdir -p /tmp
 
           golangci-lint run --config=.golangci-full.yaml \
             --output.text.print-issued-lines=true \
@@ -142,7 +141,7 @@ jobs:
               '</details>',
             ].join('\n');
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -73,6 +73,7 @@ jobs:
 
       - name: Comment Go lint result on PR
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/migration-check.yaml
+++ b/.github/workflows/migration-check.yaml
@@ -77,6 +77,7 @@ jobs:
 
       - name: Comment migration result on PR
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/migration-check.yaml
+++ b/.github/workflows/migration-check.yaml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
   pull-requests: write
 
 jobs:
@@ -139,7 +138,7 @@ jobs:
               ].join('\n');
             }
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,

--- a/.github/workflows/sql-lint.yaml
+++ b/.github/workflows/sql-lint.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Run SQL lint
         id: lint
         shell: bash
+        continue-on-error: true
         run: |
           set +e
           status=success
@@ -144,5 +145,5 @@ jobs:
             }
 
       - name: Fail if any lint failed
-        if: steps.lint.outputs.status != 'success'
+        if: always() && steps.lint.outputs.status != 'success'
         run: exit 1

--- a/.github/workflows/sql-lint.yaml
+++ b/.github/workflows/sql-lint.yaml
@@ -29,46 +29,19 @@ jobs:
       - name: Build python tool container
         run: docker compose build python_tool_runner
 
-      - name: Run SQL lint on migrations
-        id: lint_migrations
+      - name: Run SQL lint
+        id: lint
         shell: bash
-        continue-on-error: true
         run: |
           set +e
-          make sql-lint-migrations 2>&1 | tee /tmp/sqlfluff_migrations.log
-          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
-
-      - name: Run SQL lint on DML
-        id: lint_dml
-        shell: bash
-        continue-on-error: true
-        run: |
-          set +e
-          make sql-lint-dml 2>&1 | tee /tmp/sqlfluff_dml.log
-          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
-
-      - name: Run SQL lint on seed
-        id: lint_seed
-        shell: bash
-        continue-on-error: true
-        run: |
-          set +e
-          make sql-lint-seed 2>&1 | tee /tmp/sqlfluff_seed.log
-          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
-
-      - name: Summarize result
-        id: summary
-        shell: bash
-        run: |
-          m=${{ steps.lint_migrations.outputs.exit_code }}
-          d=${{ steps.lint_dml.outputs.exit_code }}
-          s=${{ steps.lint_seed.outputs.exit_code }}
-
-          if [ "$m" = "0" ] && [ "$d" = "0" ] && [ "$s" = "0" ]; then
-            echo "status=success" >> "$GITHUB_OUTPUT"
-          else
-            echo "status=failure" >> "$GITHUB_OUTPUT"
-          fi
+          status=success
+          for cat in migrations dml seed; do
+            make "sql-lint-${cat}" 2>&1 | tee "/tmp/sqlfluff_${cat}.log"
+            code=${PIPESTATUS[0]}
+            echo "exit_code_${cat}=${code}" >> "$GITHUB_OUTPUT"
+            [ "$code" = "0" ] || status=failure
+          done
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
 
       - name: Comment SQL lint result on PR
         if: github.event_name == 'pull_request'
@@ -80,11 +53,12 @@ jobs:
             const fs = require('fs');
 
             const marker = '<!-- sql-lint-result -->';
-            const status = '${{ steps.summary.outputs.status }}';
-
-            const codeM = '${{ steps.lint_migrations.outputs.exit_code }}';
-            const codeD = '${{ steps.lint_dml.outputs.exit_code }}';
-            const codeS = '${{ steps.lint_seed.outputs.exit_code }}';
+            const status = '${{ steps.lint.outputs.status }}';
+            const categories = [
+              { name: 'migrations', code: '${{ steps.lint.outputs.exit_code_migrations }}' },
+              { name: 'dml', code: '${{ steps.lint.outputs.exit_code_dml }}' },
+              { name: 'seed', code: '${{ steps.lint.outputs.exit_code_seed }}' },
+            ];
 
             const updatedAtJST = new Date().toLocaleString('ja-JP', {
               timeZone: 'Asia/Tokyo',
@@ -119,43 +93,33 @@ jobs:
               ? '✅ SQL lint: PASS'
               : '❌ SQL lint: FAIL';
 
-            const line = (name, code) => (code === '0' ? `- ✅ ${name}` : `- ❌ ${name}のディレクトリのsqlをローカルで修正して、差分をコミットしてください。`);
+            const line = (c) => c.code === '0'
+              ? `- ✅ ${c.name}`
+              : `- ❌ ${c.name}のディレクトリのsqlをローカルで修正して、差分をコミットしてください。`;
             const icon = (code) => (code === '0' ? '✅' : '🚨');
+            const details = (c) => [
+              `<details><summary> ${icon(c.code)} ${c.name} log</summary>`,
+              '',
+              '```text',
+              trimLog(read(`/tmp/sqlfluff_${c.name}.log`)),
+              '```',
+              '</details>',
+              '',
+            ];
 
             const body = [
               marker,
               `## ${title}`,
               '',
-              line('migrations', codeM),
-              line('dml', codeD),
-              line('seed', codeS),
+              ...categories.map(line),
               '',
               `- 🔖 Commit: [\`${shortSha}\`](${commitUrl})`,
               `- 🕒 UpdatedAt: ${updatedAtJST} (JST)`,
               '',
-              `<details><summary> ${icon(codeM)} migrations log</summary>`,
-              '',
-              '```text',
-              trimLog(read('/tmp/sqlfluff_migrations.log')),
-              '```',
-              '</details>',
-              '',
-              `<details><summary> ${icon(codeD)} dml log</summary>`,
-              '',
-              '```text',
-              trimLog(read('/tmp/sqlfluff_dml.log')),
-              '```',
-              '</details>',
-              '',
-              `<details><summary> ${icon(codeS)} seed log</summary>`,
-              '',
-              '```text',
-              trimLog(read('/tmp/sqlfluff_seed.log')),
-              '```',
-              '</details>',
+              ...categories.flatMap(details),
             ].join('\n');
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
@@ -180,5 +144,5 @@ jobs:
             }
 
       - name: Fail if any lint failed
-        if: steps.summary.outputs.status != 'success'
+        if: steps.lint.outputs.status != 'success'
         run: exit 1

--- a/.github/workflows/sql-lint.yaml
+++ b/.github/workflows/sql-lint.yaml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Comment SQL lint result on PR
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -109,7 +110,7 @@ jobs:
             };
 
             const trimLog = (txt) => {
-              const MAX = 45000; // 1コメント上限対策
+              const MAX = 18000; // 3ログ合算でコメント本文 65536 上限に収める
               if (txt.length <= MAX) return txt;
               return txt.slice(0, MAX) + '\n... (truncated)';
             };

--- a/.github/workflows/sync-versions-check.yaml
+++ b/.github/workflows/sync-versions-check.yaml
@@ -50,7 +50,7 @@ jobs:
           fi
           echo "status=drift" >> "$GITHUB_OUTPUT"
           {
-            echo "mise.toml の変更が以下のファイルへ伝播していません。"
+            echo "mise.toml を正とした各ファイルへの同期に差分があります（mise.toml 更新の未反映、または下流ファイルの不整合な編集が原因）。"
             echo ""
             echo "ローカルで \`make sync-versions\` を実行してコミットしてください。"
             echo ""

--- a/.github/workflows/sync-versions-check.yaml
+++ b/.github/workflows/sync-versions-check.yaml
@@ -74,7 +74,7 @@ jobs:
               fs.readFileSync('/tmp/sync-versions-drift.md', 'utf8'),
             ].join('\n');
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,

--- a/.github/workflows/trivy-fs.yaml
+++ b/.github/workflows/trivy-fs.yaml
@@ -64,7 +64,7 @@ jobs:
             .Results
             | map(.Vulnerabilities // [])
             | flatten
-            | sort_by(.Severity) | reverse
+            | sort_by({CRITICAL:0,HIGH:1,MEDIUM:2,LOW:3,UNKNOWN:4}[.Severity] // 5)
             | .[]
             | "- [\(.Severity)] \(.PkgName // "unknown") `\(.InstalledVersion // "?")` → `\(.FixedVersion // "none")` (\(.VulnerabilityID))"
           ' trivy-fs.json > trivy-fs-summary.md

--- a/.github/workflows/trivy-fs.yaml
+++ b/.github/workflows/trivy-fs.yaml
@@ -142,7 +142,7 @@ jobs:
               '</details>',
             ].join('\n');
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,

--- a/.github/workflows/trivy-fs.yaml
+++ b/.github/workflows/trivy-fs.yaml
@@ -81,6 +81,7 @@ jobs:
 
       - name: Comment Trivy FS result on PR
         if: ${{ github.event_name == 'pull_request' }}
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trivy-fs.yaml
+++ b/.github/workflows/trivy-fs.yaml
@@ -83,13 +83,15 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         continue-on-error: true
         uses: actions/github-script@v8
+        env:
+          COUNT: ${{ steps.summarize.outputs.count }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
 
             const marker = '<!-- trivy-fs-result -->';
-            const count = Number('${{ steps.summarize.outputs.count }}' || '0');
+            const count = Number(process.env.COUNT || '0');
 
             const updatedAtJST = new Date().toLocaleString('ja-JP', {
               timeZone: 'Asia/Tokyo',

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -61,7 +61,7 @@ jobs:
               | select((.trace // []) | length > 1)
             )
             | length
-          ' govulncheck.jsonl || true)
+          ' govulncheck.jsonl || echo 0)
           echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
 
           if [ "${COUNT}" -gt 0 ]; then
@@ -89,7 +89,7 @@ jobs:
                     (.fix
                       | sub("^v";"")        # 先頭の v を削除
                       | split(".")          # "1.24.9" → ["1","24","9"]
-                      | map(tonumber)       # 文字列 → 数値
+                      | map(tonumber? // 0) # 数値化（+incompatible/擬似版は 0 扱い）
                     )
                   )
                 )
@@ -117,6 +117,7 @@ jobs:
 
       - name: Comment govulncheck summary on PR
         if: ${{ github.event_name == 'pull_request' }}
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -53,49 +53,25 @@ jobs:
         run: |
           set -euo pipefail
 
-          # 対応が必要な finding の数（trace が 2つ以上あるもの = 到達可能なもの）
-          COUNT=$(jq -rs '
-            map(
-              select(.finding != null)
-              | .finding
-              | select((.trace // []) | length > 1)
-            )
-            | length
-          ' govulncheck.jsonl || echo 0)
+          # 到達可能（trace>1）な finding を一度だけ抽出して以降の入力に使う
+          jq -s '[ .[] | select(.finding != null) | .finding | select((.trace // []) | length > 1) ]' \
+            govulncheck.jsonl > _findings.json
+          COUNT=$(jq 'length' _findings.json || echo 0)
           echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
 
           if [ "${COUNT}" -gt 0 ]; then
             echo "has_findings=true" >> "$GITHUB_OUTPUT"
 
-            jq -rs '
-              map(
-                select(.finding != null)
-                | .finding
-                # trace が 2つ以上あるものだけ = 対応が必要なもの
-                | select((.trace // []) | length > 1)
-                | {
-                    mod: .trace[0].module,
-                    cur: .trace[0].version,
-                    fix: .fixed_version
-                  }
-              )
-              # fixed_version があるものだけ対象
+            jq -r '
+              map({ mod: .trace[0].module, cur: .trace[0].version, fix: .fixed_version })
               | map(select(.fix != null))
-              # モジュールごとにグルーピング
               | group_by(.mod)
-              # 各モジュールの中で、一番新しい fix を1つだけ選ぶ
               | map(
-                  max_by(
-                    (.fix
-                      | sub("^v";"")        # 先頭の v を削除
-                      | split(".")          # "1.24.9" → ["1","24","9"]
-                      | map(tonumber? // 0) # 数値化（+incompatible/擬似版は 0 扱い）
-                    )
-                  )
+                  max_by(.fix | sub("^v";"") | split(".") | map(tonumber? // 0))
                 )
               | .[]
               | "- `\(.mod // "unknown")`  \(.cur // "unknown") → \(.fix // "none")"
-            ' govulncheck.jsonl > _list.md || true
+            ' _findings.json > _list.md || true
 
             head -n 50 _list.md > _top.md || true
 

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -11,8 +11,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
-  actions: read
   pull-requests: write
   issues: write
 
@@ -50,6 +48,8 @@ jobs:
 
       - name: Summarize govulncheck
         id: summarize
+        env:
+          PR_LOGIN: ${{ github.event.pull_request.user.login }}
         run: |
           set -euo pipefail
 
@@ -73,14 +73,18 @@ jobs:
               | "- `\(.mod // "unknown")`  \(.cur // "unknown") → \(.fix // "none")"
             ' _findings.json > _list.md || true
 
+            total=$(wc -l < _list.md)
             head -n 50 _list.md > _top.md || true
+            if [ "${total}" -gt 50 ]; then
+              echo "- ... and $((total - 50)) more" >> _top.md
+            fi
 
             {
               echo "## govulncheck Findings"
               echo
               echo "Detected **${COUNT}** actionable vulnerabilities."
               echo
-              echo "@${{ github.event.pull_request.user.login }} Please review these vulnerabilities."
+              echo "@${PR_LOGIN} Please review these vulnerabilities."
               echo
               echo "### Modules to update"
               cat _top.md
@@ -95,14 +99,17 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         continue-on-error: true
         uses: actions/github-script@v8
+        env:
+          HAS_FINDINGS: ${{ steps.summarize.outputs.has_findings }}
+          COUNT: ${{ steps.summarize.outputs.count }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
 
             const marker = '<!-- govulncheck-result -->';
-            const hasFindings = ('${{ steps.summarize.outputs.has_findings }}' === 'true');
-            const count = Number('${{ steps.summarize.outputs.count }}' || '0');
+            const hasFindings = (process.env.HAS_FINDINGS === 'true');
+            const count = Number(process.env.COUNT || '0');
 
             const updatedAtJST = new Date().toLocaleString('ja-JP', {
               timeZone: 'Asia/Tokyo',
@@ -155,7 +162,7 @@ jobs:
               '</details>',
             ].join('\n');
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,

--- a/.makefiles/go/vars.mk
+++ b/.makefiles/go/vars.mk
@@ -1,1 +1,2 @@
-SQLC_OUT := /app/internal/infrastructure/rdb/sqlc/gen
+# container(CWD=/app)・CI bare runner(CWD=repo root) 双方で正しく解決するよう相対パス
+SQLC_OUT := internal/infrastructure/rdb/sqlc/gen

--- a/.makefiles/go/vars.mk
+++ b/.makefiles/go/vars.mk
@@ -1,2 +1,1 @@
-# container(CWD=/app)・CI bare runner(CWD=repo root) 双方で正しく解決するよう相対パス
 SQLC_OUT := internal/infrastructure/rdb/sqlc/gen


### PR DESCRIPTION
# 概要

full-verify が `reviews-config/` に生成した CI ワークフロー群の指摘を、High→Medium→Low の全帯で適用しました。対象は `.github/`（17ファイル）と `.makefiles/`（1ファイル）の計18ファイル・29コミット。本番コードの挙動変更は含みません。

※ mod は古いファイル基準で生成されていたため、各指摘は現行ファイルで再検証し、既に解決済みのもの（trivy-fs paths・code-ql push トリガ・image-scan SARIF 等）は対応不要として識別しています。

## 変更内容

### 不具合・正当性（High 中心）
- `SQLC_OUT` を相対パス化し、CI の生成物削除が `/app` 絶対パスで no-op になる問題を修正（`.makefiles/go/vars.mk`）
- 生成物チェックの未追跡ファイル検知漏れを是正（`git add -A` → `git diff --cached`）: gen-db / gen-go / gen-oapi / auto-generate-docs
- gen-db の `docker/db` デッドパスを実在の `docker/database` へ
- setup-postgres のスクリプトインジェクションを是正（全入力を `env` 経由へ）
- deploy-app のバージョン採番が常に `none` になる問題（`fetch-depth: 0`）
- deploy-docs に GitHub Pages の `environment` ブロック追加
- trivy-fs サマリの Severity 並びを重要度順へ
- vulnerability-check の jq を `+incompatible`/擬似バージョンに堅牢化

### CI 堅牢性・最小権限（Medium 中心）
- PR コメント投稿の失敗（fork PR の 403 等）でジョブを落とさない（`continue-on-error` 横断）
- コメント検出を `github.paginate` で全件走査（100件超の重複投稿を解消）
- app-di ブートチェックを `go build` でコンパイル分離＋ログ捕捉
- 各種トリガ paths の是正（過剰トリガ除去・実依存面へ拡張）
- 未使用権限の除去（security-events / actions:read / issues:write）
- CI の vendor 生成から `go mod tidy` を除去

### 構造・DRY（承認済み方針判断）
- deploy-app: build/deploy の concurrency 分離（deploy 直列化）・version タグ条件化・build を `strategy.matrix` 化
- image-scan のコメント upsert を共有 action `.github/actions/upsert-pr-comment` へ集約（新設）
- sql-lint の3カテゴリ重複をループ＋配列で集約
- vulnerability-check の到達可能述語を一度だけ評価

### Low（機械的）
- setup-postgres 整理・gen-go 除外リスト・gen-oapi の不要 Setup Go 除去・timeout-minutes 付与 等

## 動作確認方法

CI 設定のため、ローカルでは静的検証を実施:
- 全 YAML を `python -c "import yaml; yaml.safe_load(...)"` でパース確認
- `github-script` の JS を `node --check` で構文確認
- jq 式を実データ（`+incompatible`/擬似バージョン）で例外なく一覧生成を確認
- シェルを `bash -n`、`make -n remove-generated-sqlc-ci` でパス展開を確認

実挙動は GitHub Actions 上での実行で要確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)