### PR TITLE
Fix: SchemaSpy の行数統計を無効化し auto-docs の差分ループを停止

### DIFF
--- a/docker/database/schemaspy/schemaspy-ci.properties
+++ b/docker/database/schemaspy/schemaspy-ci.properties
@@ -10,3 +10,5 @@ schemaspy.db=test
 schemaspy.schema=public
 # 出力先ディレクトリ
 schemaspy.outputDir=/output
+# 行数統計は pg 統計の更新タイミングで揺れるため出力しない
+schemaspy.norows=true

--- a/docker/database/schemaspy/schemaspy.properties
+++ b/docker/database/schemaspy/schemaspy.properties
@@ -10,3 +10,5 @@ schemaspy.db=local
 schemaspy.schema=public
 # 出力先ディレクトリ
 schemaspy.outputDir=/output
+# 行数統計は pg 統計の更新タイミングで揺れるため出力しない
+schemaspy.norows=true


### PR DESCRIPTION
## 背景 / 問題

`auto-generate-docs` ワークフローから #348 のような **同内容の docs 同期 PR が定期的に量産** されていた。

原因は ER 図生成ツール SchemaSpy が出力に焼き込む **行数統計 `numRows`** が、PostgreSQL の統計更新（ANALYZE / autovacuum）のタイミング次第で `-1` ↔ 空 ↔ 実数（例: `100`）の間で揺れていたこと。この値が以下の生成物に入り込み、ソース無変更でも毎回差分が出ていた:

- `docs/db-schema/test.public.xml`
- `docs/db-schema/tables/*.html`
- `docs/db-schema/diagrams/**/*.dot`（＋再生成される `.png`）

これらは `Detect changes` ステップの除外リストに無いため、毎回 `has_diff=true` を立て PR を生成していた。

## 変更

- `docker/database/schemaspy/schemaspy.properties`（ローカル）
- `docker/database/schemaspy/schemaspy-ci.properties`（CI）

の双方に `schemaspy.norows=true` を追加し、行数統計を出力から除外してゆらぎの発生源を断つ。`-norows` / `schemaspy.norows` は SchemaSpy の正規オプション。

タイムスタンプ系の差分（`Generated on` / `date=`）は `index.html`・`info-html.txt` のみに出ており、これらは既に `Detect changes` の除外リストに入っているため対象外。

## マージ後の挙動

次回 `release/**` への push 時に、**既存コミット済みの `numRows` を除去する正規化 PR が一度だけ** 上がる。それをマージ後は `docs/db-schema/**` の生成物が安定し、同種の自動 PR は発生しなくなる。

## 検証

- ✅ `norows` が SchemaSpy の有効オプションであることを確認（`docker run --rm schemaspy/schemaspy:latest -?`）
- ⚠️ 実生成による確認はローカルに CI 同等の seed 済み `test` DB が無く未実施。`docs/db-schema/**` は生成物のため手編集は行っていない（CI 側の生成に委ねる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)