### PR TITLE
Refactor: dev 設定と lefthook フローの整備（reviews-config 第3R / root）

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -55,8 +55,8 @@ tmp_dir = "tmp"                # ビルド済バイナリなどを一時出力�
   # 実行中プロセスをSIGINTで終了（graceful shutdown向け）
   send_interrupt = true
 
-  # kill信号を送るまでの待機時間（ミリ秒）
-  kill_delay = 0
+  # SIGINT 送出後に強制 kill するまでの猶予（graceful shutdown 用。duration 文字列）
+  kill_delay = "2s"
 
   # ファイル変更がなくても一定間隔で再起動するか
   rerun = false

--- a/.lefthook.yaml
+++ b/.lefthook.yaml
@@ -2,18 +2,30 @@ pre-commit:
   parallel: true
   commands:
     lint:
+      glob: "*.go"
       run: make lint
     test:
-      run: make test
+      glob: "*.go"
+      run: make test-cached
     sql-lint:
+      glob: "*.sql"
       run: make sql-lint
     migration-check-version:
+      glob: "database/migrations/*.sql"
       run: make check-migration-up-version check-migration-down-version
     migration-check-gap:
+      glob: "database/migrations/*.sql"
       run: make check-migration-up-gap check-migration-down-gap
+
+commit-msg:
+  commands:
+    prefix:
+      run: node scripts/validate-commit-msg.cjs {1}
 
 pre-push:
   commands:
+    test:
+      run: make test
     gen-go-check:
       run: make gen-bundle-oapi gen-go-code && git diff --exit-code -- '*.gen.go' '*/mock/mock_*.go' '*_mock.go' openapi/openapi.gen.yaml
     tidy-check:

--- a/.makefiles/go/test.mk
+++ b/.makefiles/go/test.mk
@@ -1,14 +1,19 @@
 ## Go言語のテスト関連のコマンド群
-.PHONY: test ## CI用のテスト実行
+.PHONY: test ## CI用のテスト実行（キャッシュ無効）
+.PHONY: test-cached ## ローカル用テスト実行（キャッシュ有効・pre-commit向け）
 .PHONY: gen-test-repo ## テストの実行とテストレポートの生成
 .PHONY: test-cover-ci ## CI用のカバレッジ付きテスト実行
 
-# カバレッジ対象外パッケージ（test / gen-test-repo / test-cover-ci で共有）
+# カバレッジ対象外パッケージ（test / test-cached / gen-test-repo / test-cover-ci で共有）
 GO_TEST_EXCLUDE := /(gen|cmd|mock|apperror|scripts)(/|$$)
 
 test:
 	@TGT_PKGS="$$(go list ./... | grep -Ev '$(GO_TEST_EXCLUDE)')"; \
 	go test $$TGT_PKGS -cover -count=1
+
+test-cached:
+	@TGT_PKGS="$$(go list ./... | grep -Ev '$(GO_TEST_EXCLUDE)')"; \
+	go test $$TGT_PKGS -cover
 
 gen-test-repo:
 	@echo "🔄 テストを実行し、レポートを生成します..."

--- a/mise.toml
+++ b/mise.toml
@@ -11,8 +11,11 @@
 # 言語ランタイム
 # 注: ここに書いた version を `make sync-versions` が以下に伝播する。
 #       go     -> go.mod (`go X.Y.Z` directive) + docker/{server,tools}/Dockerfile (FROM golang:X.Y.Z-alpine)
+#                 + docker/{,server/,tools/}README{,.ja}.md の golang image 記述
 #       node   -> docker/tools/Dockerfile (FROM node:X.Y-alpine)
+#                 + docker/{,tools/}README{,.ja}.md の node image 記述
 #       python -> docker/tools/Dockerfile (FROM python:X.Y.Z-slim)
+#                 + docker/{,tools/}README{,.ja}.md の python image 記述
 #     mise install で host にも入れられるが、各 Dockerfile では公式 base image を採用しているため
 #     mise.toml 側を SSOT、Dockerfile FROM タグは sync によって追従する形になる。
 go = "1.26.4"

--- a/scripts/validate-commit-msg.cjs
+++ b/scripts/validate-commit-msg.cjs
@@ -1,0 +1,38 @@
+const fs = require("fs")
+
+// コミットメッセージ先頭に要求する prefix（CLAUDE.md のコミット規約と一致させる）
+const PREFIXES = [
+  "Feat",
+  "Fix",
+  "Refactor",
+  "Perf",
+  "Docs",
+  "Test",
+  "Build",
+  "CI",
+  "Chore",
+  "Style",
+  "Revert"
+]
+
+// Merge / Revert の自動生成メッセージは prefix 規約の対象外として許可する
+const ALLOWED = new RegExp(`^(Merge |Revert |(${PREFIXES.join("|")})(\\([^)]+\\))?: )`)
+
+function main() {
+  const msgFile = process.argv[2]
+
+  if (!msgFile) {
+    console.error("コミットメッセージファイルのパスを指定してください。")
+    process.exit(1)
+  }
+
+  const firstLine = fs.readFileSync(msgFile, "utf8").split("\n")[0]
+
+  if (!ALLOWED.test(firstLine)) {
+    console.error(`✖ コミットメッセージ先頭は <Prefix>: で始めてください（${PREFIXES.join("/")}）`)
+    console.error(`  受領: ${firstLine}`)
+    process.exit(1)
+  }
+}
+
+main()


### PR DESCRIPTION
# 概要

reviews-config レビューの残保留（第3ラウンド）のうち root 設定と開発ワークフロー（lefthook）を整備します。

## 変更内容

- `.air.toml`: `kill_delay=0→"2s"` で dev でも graceful shutdown を有効化、誤コメント「（ミリ秒）」修正
- `mise.toml`: `sync-versions` の伝播先コメントに docker 配下 README 群を追記
- `.lefthook.yaml`: lint/test を glob スコープ化、重い `make test` を pre-push へ移動し pre-commit は新設 `make test-cached`（キャッシュ有効）で高速化。commit-msg フックで prefix 規約を機械強制
- `scripts/validate-commit-msg.cjs`（新規）: commit-msg 検証ロジックを責務分離（prefix 一覧を一元管理）
- `.makefiles/go/test.mk`: `test-cached` ターゲット追加

## 動作確認方法

- `lefthook validate` / `make -n test-cached` / `node scripts/validate-commit-msg.cjs <msgfile>` の実例（正常系/異常系）で確認済み