### PR TITLE
Fix: runtime イメージのベース CVE 解消（Docker Image Scan ゲート通過）

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -34,9 +34,10 @@ FROM alpine:3.23 AS runtime
 # デプロイ対象環境（prd/stg/dev）。当該 env ファイルのみ焼き込み、ENV として固定する。
 ARG APP_ENV=prd
 
-# apk upgrade でベースイメージの修正済み CVE（OpenSSL libcrypto3/libssl3 等）を取り込む。
-RUN apk upgrade --no-cache \
-  && apk add --no-cache ca-certificates tzdata
+# セキュリティ: ベースイメージの修正済み CVE（OpenSSL libcrypto3/libssl3 等）を取り込む
+RUN apk upgrade --no-cache
+
+RUN apk add --no-cache ca-certificates tzdata
 
 RUN addgroup -S app && adduser -S app -G app
 USER app

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -34,7 +34,6 @@ FROM alpine:3.23 AS runtime
 # デプロイ対象環境（prd/stg/dev）。当該 env ファイルのみ焼き込み、ENV として固定する。
 ARG APP_ENV=prd
 
-# セキュリティ: ベースイメージの修正済み CVE（OpenSSL libcrypto3/libssl3 等）を取り込む
 RUN apk upgrade --no-cache
 
 RUN apk add --no-cache ca-certificates tzdata

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -34,7 +34,9 @@ FROM alpine:3.23 AS runtime
 # デプロイ対象環境（prd/stg/dev）。当該 env ファイルのみ焼き込み、ENV として固定する。
 ARG APP_ENV=prd
 
-RUN apk add --no-cache ca-certificates tzdata
+# apk upgrade でベースイメージの修正済み CVE（OpenSSL libcrypto3/libssl3 等）を取り込む。
+RUN apk upgrade --no-cache \
+  && apk add --no-cache ca-certificates tzdata
 
 RUN addgroup -S app && adduser -S app -G app
 USER app


### PR DESCRIPTION
# 概要

`release/v1.3.0` の Docker Image Scan Workflow（Trivy の fixable CRITICAL/HIGH ゲート）が、alpine:3.23 ベースの OpenSSL `libcrypto3`/`libssl3` の **CVE-2026-45447（HIGH×2・修正版 3.5.7-r0）** を検出して失敗していたため修正します。ベースイメージの新規 CVE（Trivy DB 更新で顕在化）で、構成レビュー変更とは独立した保守対応です。

## 変更内容

- `docker/server/Dockerfile` の runtime ステージ先頭に `RUN apk upgrade --no-cache` を追加し、ベースイメージの修正済み CVE（OpenSSL 等）を取り込み（migration ステージは runtime 継承で同様に修正）

## 動作確認方法

1. `docker build --target runtime` 後、`libcrypto3`/`libssl3` が `3.5.7-r0` に更新されていること
2. `trivy image --severity CRITICAL,HIGH --ignore-unfixed --exit-code 1 --pkg-types os,library <image>` が alpine/gobinary とも 0 件で **exit 0**（ゲート通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)