### PR TITLE
Refactor: makefiles の $(MAKE) 統一・命名整理・md-lint 修正（reviews-config 第3R / makefiles）

### DIFF
--- a/.claude/skills/go-upgrade/SKILL.ja.md
+++ b/.claude/skills/go-upgrade/SKILL.ja.md
@@ -157,7 +157,7 @@ Go バージョンアップでは base image タグが変わるため、新し�
 
 ```sh
 make serve-build-clean
-make tools-build-clean
+make tool-runners-build-clean
 ```
 
 ### 10. コード生成の再実行
@@ -190,7 +190,7 @@ make gen
 make test
 make lint
 make serve-build-clean
-make tools-build-clean
+make tool-runners-build-clean
 ```
 
 `make sync-versions` を最後にも入れているのは、作業中に `mise.toml` と下流ファイルの drift が残っていた場合に検知するため。

--- a/.claude/skills/go-upgrade/SKILL.md
+++ b/.claude/skills/go-upgrade/SKILL.md
@@ -160,7 +160,7 @@ Because the Go base image tag changes with this upgrade, use the clean (`--no-ca
 
 ```sh
 make serve-build-clean
-make tools-build-clean
+make tool-runners-build-clean
 ```
 
 ### 10. Re-run Code Generation
@@ -193,7 +193,7 @@ make gen
 make test
 make lint
 make serve-build-clean
-make tools-build-clean
+make tool-runners-build-clean
 ```
 
 `make sync-versions` is included so that any leftover drift between `mise.toml` and downstream files is caught before the work is reported as done.

--- a/.makefiles/README.ja.md
+++ b/.makefiles/README.ja.md
@@ -45,9 +45,8 @@ Make ターゲットは主に以下の単位で整理されています。
 | `make serve-build` | Docker イメージをキャッシュを利用して再ビルドしたうえで開発環境を起動します。 | Dockerfile や依存変更の反映 |
 | `make serve-build-clean` | `--no-cache --pull` でクリーンビルドしたうえで開発環境を起動します。 | base image 更新の取り込み（例: Go バージョンアップ） |
 | `make tools` | `tools` プロファイルの開発支援ツール群を起動します。 | 開発ツール利用時 |
-| `make tools-build` | 開発用ツールコンテナをキャッシュを利用してビルドします（起動はしません）。 | ツールコンテナの Dockerfile や依存変更の反映 |
-| `make tools-build-clean` | 開発用ツールコンテナを `--no-cache --pull` 付きでクリーンビルドします（起動はしません）。 | ツールコンテナの base image 更新の取り込み |
-| `make smoke` | `smoke` プロファイルの `smoke_server` をビルド付きで起動します。 | Smoke Test 環境の確認 |
+| `make tool-runners-build` | オンデマンド実行のツールランナー画像(go/node/python)をキャッシュ利用でビルドします（起動はしません）。 | ツールランナーの Dockerfile や依存変更の反映 |
+| `make tool-runners-build-clean` | ツールランナー画像を `--no-cache --pull` 付きでクリーンビルドします（起動はしません）。 | ツールランナーの base image 更新の取り込み |
 
 #### `make job NAME=<job名> ARGS="<引数>"`
 
@@ -308,7 +307,6 @@ CI のセキュリティ指摘をローカルで再現するための Trivy 依�
 | `make setup-replace-app-metadata APP_NAME=<name> OPENAPI_TITLE=<title> COPILOT_TITLE=<title>` | アプリケーション名や OpenAPI タイトルなどのメタデータを一括置換します。 | README や OpenAPI 定義などに反映されます。 |
 | `make setup-replace-repository-reference REPOSITORY=<org/repo>` | リポジトリ参照（GitHub URL など）を一括置換します。 | README やドキュメント内のリンクを更新します。 |
 | `make setup-replace-license-copyright COPYRIGHT_HOLDER=<name> [COPYRIGHT_YEAR=<year>]` | LICENSE の著作権表記を更新します。 | 年は省略可能です。 |
-| `make setup-remove-debug-handlers` | Debug 用ハンドラ一式を削除します。 | 本番利用時の不要コード削除に使用します。 |
 
 ### リリースブランチ関連
 

--- a/.makefiles/README.md
+++ b/.makefiles/README.md
@@ -45,9 +45,8 @@ This is a group of targets related to application development environment startu
 | `make serve-build` | Rebuilds Docker images (cache enabled) and then starts the development environment. | Reflect Dockerfile or dependency changes |
 | `make serve-build-clean` | Cleanly rebuilds Docker images with `--no-cache --pull` and then starts the development environment. | Pick up base image updates (e.g., Go version upgrade) |
 | `make tools` | Starts development support tools with the `tools` profile. | When using development tools |
-| `make tools-build` | Builds development tool containers (cache enabled, no startup). | When updating tool container Dockerfile or dependencies |
-| `make tools-build-clean` | Cleanly builds development tool containers with `--no-cache --pull` (no startup). | Pick up base image updates for tool containers |
-| `make smoke` | Starts `smoke_server` with build under the `smoke` profile. | Verify Smoke Test environment |
+| `make tool-runners-build` | Builds the on-demand tool runner images (go/node/python, cache enabled, no startup). | When updating tool runner Dockerfile or dependencies |
+| `make tool-runners-build-clean` | Cleanly builds the tool runner images with `--no-cache --pull` (no startup). | Pick up base image updates for tool runners |
 
 #### `make job NAME=<job_name> ARGS="<arguments>"`
 
@@ -308,7 +307,6 @@ This is an initial setup command when launching a new repository as a boilerplat
 | `make setup-replace-app-metadata APP_NAME=<name> OPENAPI_TITLE=<title> COPILOT_TITLE=<title>` | Replaces application name and OpenAPI title in batch. | Reflected in README and OpenAPI definitions. |
 | `make setup-replace-repository-reference REPOSITORY=<org/repo>` | Replaces repository references (GitHub URLs, etc.) in batch. | Updates links in README and documentation. |
 | `make setup-replace-license-copyright COPYRIGHT_HOLDER=<name> [COPYRIGHT_YEAR=<year>]` | Updates LICENSE copyright notation. | Year is optional. |
-| `make setup-remove-debug-handlers` | Removes debug handler set. | Used to remove unnecessary code for production use. |
 
 ### Release branch related
 

--- a/.makefiles/app/server.mk
+++ b/.makefiles/app/server.mk
@@ -2,9 +2,9 @@
 .PHONY: serve ## 開発環境の起動
 .PHONY: serve-build ## キャッシュを利用したビルド後、開発環境を起動する
 .PHONY: serve-build-clean ## キャッシュ無効・base image を pull したクリーンビルド後、開発環境を起動する
-.PHONY: tools ## 開発ツールの起動
-.PHONY: tools-build ## 開発ツールコンテナをビルドする（キャッシュ利用・起動はしない）
-.PHONY: tools-build-clean ## 開発ツールコンテナをクリーンビルドする（--no-cache --pull・起動はしない）
+.PHONY: tools ## 開発支援サービス(DB/docs/SQL viewer)を起動する
+.PHONY: tool-runners-build ## ツールランナー画像(go/node/python)をビルドする（キャッシュ利用・起動はしない）
+.PHONY: tool-runners-build-clean ## ツールランナー画像をクリーンビルドする（--no-cache --pull・起動はしない）
 
 serve:
 	@echo "🔄 開発環境を起動します。"
@@ -27,12 +27,12 @@ tools:
 	@docker compose --profile tools up -d --build
 	@echo "✅ 開発ツールの起動が完了しました。"
 
-tools-build:
-	@echo "🧰 開発ツールコンテナをビルドします。"
+tool-runners-build:
+	@echo "🧰 ツールランナー画像をビルドします。"
 	@docker compose build go_tool_runner node_tool_runner python_tool_runner
-	@echo "✅ 開発ツールコンテナのビルドが完了しました。"
+	@echo "✅ ツールランナー画像のビルドが完了しました。"
 
-tools-build-clean:
-	@echo "🧹 開発ツールコンテナをクリーンビルドします（--no-cache --pull）。"
+tool-runners-build-clean:
+	@echo "🧹 ツールランナー画像をクリーンビルドします（--no-cache --pull）。"
 	@docker compose build --no-cache --pull go_tool_runner node_tool_runner python_tool_runner
-	@echo "✅ 開発ツールコンテナのクリーンビルドが完了しました。"
+	@echo "✅ ツールランナー画像のクリーンビルドが完了しました。"

--- a/.makefiles/database/dml-merge.mk
+++ b/.makefiles/database/dml-merge.mk
@@ -18,13 +18,13 @@
 merge-dml:
 	@docker compose run --rm go_tool_runner make merge-dml-ci work-dir=/app
 merge-dml-repo:
-	make merge-dml-core type="repository" work-dir="/app"
+	$(MAKE) merge-dml-core type="repository" work-dir="/app"
 merge-dml-qs:
-	make merge-dml-core type="query_service" work-dir="/app"
+	$(MAKE) merge-dml-core type="query_service" work-dir="/app"
 merge-dml-sysq:
-	make merge-dml-core type="system_query" work-dir="/app"
+	$(MAKE) merge-dml-core type="system_query" work-dir="/app"
 merge-dml-cs:
-	make merge-dml-core type="command_service" work-dir="/app"
+	$(MAKE) merge-dml-core type="command_service" work-dir="/app"
 merge-dml-core:
 	@echo "🔄 DMLのマージを実行します... (type=$(type) work-dir=$(work-dir))"
 	@docker compose run --rm go_tool_runner make merge-dml-ci-core type="$(type)" work-dir="$(work-dir)"
@@ -32,17 +32,17 @@ merge-dml-core:
 
 # -----CI用ターゲット-----
 merge-dml-ci:
-	make merge-dml-ci-repo work-dir=$(work-dir)
-	make merge-dml-ci-qs work-dir=$(work-dir)
-	make merge-dml-ci-sysq work-dir=$(work-dir)
-	make merge-dml-ci-cs work-dir=$(work-dir)
+	$(MAKE) merge-dml-ci-repo work-dir=$(work-dir)
+	$(MAKE) merge-dml-ci-qs work-dir=$(work-dir)
+	$(MAKE) merge-dml-ci-sysq work-dir=$(work-dir)
+	$(MAKE) merge-dml-ci-cs work-dir=$(work-dir)
 merge-dml-ci-repo:
-	make merge-dml-ci-core type="repository" work-dir=$(work-dir)
+	$(MAKE) merge-dml-ci-core type="repository" work-dir=$(work-dir)
 merge-dml-ci-qs:
-	make merge-dml-ci-core type="query_service" work-dir=$(work-dir)
+	$(MAKE) merge-dml-ci-core type="query_service" work-dir=$(work-dir)
 merge-dml-ci-sysq:
-	make merge-dml-ci-core type="system_query" work-dir=$(work-dir)
+	$(MAKE) merge-dml-ci-core type="system_query" work-dir=$(work-dir)
 merge-dml-ci-cs:
-	make merge-dml-ci-core type="command_service" work-dir=$(work-dir)
+	$(MAKE) merge-dml-ci-core type="command_service" work-dir=$(work-dir)
 merge-dml-ci-core:
 	go run ./cmd/ merge-dml --type=$(type) --work-dir=$(work-dir)

--- a/.makefiles/database/start-up.mk
+++ b/.makefiles/database/start-up.mk
@@ -5,20 +5,20 @@
 
 db-init:
 	@echo "🔄 DB初期化関連のコマンドを実行します..."
-	@make db-init-local
-	@make db-init-test
+	@$(MAKE) db-init-local
+	@$(MAKE) db-init-test
 	@echo "✅ DB初期化関連のコマンドが完了しました。"
 
 db-init-local:
 	@echo "🔄 localDBを初期化します..."
-	@make db-local-migrate-down
-	@make db-local-migrate-up
-	@make db-local-seed
+	@$(MAKE) db-local-migrate-down
+	@$(MAKE) db-local-migrate-up
+	@$(MAKE) db-local-seed
 	@echo "✅ localDBの初期化が完了しました。"
 
 db-init-test:
 	@echo "🔄 testDBを初期化します..."
-	@make db-test-migrate-down
-	@make db-test-migrate-up
-	@make db-test-seed
+	@$(MAKE) db-test-migrate-down
+	@$(MAKE) db-test-migrate-up
+	@$(MAKE) db-test-seed
 	@echo "✅ testDBの初期化が完了しました。"

--- a/.makefiles/gen/gen.mk
+++ b/.makefiles/gen/gen.mk
@@ -10,54 +10,54 @@
 
 gen:
 	@echo "🔄 各種ドキュメントやコードの生成します..."
-	@make gen-api
-	@make gen-query
-	@make gen-docs
+	@$(MAKE) gen-api
+	@$(MAKE) gen-query
+	@$(MAKE) gen-docs
 	@echo "✅ 各種ドキュメントやコードの生成が完了しました。"
 
 gen-api:
-	@make gen-bundle-oapi
-	@make gen-api-docs
-	@make gen-go-code
+	@$(MAKE) gen-bundle-oapi
+	@$(MAKE) gen-api-docs
+	@$(MAKE) gen-go-code
 
 gen-docs:
-	@make gen-portal-docs
-	@make gen-docs-json
+	@$(MAKE) gen-portal-docs
+	@$(MAKE) gen-docs-json
 
 gen-all-docs:
-	@make gen-api-docs
-	@make gen-docs
-	@make gen-db-schema
-	@make gen-test-repo
+	@$(MAKE) gen-api-docs
+	@$(MAKE) gen-docs
+	@$(MAKE) gen-db-schema
+	@$(MAKE) gen-test-repo
 
 gen-query:
 	@echo "🔄 SQLCのコードを生成します..."
-	@make dump-schema
-	@make merge-dml
-	@make gen-sqlc
-	@make fmt
+	@$(MAKE) dump-schema
+	@$(MAKE) merge-dml
+	@$(MAKE) gen-sqlc
+	@$(MAKE) fmt
 	@echo "✅ SQLCのコード生成が完了しました。"
 
 gen-query-repo:
 	@echo "🔄 ドメイン用のSQLCコードを生成します..."
-	@make dump-schema
-	@make merge-dml-repo
-	@make gen-sqlc
-	@make fmt
+	@$(MAKE) dump-schema
+	@$(MAKE) merge-dml-repo
+	@$(MAKE) gen-sqlc
+	@$(MAKE) fmt
 	@echo "✅ ドメイン用のSQLCコード生成が完了しました。"
 
 gen-query-qs:
 	@echo "🔄 クエリサービス用のSQLCコードを生成します..."
-	@make dump-schema
-	@make merge-dml-qs
-	@make gen-sqlc
-	@make fmt
+	@$(MAKE) dump-schema
+	@$(MAKE) merge-dml-qs
+	@$(MAKE) gen-sqlc
+	@$(MAKE) fmt
 	@echo "✅ クエリサービス用のSQLCコード生成が完了しました。"
 
 gen-query-sysq:
 	@echo "🔄 システムクエリ用のSQLCコードを生成します..."
-	@make dump-schema
-	@make merge-dml-sysq
-	@make gen-sqlc
-	@make fmt
+	@$(MAKE) dump-schema
+	@$(MAKE) merge-dml-sysq
+	@$(MAKE) gen-sqlc
+	@$(MAKE) fmt
 	@echo "✅ システムクエリ用のSQLCコード生成が完了しました。"

--- a/.makefiles/github/operation/setup-repository.mk
+++ b/.makefiles/github/operation/setup-repository.mk
@@ -4,7 +4,6 @@
 .PHONY: setup-replace-app-metadata ## node_tool_runnerでAPP_NAMEやOpenAPIタイトルの置換を実行
 .PHONY: setup-replace-repository-reference ## node_tool_runnerでリポジトリ参照の置換を実行
 .PHONY: setup-replace-license-copyright ## node_tool_runnerでLICENSEの著作権表示更新を実行
-.PHONY: setup-remove-debug-handlers ## node_tool_runnerでdebugハンドラ一式の削除を実行
 
 SETUP_DRY_RUN_FLAG := $(if $(DRY_RUN),--dry-run,)
 
@@ -19,7 +18,7 @@ setup-repo:
 	@echo "✅ 初期化を開始します"
 
 	@echo "🔧 ghコマンドのログインを開始します..."
-	@make gh-login
+	@$(MAKE) gh-login
 	@echo "✅ ghコマンドのログインが完了しました。"
 
 	@echo "🔧 タグの初期化を開始します..."
@@ -76,12 +75,12 @@ setup-repo:
 	@echo "✅ デフォルトブランチの設定を終了します。"
 
 	@echo "🔧 ルールセットの適用を開始します..."
-	@make apply-branch-protection
+	@$(MAKE) apply-branch-protection
 	@echo "✅ ルールセットの適用を終了します。"
 
 	@echo "🔧 ラベルの初期化を開始します..."
-	@make delete-all-labels
-	@make create-default-labels
+	@$(MAKE) delete-all-labels
+	@$(MAKE) create-default-labels
 	@echo "✅ ラベルの初期化を終了します。"
 
 	@echo "🔧 リリースノートの初期化を開始します..."
@@ -131,6 +130,3 @@ setup-replace-license-copyright:
 		--holder "$(COPYRIGHT_HOLDER)" \
 		$(if $(COPYRIGHT_YEAR),--year $(COPYRIGHT_YEAR),) \
 		$(SETUP_DRY_RUN_FLAG)
-
-setup-remove-debug-handlers:
-	@docker compose run --rm node_tool_runner node scripts/setup/remove-debug-handlers.cjs $(SETUP_DRY_RUN_FLAG)

--- a/.makefiles/go/sqlc.mk
+++ b/.makefiles/go/sqlc.mk
@@ -9,8 +9,8 @@
 
 # -----Dockerコンテナ内で実行するコマンド群-----
 gen-sqlc:
-	@make remove-generated-sqlc
-	@make sqlc-generate
+	@$(MAKE) remove-generated-sqlc
+	@$(MAKE) sqlc-generate
 
 remove-generated-sqlc:
 	@docker compose run --rm go_tool_runner make remove-generated-sqlc-ci

--- a/.makefiles/markdown/lint.mk
+++ b/.makefiles/markdown/lint.mk
@@ -14,7 +14,8 @@ md-fix:
 	@docker compose run --rm node_tool_runner make md-fix-ci
 
 # -----CI内で実行するコマンド群-----
-MD_GLOBS := "**/*.md" "#vendor/**" "#node_modules/**" "#.git/**" "#docs/portal/guides/**" "#docs/coverage/**" "#docs/db-schema/**" "#AGENTS.md"
+# markdownlint-cli2 の ignore 記法は "#glob"。Make 変数代入では # がコメント開始になるため \# でエスケープする。
+MD_GLOBS := "**/*.md" "\#vendor/**" "\#node_modules/**" "\#.git/**" "\#docs/portal/guides/**" "\#docs/coverage/**" "\#docs/db-schema/**" "\#AGENTS.md"
 
 md-lint-ci:
 	markdownlint-cli2 $(MD_GLOBS)

--- a/docs/ja/maintenance/go-upgrade.ja.md
+++ b/docs/ja/maintenance/go-upgrade.ja.md
@@ -182,7 +182,7 @@ make serve-build-clean
 ツール系コンテナ
 
 ```sh
-make tools-build-clean
+make tool-runners-build-clean
 ```
 
 ## 9. Code generation の再実行
@@ -222,7 +222,7 @@ make gen
 make test
 make lint
 make serve-build-clean
-make tools-build-clean
+make tool-runners-build-clean
 ```
 
 ## Upgrade Checklist
@@ -236,7 +236,7 @@ Go version を更新する際は以下を確認してください。
 - [ ] `make tidy-lib` 実行
 - [ ] （任意）Go モジュール依存を更新するか判断。更新する場合は `go get -u[=patch] ./...` + `make tidy-lib` 実行（`go` directive は据え置き）
 - [ ] `make install-tools` 実行
-- [ ] Docker コンテナ再ビルド（`make serve-build-clean`, `make tools-build-clean`）
+- [ ] Docker コンテナ再ビルド（`make serve-build-clean`, `make tool-runners-build-clean`）
 - [ ] code generation 再実行
 - [ ] test 実行
 - [ ] lint 実行

--- a/docs/maintenance/go-upgrade.md
+++ b/docs/maintenance/go-upgrade.md
@@ -174,7 +174,7 @@ make serve-build-clean
 Tool containers
 
 ```sh
-make tools-build-clean
+make tool-runners-build-clean
 ```
 
 ## 9. Re-run code generation
@@ -214,7 +214,7 @@ make gen
 make test
 make lint
 make serve-build-clean
-make tools-build-clean
+make tool-runners-build-clean
 ```
 
 ## Upgrade Checklist
@@ -228,7 +228,7 @@ When updating the Go version, check the following.
 - [ ] Run `make tidy-lib`
 - [ ] (Optional) Decide whether to update Go module dependencies; if yes, run `go get -u[=patch] ./...` + `make tidy-lib` (keep the `go` directive unchanged)
 - [ ] Run `make install-tools`
-- [ ] Rebuild Docker containers (`make serve-build-clean`, `make tools-build-clean`)
+- [ ] Rebuild Docker containers (`make serve-build-clean`, `make tool-runners-build-clean`)
 - [ ] Re-run code generation
 - [ ] Run test
 - [ ] Run lint

--- a/docs/portal/guides/ja/make.ja.md
+++ b/docs/portal/guides/ja/make.ja.md
@@ -45,9 +45,8 @@ Make ターゲットは主に以下の単位で整理されています。
 | `make serve-build` | Docker イメージをキャッシュを利用して再ビルドしたうえで開発環境を起動します。 | Dockerfile や依存変更の反映 |
 | `make serve-build-clean` | `--no-cache --pull` でクリーンビルドしたうえで開発環境を起動します。 | base image 更新の取り込み（例: Go バージョンアップ） |
 | `make tools` | `tools` プロファイルの開発支援ツール群を起動します。 | 開発ツール利用時 |
-| `make tools-build` | 開発用ツールコンテナをキャッシュを利用してビルドします（起動はしません）。 | ツールコンテナの Dockerfile や依存変更の反映 |
-| `make tools-build-clean` | 開発用ツールコンテナを `--no-cache --pull` 付きでクリーンビルドします（起動はしません）。 | ツールコンテナの base image 更新の取り込み |
-| `make smoke` | `smoke` プロファイルの `smoke_server` をビルド付きで起動します。 | Smoke Test 環境の確認 |
+| `make tool-runners-build` | オンデマンド実行のツールランナー画像(go/node/python)をキャッシュ利用でビルドします（起動はしません）。 | ツールランナーの Dockerfile や依存変更の反映 |
+| `make tool-runners-build-clean` | ツールランナー画像を `--no-cache --pull` 付きでクリーンビルドします（起動はしません）。 | ツールランナーの base image 更新の取り込み |
 
 #### `make job NAME=<job名> ARGS="<引数>"`
 
@@ -308,7 +307,6 @@ CI のセキュリティ指摘をローカルで再現するための Trivy 依�
 | `make setup-replace-app-metadata APP_NAME=<name> OPENAPI_TITLE=<title> COPILOT_TITLE=<title>` | アプリケーション名や OpenAPI タイトルなどのメタデータを一括置換します。 | README や OpenAPI 定義などに反映されます。 |
 | `make setup-replace-repository-reference REPOSITORY=<org/repo>` | リポジトリ参照（GitHub URL など）を一括置換します。 | README やドキュメント内のリンクを更新します。 |
 | `make setup-replace-license-copyright COPYRIGHT_HOLDER=<name> [COPYRIGHT_YEAR=<year>]` | LICENSE の著作権表記を更新します。 | 年は省略可能です。 |
-| `make setup-remove-debug-handlers` | Debug 用ハンドラ一式を削除します。 | 本番利用時の不要コード削除に使用します。 |
 
 ### リリースブランチ関連
 

--- a/docs/portal/guides/make.md
+++ b/docs/portal/guides/make.md
@@ -45,9 +45,8 @@ This is a group of targets related to application development environment startu
 | `make serve-build` | Rebuilds Docker images (cache enabled) and then starts the development environment. | Reflect Dockerfile or dependency changes |
 | `make serve-build-clean` | Cleanly rebuilds Docker images with `--no-cache --pull` and then starts the development environment. | Pick up base image updates (e.g., Go version upgrade) |
 | `make tools` | Starts development support tools with the `tools` profile. | When using development tools |
-| `make tools-build` | Builds development tool containers (cache enabled, no startup). | When updating tool container Dockerfile or dependencies |
-| `make tools-build-clean` | Cleanly builds development tool containers with `--no-cache --pull` (no startup). | Pick up base image updates for tool containers |
-| `make smoke` | Starts `smoke_server` with build under the `smoke` profile. | Verify Smoke Test environment |
+| `make tool-runners-build` | Builds the on-demand tool runner images (go/node/python, cache enabled, no startup). | When updating tool runner Dockerfile or dependencies |
+| `make tool-runners-build-clean` | Cleanly builds the tool runner images with `--no-cache --pull` (no startup). | Pick up base image updates for tool runners |
 
 #### `make job NAME=<job_name> ARGS="<arguments>"`
 
@@ -308,7 +307,6 @@ This is an initial setup command when launching a new repository as a boilerplat
 | `make setup-replace-app-metadata APP_NAME=<name> OPENAPI_TITLE=<title> COPILOT_TITLE=<title>` | Replaces application name and OpenAPI title in batch. | Reflected in README and OpenAPI definitions. |
 | `make setup-replace-repository-reference REPOSITORY=<org/repo>` | Replaces repository references (GitHub URLs, etc.) in batch. | Updates links in README and documentation. |
 | `make setup-replace-license-copyright COPYRIGHT_HOLDER=<name> [COPYRIGHT_YEAR=<year>]` | Updates LICENSE copyright notation. | Year is optional. |
-| `make setup-remove-debug-handlers` | Removes debug handler set. | Used to remove unnecessary code for production use. |
 
 ### Release branch related
 


### PR DESCRIPTION
# 概要

reviews-config 第3ラウンドの makefiles カテゴリ（M1/M2）＋作業中に発見した md-lint 回帰の修正。

## 変更内容

- host 再帰 make 54箇所を `@make→@$(MAKE)` / 行頭 `make→$(MAKE)` に統一（jobserver 共有・`make -n` でサブ make も正しくプレビュー）。コンテナ内 make は対象外
- `setup-repository.mk`: 撤去済み debug サンプル向け `setup-remove-debug-handlers` ターゲット/.PHONY を削除
- **Fix（回帰）**: `make md-lint`/`md-fix` の `MD_GLOBS` の `#` が Make コメント化で壊れていた件を `\#` エスケープで修正
- `tools-build*`→`tool-runners-build*` 改名（`tools`=補助常駐サービス起動 と `tools-build`=オンデマンド runner 画像ビルド が互いに素なため誤読を解消）。README・go-upgrade 手順/スキル・portal を更新
- 削除済み `smoke` ターゲットの stale 行を README から除去

## 動作確認方法

- `make help` 全 parse・`make -n`（merge-dml-ci/gen-all-docs/db-init）で `$(MAKE)` 再帰展開・`make md-lint` 復旧（MD_GLOBS 完全展開）を確認済み