### PR TITLE
Fix: logging の event_type 誤分類を是正し ConvertFields を非公開化

### DIFF
--- a/internal/controller/httpstack/errorhandler/http_error_handler.go
+++ b/internal/controller/httpstack/errorhandler/http_error_handler.go
@@ -45,7 +45,7 @@ func handleHTTPError(c echo.Context, logger logging.Logger, lf logging.LogFieldB
 
 	if !c.Response().Committed {
 		if writeErr := writeErrorResponse(c, resp); writeErr != nil {
-			reqIn := server.BuildHTTPRequestLogInput(c)
+			reqIn := server.BuildHTTPRequestLogInput(c, logging.EventTypeError)
 			writeErrFields := []*logging.Field{logging.String(logging.InternalErrorKey, writeErr.Error())}
 			fields := append(lf.BuildHTTPRequestFields(reqIn), writeErrFields...)
 			logger.Named("errorhandler.handleHTTPError").Error("failed to write error response", fields...)
@@ -118,7 +118,7 @@ func httpErrorField(
 		logging.String(logging.ErrorMessageKey, he.Message),
 		logging.String(logging.RequestIDKey, he.RequestId),
 	}
-	fields = append(fields, lf.BuildHTTPRequestFields(server.BuildHTTPRequestLogInput(c))...)
+	fields = append(fields, lf.BuildHTTPRequestFields(server.BuildHTTPRequestLogInput(c, logging.EventTypeError))...)
 	if he.Details != nil {
 		fields = append(fields, logging.Strings(logging.ErrorDetailsKey, *he.Details))
 	}

--- a/internal/controller/httpstack/errorhandler/http_error_handler_test.go
+++ b/internal/controller/httpstack/errorhandler/http_error_handler_test.go
@@ -443,8 +443,10 @@ func Test_logHTTPError(t *testing.T) {
 
 			logHTTPError(c, logger, lf, obsCfg, he)
 
-			assert.Equal(t, 1, observed.FilterMessage("errorhandler.server_error").Len())
+			entries := observed.FilterMessage("errorhandler.server_error").All()
+			require.Len(t, entries, 1)
 			assert.Equal(t, 0, observed.FilterMessage("errorhandler.client_error").Len())
+			assert.Equal(t, logging.EventTypeError, entries[0].ContextMap()[logging.EventTypeKey])
 		})
 
 		t.Run("400〜499はWarnログとして出力される", func(t *testing.T) {
@@ -465,8 +467,10 @@ func Test_logHTTPError(t *testing.T) {
 
 			logHTTPError(c, logger, lf, obsCfg, he)
 
-			assert.Equal(t, 1, observed.FilterMessage("errorhandler.client_error").Len())
+			entries := observed.FilterMessage("errorhandler.client_error").All()
+			require.Len(t, entries, 1)
 			assert.Equal(t, 0, observed.FilterMessage("errorhandler.server_error").Len())
+			assert.Equal(t, logging.EventTypeError, entries[0].ContextMap()[logging.EventTypeKey])
 		})
 	})
 }

--- a/internal/controller/httpstack/logging/logging.go
+++ b/internal/controller/httpstack/logging/logging.go
@@ -64,6 +64,7 @@ func loggingMiddleware(logger logging.Logger, lf logging.LogFieldBuilder) echo.M
 func (l requestLog) buildRequestLogFields(start time.Time) []*logging.Field {
 	req := l.c.Request()
 	reqIn := logging.HTTPRequestLogInput{
+		EventType:     logging.EventTypeStart,
 		EventAt:       start,
 		Method:        req.Method,
 		URI:           req.RequestURI,

--- a/internal/controller/httpstack/recovery/recover.go
+++ b/internal/controller/httpstack/recovery/recover.go
@@ -44,7 +44,7 @@ func newRecoverConfig(logger logging.Logger, appCfg *config.ApplicationConfig) m
 // newRecoverLogErrorFunc は、リカバリミドルウェアのログ出力関数を生成します。
 func newRecoverLogErrorFunc(logger logging.Logger, lf logging.LogFieldBuilder) func(c echo.Context, err error, stack []byte) error {
 	return func(c echo.Context, err error, stack []byte) error {
-		reqIn := server.BuildHTTPRequestLogInput(c)
+		reqIn := server.BuildHTTPRequestLogInput(c, logging.EventTypePanic)
 		recoverFields := []*logging.Field{
 			logging.String(logging.InternalErrorKey, err.Error()),
 			logging.String(logging.InternalStackTraceKey, string(stack)),

--- a/internal/controller/httpstack/recovery/recover_test.go
+++ b/internal/controller/httpstack/recovery/recover_test.go
@@ -105,6 +105,8 @@ func TestMiddleware_realPanic(t *testing.T) {
 			require.Len(t, entries, 1)
 			cm := entries[0].ContextMap()
 
+			assert.Equal(t, logging.EventTypePanic, cm[logging.EventTypeKey])
+
 			errStr, ok := cm[logging.InternalErrorKey].(string)
 			require.True(t, ok)
 			assert.Contains(t, errStr, "boom-panic")

--- a/internal/controller/server/echo.go
+++ b/internal/controller/server/echo.go
@@ -23,10 +23,12 @@ func IsRecovered(c echo.Context) bool {
 }
 
 // BuildHTTPRequestLogInput は、Echo コンテキストから HTTP リクエストのログ入力を組み立てます（エラー/リカバリ経路の共通生成点）。
-func BuildHTTPRequestLogInput(c echo.Context) logging.HTTPRequestLogInput {
+// eventType には呼び出し経路に応じたイベント種別（logging.EventTypeError / EventTypePanic 等）を渡す。
+func BuildHTTPRequestLogInput(c echo.Context, eventType string) logging.HTTPRequestLogInput {
 	req := c.Request()
 	traceCtx := observability.ExtractTraceContext(req.Context())
 	return logging.HTTPRequestLogInput{
+		EventType:     eventType,
 		EventAt:       time.Now(),
 		Method:        req.Method,
 		Path:          c.Path(),

--- a/internal/controller/server/echo_test.go
+++ b/internal/controller/server/echo_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"go-boilerplate/internal/logging"
+
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -100,8 +102,9 @@ func Test_BuildHTTPRequestLogInput(t *testing.T) {
 			c.SetParamNames("id")
 			c.SetParamValues("123")
 
-			got := BuildHTTPRequestLogInput(c)
+			got := BuildHTTPRequestLogInput(c, logging.EventTypeError)
 
+			assert.Equal(t, logging.EventTypeError, got.EventType)
 			assert.Equal(t, http.MethodPost, got.Method)
 			assert.Equal(t, "/users/:id", got.Path)
 			assert.Equal(t, "/users/123?q=v", got.URI)

--- a/internal/logging/const.go
+++ b/internal/logging/const.go
@@ -9,6 +9,10 @@ const (
 	EventTypeStart = "start"
 	// EventTypeEnd は、終了イベントを表すイベントタイプの値です。
 	EventTypeEnd = "end"
+	// EventTypeError は、エラー応答イベントを表すイベントタイプの値です。
+	EventTypeError = "error"
+	// EventTypePanic は、パニック復旧イベントを表すイベントタイプの値です。
+	EventTypePanic = "panic"
 	// EventAtKey は、イベント発生時刻を表すログフィールドのキーです。
 	EventAtKey = "event_at"
 	// EventTzKey は、イベント発生時刻のタイムゾーンを表すログフィールドのキーです。

--- a/internal/logging/field_builder.go
+++ b/internal/logging/field_builder.go
@@ -24,7 +24,6 @@ type logFieldBuilder struct {
 // HTTPRequestLogInput は、HTTPリクエストのログ出力用の入力情報をまとめた構造体です。
 type HTTPRequestLogInput struct {
 	// EventType は、イベント種別（start/error/panic）を表す。
-	// リクエスト開始は start、エラー応答は error、パニック復旧は panic を指定する。
 	EventType string
 	EventAt   time.Time
 

--- a/internal/logging/field_builder.go
+++ b/internal/logging/field_builder.go
@@ -23,7 +23,10 @@ type logFieldBuilder struct {
 
 // HTTPRequestLogInput は、HTTPリクエストのログ出力用の入力情報をまとめた構造体です。
 type HTTPRequestLogInput struct {
-	EventAt time.Time
+	// EventType は、イベント種別（start/error/panic）を表す。
+	// リクエスト開始は start、エラー応答は error、パニック復旧は panic を指定する。
+	EventType string
+	EventAt   time.Time
 
 	Method   string
 	Path     string
@@ -124,7 +127,7 @@ func NewLogFields(
 
 // BuildHTTPRequestFields は、HTTPリクエストの情報を含むFieldのスライスを生成します。
 func (l *logFieldBuilder) BuildHTTPRequestFields(req HTTPRequestLogInput) []*Field {
-	fields := append(l.buildEventHeader(EventTypeStart, req.EventAt),
+	fields := append(l.buildEventHeader(req.EventType, req.EventAt),
 		String(MethodKey, req.Method),
 		String(PathKey, req.Path),
 		String(URIKey, req.URI),

--- a/internal/logging/field_builder_test.go
+++ b/internal/logging/field_builder_test.go
@@ -54,7 +54,8 @@ func TestLogFields_BuildHTTPRequestFields(t *testing.T) {
 		URI:      "/api/v1/example?key3=value3&key4=value4a&key4=value4b",
 		RemoteIP: "192.168.1.1",
 
-		EventAt: time.Now(),
+		EventType: EventTypeStart,
+		EventAt:   time.Now(),
 
 		Host:          "example.com",
 		Scheme:        "https",
@@ -131,6 +132,16 @@ func TestLogFields_BuildHTTPRequestFields(t *testing.T) {
 
 			actual := lf.BuildHTTPRequestFields(input)
 			assert.Equal(t, expected, actual)
+		})
+
+		t.Run("指定したイベント種別がevent_typeに反映される", func(t *testing.T) {
+			t.Parallel()
+
+			input := exampleInput
+			input.EventType = EventTypePanic
+
+			actual := lf.BuildHTTPRequestFields(input)
+			assert.Contains(t, actual, String(EventTypeKey, EventTypePanic))
 		})
 	})
 }

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -21,8 +21,6 @@ type Logger interface {
 	Named(name string) Logger
 	// CallerSkip は、コールスタックのスキップ数を設定した新しいLoggerを返す。
 	CallerSkip(skip int) Logger
-	// ConvertFields は Field のスライスを zap.Field のスライスに変換する。
-	ConvertFields(fields []*Field) []zap.Field
 }
 
 type logger struct {
@@ -45,26 +43,26 @@ func (l *logger) CallerSkip(skip int) Logger {
 
 // Debug はデバッグレベルのログを出力する。
 func (l *logger) Debug(msg string, fields ...*Field) {
-	l.log.Debug(msg, l.ConvertFields(fields)...)
+	l.log.Debug(msg, l.convertFields(fields)...)
 }
 
 // Info は情報レベルのログを出力する。
 func (l *logger) Info(msg string, fields ...*Field) {
-	l.log.Info(msg, l.ConvertFields(fields)...)
+	l.log.Info(msg, l.convertFields(fields)...)
 }
 
 // Warn は警告レベルのログを出力する。
 func (l *logger) Warn(msg string, fields ...*Field) {
-	l.log.Warn(msg, l.ConvertFields(fields)...)
+	l.log.Warn(msg, l.convertFields(fields)...)
 }
 
 // Error はエラーレベルのログを出力する。
 func (l *logger) Error(msg string, fields ...*Field) {
-	l.log.Error(msg, l.ConvertFields(fields)...)
+	l.log.Error(msg, l.convertFields(fields)...)
 }
 
-// ConvertFields は Field のスライスを zap.Field のスライスに変換する。
-func (l *logger) ConvertFields(fs []*Field) []zap.Field {
+// convertFields は Field のスライスを zap.Field のスライスに変換する。
+func (l *logger) convertFields(fs []*Field) []zap.Field {
 	zfs := make([]zap.Field, 0, len(fs))
 
 	for _, f := range fs {

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -96,7 +96,7 @@ func Test_logger_ConvertFields(t *testing.T) {
 				zap.NamedError("key6", expectedError),
 				zap.Any("key7", expectedAny),
 			}
-			actual := l.ConvertFields(fields)
+			actual := l.convertFields(fields)
 			assert.Equal(t, expected, actual)
 		})
 	})

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -54,7 +54,7 @@ func Test_logger_Named(t *testing.T) {
 	})
 }
 
-func Test_logger_ConvertFields(t *testing.T) {
+func Test_logger_convertFields(t *testing.T) {
 	t.Parallel()
 
 	t.Run("正常系", func(t *testing.T) {

--- a/internal/logging/mock/mock_logger.go
+++ b/internal/logging/mock/mock_logger.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
-	zap "go.uber.org/zap"
 )
 
 // MockLogger is a mock of Logger interface.
@@ -53,20 +52,6 @@ func (m *MockLogger) CallerSkip(skip int) logging.Logger {
 func (mr *MockLoggerMockRecorder) CallerSkip(skip any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallerSkip", reflect.TypeOf((*MockLogger)(nil).CallerSkip), skip)
-}
-
-// ConvertFields mocks base method.
-func (m *MockLogger) ConvertFields(fields []*logging.Field) []zap.Field {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConvertFields", fields)
-	ret0, _ := ret[0].([]zap.Field)
-	return ret0
-}
-
-// ConvertFields indicates an expected call of ConvertFields.
-func (mr *MockLoggerMockRecorder) ConvertFields(fields any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConvertFields", reflect.TypeOf((*MockLogger)(nil).ConvertFields), fields)
 }
 
 // Debug mocks base method.


### PR DESCRIPTION
# 概要

full-verify/full-apply の保留事項（`reviews/PENDING.md` の A-1・A-2）のうち、logging 層の 2 点を解消します。
パニック/エラーログが `event_type: start` と誤分類される不具合の是正と、Logger インターフェースからの zap 依存漏れの解消です。

## 変更内容

- **Fix（A-1）event_type 誤分類**: `BuildHTTPRequestFields` が `event_type` を `start` 固定で出力していたため、これを流用する recovery（パニック復旧）・errorhandler（エラー応答）のログまで `start` となり、`event_type` での集計・フィルタ時に誤分類されていた。
  - `HTTPRequestLogInput` に `EventType` フィールドを追加（既存 `ObservabilityFieldsInput.EventType` の前例に倣う）
  - 共通生成点 `BuildHTTPRequestLogInput` を eventType 引数必須化し、recovery=`panic` / errorhandler=`error` / リクエスト開始=`start` を明示
  - `EventTypeError` / `EventTypePanic` を追加。インターフェース署名は不変のため mock 再生成は不要
- **Refactor（A-2）zap 依存漏れ解消**: `Logger.ConvertFields` が `zap.Field` を返し抽象（zap 隠蔽）が漏れていたため、`convertFields` へ非公開化しインターフェースから除去（呼出元が logger 実装内＋同パッケージテストのみ＝外部利用なしを確認のうえ、生成モックを再生成）

## 動作確認方法

1. `make fix` / `make lint`（0 issues）/ `make test`（全 pass・logging 92.0%・errorhandler 98.5%）
2. `make serve` で起動し実機確認（実 DB・実サーバ）:
   - 通常リクエスト `GET /v1/users` → `event_type: start`（request received）/ `end`（request handled）
   - エラー応答 `GET /v1/users/:id`（401）→ `event_type: error`
   - パニック復旧（version ハンドラへ一時注入）→ `event_type: panic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)