### PR TITLE
Refactor: cli/cmd のエラーラップを xerrors.Wrap へ統一

### DIFF
--- a/cmd/fix_collation.go
+++ b/cmd/fix_collation.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"go-boilerplate/internal/cli/fixcollation"
 	"go-boilerplate/internal/config"
 	"go-boilerplate/internal/infrastructure/rdb/driver"
 	"go-boilerplate/internal/logging"
 	"go-boilerplate/pkg/exec"
+	"go-boilerplate/pkg/xerrors"
 
 	"github.com/spf13/cobra"
 )
@@ -36,7 +36,7 @@ func newFixCollationCommand() *cobra.Command {
 func runFixCollation(ctx context.Context, database string) error {
 	logger, err := logging.NewProductionLogger()
 	if err != nil {
-		return fmt.Errorf("failed to init logger: %w", err)
+		return xerrors.Wrap(err, "failed to init logger")
 	}
 
 	loadDSN := func() (string, string, error) {

--- a/cmd/merge_dml.go
+++ b/cmd/merge_dml.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"go-boilerplate/internal/cli/mergedml"
 	"go-boilerplate/internal/logging"
+	"go-boilerplate/pkg/xerrors"
 
 	"github.com/spf13/cobra"
 )
@@ -39,7 +39,7 @@ func newMergeDMLCommand() *cobra.Command {
 func mergeDMLRun(ctx context.Context, targetType, workDir string) error {
 	logger, err := logging.NewProductionLogger()
 	if err != nil {
-		return fmt.Errorf("failed to create logger: %w", err)
+		return xerrors.Wrap(err, "failed to create logger")
 	}
 
 	gen := mergedml.NewGenerator(logger, workDir)

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,13 +1,12 @@
 package main
 
 import (
-	"fmt"
-
 	climigrate "go-boilerplate/internal/cli/migrate"
 	"go-boilerplate/internal/config"
 	"go-boilerplate/internal/infrastructure/rdb/driver"
 	"go-boilerplate/internal/logging"
 	"go-boilerplate/pkg/envutil"
+	"go-boilerplate/pkg/xerrors"
 
 	"github.com/spf13/cobra"
 
@@ -83,25 +82,25 @@ func newMigrateDownCommand() *cobra.Command {
 // buildMigrateInstance は、設定を読み込み golang-migrate のインスタンスを生成します。
 func buildMigrateInstance(database string) (climigrate.Migrator, error) {
 	if err := config.Load(); err != nil {
-		return nil, fmt.Errorf("failed to load config: %w", err)
+		return nil, xerrors.Wrap(err, "failed to load config")
 	}
 	if database != "" {
 		restore, err := envutil.Override("DB_NAME", database)
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Wrap(err, "failed to override DB_NAME env var")
 		}
 		defer restore()
 	}
 	cfg, err := config.New()
 	if err != nil {
-		return nil, fmt.Errorf("failed to build config: %w", err)
+		return nil, xerrors.Wrap(err, "failed to build config")
 	}
 	dbCfg := config.NewDatabaseConfig(cfg)
 	osCfg := config.NewOperatingSystemConfig(cfg)
 
 	m, err := migrate.New("file://"+migrateFilePlace, driver.DSNWithTimeZoneString(dbCfg, osCfg))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create migrate instance: %w", err)
+		return nil, xerrors.Wrap(err, "failed to create migrate instance")
 	}
 	return m, nil
 }

--- a/internal/cli/dumpschema/dump_schema.go
+++ b/internal/cli/dumpschema/dump_schema.go
@@ -3,7 +3,6 @@ package dumpschema
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"go-boilerplate/internal/logging"
 	"go-boilerplate/pkg/exec"
 	"go-boilerplate/pkg/fs"
+	"go-boilerplate/pkg/xerrors"
 )
 
 const schemaFilePerm = 0o644 // rw-r--r--
@@ -94,12 +94,12 @@ func (g *Generator) dumpSchema(ctx context.Context, dbURL, password string) erro
 			logging.String("out", g.schemaRelPath),
 			logging.Error(logging.ErrorKey, err),
 		)
-		return fmt.Errorf("pg_dump failed: %w", err)
+		return xerrors.Wrap(err, "pg_dump failed")
 	}
 
 	schemaAbs := filepath.Join(g.workDir, g.schemaRelPath)
 	if err := g.fs.WriteFile(schemaAbs, out, g.permission); err != nil {
-		return fmt.Errorf("failed to write schema file: %w", err)
+		return xerrors.Wrap(err, "failed to write schema file")
 	}
 
 	g.logger.CallerSkip(g.callerSkipCount).Named("dumpschema.dumpSchema").Info("pg_dump schema completed",
@@ -116,7 +116,7 @@ func (g *Generator) sanitizeSchemaInPlace() error {
 
 	b, err := g.fs.ReadFile(srcAbs)
 	if err != nil {
-		return fmt.Errorf("read schema: %w", err)
+		return xerrors.Wrap(err, "read schema")
 	}
 
 	lines := strings.Split(string(b), "\n")
@@ -136,7 +136,7 @@ func (g *Generator) sanitizeSchemaInPlace() error {
 	}
 
 	if err := g.fs.WriteFile(srcAbs, []byte(strings.Join(out, "\n")), g.permission); err != nil {
-		return fmt.Errorf("write sanitized schema: %w", err)
+		return xerrors.Wrap(err, "write sanitized schema")
 	}
 
 	g.logger.CallerSkip(g.callerSkipCount).Named("dumpschema.sanitizeSchemaInPlace").Info("schema sanitized for sqlc",

--- a/internal/cli/fixcollation/fix_collation.go
+++ b/internal/cli/fixcollation/fix_collation.go
@@ -7,6 +7,7 @@ import (
 
 	"go-boilerplate/internal/logging"
 	"go-boilerplate/pkg/exec"
+	"go-boilerplate/pkg/xerrors"
 )
 
 const (
@@ -61,7 +62,7 @@ func fixCollation(ctx context.Context, runner exec.Runner, logger logging.Logger
 				logging.String("sql", sql),
 				logging.Error(logging.ErrorKey, err),
 			)
-			return fmt.Errorf("psql command failed: %w", err)
+			return xerrors.Wrap(err, "psql command failed")
 		}
 	}
 


### PR DESCRIPTION
# 概要

full-verify/full-apply の保留事項（`reviews/PENDING.md` ）を解消します。
`buildMigrateInstance` のエラー文脈付与漏れの是正と、cli/cmd 系のエラーラップ方針を
プロジェクト全体の標準である `xerrors.Wrap` へ統一します。

## 変更内容

- `buildMigrateInstance`（実体は `cmd/migrate.go`。PENDING の `internal/cli/migrate/common.go` は誤記）の `envutil.Override` 失敗が `return nil, err` で文脈を付けず素通しだった点を `xerrors.Wrap` で文脈付与。
- **エラーラップ統一（`%w` → `xerrors.Wrap`）**:
  - cmd: migrate（config 読込/生成・instance 生成）・fix_collation（logger 初期化）・merge_dml（logger 生成）
  - internal/cli: dumpschema（pg_dump/書込/読込/整形の4箇所）・fixcollation（psql 失敗）
- `xerrors.Wrap`（cockroachdb/errors）は `errors.Is`/`errors.As` を保持するため照合動作は不変。`%s`/`%d` 整形による新規エラー生成（非ラップ）は `xerrors.New` が書式非対応のため `fmt.Errorf` を維持。

## 動作確認方法

1. `go build ./...` / `make fix`・`make lint`（0 issues）/ `make test`（cli 95〜100% coverage・全 pass）
2. ローカルレビュー（別モデル）実施: dumpschema/fixcollation の返却エラーは cobra の `PrintErrln`（`err.Error()` 文字列）に流れ zap を通らないため `errorVerbose` は発生しない。migrate のセットアップ失敗ログのみ `xerrors` のスタックが `errorVerbose` に乗るが、管理 CLI のデバッグ情報として許容。

🤖 Generated with [Claude Code](https://claude.com/claude-code)