### PR TITLE
Fix: scripts/ の構成検証指摘対応（置換文字列の $ 破損・semver 検証）

### DIFF
--- a/scripts/semver.cjs
+++ b/scripts/semver.cjs
@@ -9,8 +9,8 @@ if (!version) {
 }
 
 const v = version.replace(/^v/, "");
-if (!/^\d+\.\d+\.\d+$/.test(v)) {
-  console.error("version must be in the format vX.Y.Z");
+if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(v)) {
+  console.error("version must be in the format X.Y.Z (optional leading 'v')");
   process.exit(1);
 }
 let [major, minor, patch] = v.split(".").map(Number);

--- a/scripts/setup/lib/file-utils.cjs
+++ b/scripts/setup/lib/file-utils.cjs
@@ -51,6 +51,7 @@ function listFilesRecursive(dirPath, options = {}, files = []) {
   const excludedDirectories = options.excludedDirectories ?? new Set()
   const shouldIncludeFile = options.shouldIncludeFile ?? (() => true)
   const entries = fs.readdirSync(dirPath, { withFileTypes: true })
+    .sort((a, b) => a.name.localeCompare(b.name))
 
   for (const entry of entries) {
     const entryPath = path.join(dirPath, entry.name)

--- a/scripts/setup/lib/validators.cjs
+++ b/scripts/setup/lib/validators.cjs
@@ -1,5 +1,5 @@
 function ensureRepositoryReference(value) {
-  if (!/^[^/\s]+\/[^/\s]+$/.test(value)) {
+  if (!/^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9._-]+$/.test(value)) {
     throw new Error("リポジトリ参照は <owner>/<repo> 形式で指定してください。")
   }
 }

--- a/scripts/setup/replace-app-metadata.cjs
+++ b/scripts/setup/replace-app-metadata.cjs
@@ -76,7 +76,7 @@ function replaceEnvAppName(content, appName) {
     return null
   }
 
-  return content.replace(pattern, `APP_NAME=${appName}`)
+  return content.replace(pattern, () => `APP_NAME=${appName}`)
 }
 
 function replaceOpenapiTitle(content, title) {
@@ -86,7 +86,7 @@ function replaceOpenapiTitle(content, title) {
     return null
   }
 
-  return content.replace(pattern, `  title: ${title}`)
+  return content.replace(pattern, () => `  title: ${title}`)
 }
 
 function replaceCopilotTitle(content, title) {
@@ -96,7 +96,7 @@ function replaceCopilotTitle(content, title) {
     return null
   }
 
-  return content.replace(pattern, `# ${title}`)
+  return content.replace(pattern, () => `# ${title}`)
 }
 
 function main() {

--- a/scripts/setup/replace-license-copyright.cjs
+++ b/scripts/setup/replace-license-copyright.cjs
@@ -81,7 +81,7 @@ function main() {
 
     return original.replace(
       pattern,
-      `Copyright (c) ${options.year} ${options.holder}`
+      () => `Copyright (c) ${options.year} ${options.holder}`
     )
   }, options.dryRun)
 

--- a/scripts/setup/replace-repository-reference.cjs
+++ b/scripts/setup/replace-repository-reference.cjs
@@ -37,26 +37,26 @@ function updateReadme(content, repository) {
   const repoName = repository.split("/")[1]
 
   return content
-    .replace(/^# .*/m, `# ${repoName}`)
+    .replace(/^# .*/m, () => `# ${repoName}`)
     .replace(
       /https:\/\/img\.shields\.io\/github\/go-mod\/go-version\/[^\s)]+/g,
-      `https://img.shields.io/github/go-mod/go-version/${repository}`
+      () => `https://img.shields.io/github/go-mod/go-version/${repository}`
     )
     .replace(
       /https:\/\/img\.shields\.io\/github\/license\/[^\s)]+/g,
-      `https://img.shields.io/github/license/${repository}`
+      () => `https://img.shields.io/github/license/${repository}`
     )
     .replace(
       /https:\/\/github\.com\/[^/\s>]+\/[^/\s>]+\.git/g,
-      `https://github.com/${repository}.git`
+      () => `https://github.com/${repository}.git`
     )
-    .replace(/^cd .*/m, `cd ${repoName}`)
+    .replace(/^cd .*/m, () => `cd ${repoName}`)
 }
 
 function updateOpenapi(content, repository) {
   return content.replace(
     /^  termsOfService: https:\/\/github\.com\/.*$/m,
-    `  termsOfService: https://github.com/${repository}`
+    () => `  termsOfService: https://github.com/${repository}`
   )
 }
 


### PR DESCRIPTION
# 概要

reviews-config の **scripts/**（setup スクリプト・semver・lib）の指摘のうち機械的に修正可能なものを適用。設計判断（失敗ポリシー変更・DRY・テンプレ再生成）は保留。

## 変更内容

- **setup/replace-{license-copyright,app-metadata,repository-reference}.cjs**: ユーザー入力を `String.prototype.replace` の置換文字列へ直接補間しており `$&`/`$1` 等で出力が破損する問題を、関数形式 `() => リテラル` へ変更して解消（`replace-module` の split/join と同じ安全イディオム）
- **setup/lib/validators.cjs**: `ensureRepositoryReference` の正規表現を GitHub の owner/repo 文字集合へ厳格化
- **semver.cjs**: 先頭ゼロ（`v01.02.03`）を拒否、`v` 省略可のエラーメッセージへ整合
- **setup/lib/file-utils.cjs**: `listFilesRecursive` の列挙順を `localeCompare` で決定論化

## 動作確認方法

1. `node --check` 全ファイル OK
2. `node scripts/setup/replace-license-copyright.cjs --holder 'A $& B' --dry-run` で `$&` がリテラル出力
3. `node scripts/semver.cjs v01.02.03 patch` が exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)