### PR TITLE
Docs: v1.3.0 のリリースノートを追加

### DIFF
--- a/.github/release/v1.3.0.md
+++ b/.github/release/v1.3.0.md
@@ -1,0 +1,109 @@
+<!-- markdownlint-disable MD041 -->
+## 概要
+
+`v1.2.0` を起点としたマイナーリリースです。
+新機能の追加よりも、リポジトリ全体を対象とした品質レビュー（full-verify / full-apply）に基づく内部実装の是正と、開発ツールチェーン・CI・Docker・スクリプト基盤の堅牢化を中心に据えています。
+全レイヤ（domain / usecase / controller / infrastructure / di / config / cli / logging / observability / apperror / pkg）の実装とコメント・命名・エラー分類を実体へ追従させつつ、HTTP ステータス分類やリソースリークなど挙動に関わる不具合も併せて修正しました。
+
+変更規模は以下です。
+
+- `343` コミット
+- `588` ファイル変更
+- `+20,668 / -16,462`
+
+## 変更内容
+
+### 新機能・改善
+
+#### リポジトリ全体の品質レビュー（full-review）
+
+- `internal/` 全レイヤを対象に、命名・可視性・コメント・エラーラップ方針を実体へ統一しました。
+  - エラーラップを `xerrors.Wrap` に統一し、cli / config / infra 各層で文脈付与漏れを解消（`99ca3e1`、`2acc69e`、`08cbd3b`、`d6bd911`）。
+  - di モジュールの Pre/Use 二重化解消・ライフサイクルフックの命名/責務整理・`fxevent.Logger` による fx ライフサイクルログの構造化ロガー連携を追加（`b22787e`、`f4f194e`、`5b17ed1` ほか）。
+  - infrastructure 層で `loggingdb` の span 名再計算・caller 段差・DSN 組み立ての往復を解消し、`DBProvider` を単一メソッドへ縮小して service locator 結合を排除（`673bf0e`、`4a19d6a`、`c5cd392`）。
+  - usecase 層で user 検索の DTO 入出力分離・フィルタ構築集約・nil ガード追加、一覧+総件数の合成を usecase へ寄せて handler を単一委譲に整理（`0e0b5af`、`ec9853a`）。
+  - pkg 群（`datetime` / `stringkit` / `safecast` / `uuid` / `xerrors` / `fnmeta` ほか）の命名・コメント・境界引数を是正し、`xerrors.Errors` を具象実装＋mock で抽象化（`3898f2f` ほか）。
+- 冗長な内部説明コメントを全体的に削減し、godoc を振る舞いの記述へ限定しました（`c105f20`、`1d2582c`、`75a6a45` ほか）。
+
+#### cli 層の純コア化とテスト網羅
+
+- Cobra と実依存の結線を `cmd/`（package main）へ集約し、`internal/cli/*` を純粋・テスト可能なコアへ分離しました（`1b83bc8`）。
+- FS / 外部プロセス操作を継ぎ目（インターフェース）付きで抽出し、gomock 生成モックで密閉した分岐網羅テストを追加（`08a3789`、`e6a13e2`、`e73a62e`）。
+- `migrate` コマンドの `--version` を相対ステップ意味論の `--steps` へ改名し、テスト可能化しました（`6986acf`、`674c31c`）。
+- テストゲートの計測対象に `internal/cli/*` を追加し、カバレッジ計測を開放しました（`e00c942`、`a868e9a`）。
+
+#### スクリプト基盤の ESM 正規パッケージ化
+
+- `scripts/` 配下を ESM 正規パッケージ化し、in-tree 解決へ移行しました。`make help` も `make_help.sh` から `make_help.mjs` の node 実行へ置換（`ed92acf`、`a665f9c`）。
+- 引数パースを `commander`、manifest 検証を `zod` に置換し、宣言的・堅牢化しました（`22778ac`、`6ee22b8`）。
+- commit-msg 検証を `commitlint`（`mise exec` 経由）に置換し、pre-commit / pre-push フックを再編しました（`93cc23b`、`4545235`、`4feeb21`）。
+- tools の node 依存に lockfile と `npm ci` を導入し、`mise` / `js-yaml` を版固定して再現性を確保しました（`48aed4b`、`04dd522`）。
+
+#### CI / Docker の堅牢化
+
+- GitHub Actions の生成物ドリフト検知漏れ・過剰トリガ・PR コメント投稿の失敗耐性を是正し、`image-scan` のコメント upsert を共有 action へ集約しました（`bd996da`、`faa9d59`、`f8f2ae9`）。
+- `deploy-app` の build matrix 化・concurrency 分離・バージョン採番不具合を是正、`deploy-docs` に Pages デプロイの environment / concurrency を追加しました（`54a2732`、`8281593`、`57c7824`）。
+- server イメージを per-env 化して env 焼き込みを対象環境のみに絞り、buildx の `TARGETARCH` に追従させました（`dd8bd79`、`9e8a81d`）。
+- 再帰 make を `$(MAKE)` へ統一し、デッドターゲット/変数の除去と SchemaSpy 行数統計の無効化により auto-docs の差分ループを停止しました（`d4d6aac`、`42dc5c9`）。
+
+#### その他の改善
+
+- ボイラープレートから debug / cookie 系のサンプルエンドポイントを撤去しました（`0c85fdc` ほか／詳細は補足参照）。
+- 既存コード向けユニットテスト生成スキル `scaffold-test` と、テストファイル品質レビュースキル `test-review` を追加しました（`171c844`、`c55d33b`）。
+- 正常系 / 異常系の外殻統一規約を全パッケージのテストへ適用しました（`254c70e`）。
+
+#### ドキュメント整備
+
+- domain README に `apperror` 依存許可・`context.Context` の Repository IF 署名限定許可・pkg の役割境界を明文化しました（`14b930a`、`7785d13`、`4539cd6`）。
+- usecase / infra / di の README・spec を改名後の実体へ追従させ、handler 単一委譲 / usecase 合成パターンを明記しました（`c85a1ba`、`cea79da`、`6a6acb3`）。
+- `rules.md` の Repository / QueryService 責務定義を CQRS 実態へ是正しました（`fbc9a04`）。
+
+## 動作確認手順
+
+1. `make gen-api`
+2. `make gen-query`
+3. `make lint`
+4. `make test`（`internal/cli/*` を含むカバレッジが計測されること）
+5. `make help` が node（`make_help.mjs`）経由で正しくヘルプを出力すること
+6. コミット時に `commitlint` による commit-msg 検証が働くこと
+7. `internal/cli` 各コマンド（`migrate --steps`、`db-seed`、`merge-dml`、`dump-schema`、`server`、`job`）が想定どおり動作すること
+8. HTTP エラー分類の確認:
+    - 既存ユーザーの prefecture 未解決時に `500 (ErrInternal)` が返ること
+    - クライアント切断時に `499` が記録されること
+    - `ErrAuthnSlotNotFound` 系が `401` に分類されること
+9. パニック発生時に本番環境でもランタイムスタックがログ捕捉され、`500` が返ること
+
+## 影響（想定されるメリット／注意点）
+
+- ✅ 全レイヤの命名・エラーラップ・コメントが実体へ揃い、コードベースの一貫性と AI エージェントによる参照精度が向上します。
+- ✅ `internal/cli/*` の純コア化により、CLI コマンドの分岐がユニットテストで網羅され、回帰検知が容易になりました。
+- ✅ スクリプトの ESM 正規パッケージ化と lockfile / `npm ci` 導入により、ツール実行の再現性が向上します。
+- ✅ HTTP ステータス分類の是正により、クライアント切断・内部エラー・認証失敗が適切なコードで観測できるようになりました。
+- ✅ ジョブ / グレースフルシャットダウン / トランザクションのリソースリークおよび context キャンセル巻き込みが解消されました。
+- ⚠️ `migrate` コマンドの `--version` は `--steps`（相対ステップ意味論）へ改名されています。既存の呼び出しは更新が必要です。
+- ⚠️ debug / cookie 系のサンプルエンドポイントが撤去されています。これらに依存していた検証手順は使用できません。
+- ⚠️ commit-msg 検証が `commitlint` に置き換わったため、規約外のコミットメッセージは拒否されます。
+
+## 追加ライブラリ
+
+- Go 依存の追加はありません。`gorilla/websocket` は debug / cookie サンプル撤去に伴い直接依存から除外され、`labstack/gommon` は indirect へ移動しました。
+- node ツールチェーン側で `commander` / `zod` / `commitlint` を採用し、`docker/tools` に `package-lock.json` を追加しています（リポジトリ運用ツール用途であり、アプリ実行時依存ではありません）。
+
+## 不具合修正
+
+- 既存ユーザーの prefecture 未解決を `404` でなく `500 (ErrInternal)` に分類するよう是正しました（`742220f`）。
+- クライアント切断（`context.Canceled`）を `503` でなく `499` に分類するよう是正しました（`968d54e`）。
+- `ErrAuthnSlotNotFound` を `401` に寄せ、認証失敗の分類を是正しました（`48d5962`）。
+- パニック時に本番でもランタイムスタックをログ捕捉しつつ、`500` を返しログ二重化を防ぐよう是正しました（`568ef95`、`5d2eb9b`、`d272fde`）。
+- HTTP リクエストログの `event_type` 誤分類、および `logging.Build` 失敗時に中身 nil の Logger を返す不具合を修正しました（`c373e1c`、`77e947a`）。
+- ヘルスチェック応答キーの英語誤記 `responsed` を `responded` に是正しました（`cf9e6db`）。
+- `pgerror` の接続不能検出を拡張し、正規化の冪等性を確保しました（`ab292ff`）。
+- テスト失敗時（Goexit）のトランザクション接続リーク、auth boundary の不変性リーク・トークン検証を是正しました（`03726c2`、`d29af4e`）。
+- cli / ジョブ系: `db-seed` の SQL 実行エラー握り潰し、補助メトリクスサーバー起動失敗時の panic、ジョブのタイムアウト経路での context 巻き込み、`merge-dml` の入出力パス基点を是正しました（`7079d35`、`c7ef752`、`4a10247`、`52ae950`、`4fcdba8`）。
+- セキュリティ: `psql` / `pg_dump` の資格情報をプロセス引数から外し `PGPASSWORD` 経由へ、`setup-postgres` のスクリプトインジェクション、runtime イメージのベース CVE を是正しました（`69a6188`、`4c9400c`、`e6f33cb`）。
+
+## 補足・備考
+
+- 本リリースでは実 API（`v1/users` など）の OpenAPI スキーマに破壊的変更はありません。撤去した debug / cookie エンドポイントはボイラープレート同梱のサンプルであり、実機能ではありません。
+- 多数の `chore(docs): auto update docs [skip ci]` コミットは、各レビュー PR マージ後にドキュメント自動生成ワークフローが生成した差分です。本リリースで SchemaSpy の行数統計出力を無効化し、auto-docs の差分ループを停止しています（`42dc5c9`）。
+- 本リリースは `release/v1.3.0` ブランチを起点に、通常のリリースフロー（feature → release → production）に従って取り込みます。


### PR DESCRIPTION
# 概要

`v1.2.0` → `v1.3.0` のリリースノート `.github/release/v1.3.0.md` を追加します。

このリリースは、リポジトリ全体を対象とした品質レビュー（full-verify / full-apply）に基づく内部実装の是正と、開発ツールチェーン・CI・Docker・スクリプト基盤の堅牢化が主軸です。リリースノートは既存の `v1.1.0` 形式（概要 / 変更内容 / 動作確認手順 / 影響 / 追加ライブラリ / 不具合修正 / 補足）に揃えてあります。

## 変更内容

- `.github/release/v1.3.0.md` を新規追加（109 行）。`v1.2.0..` の 343 コミット / 588 ファイル変更を以下のテーマで整理:
  - 全レイヤの品質レビュー（命名・可視性・エラーラップ統一、di / infra / usecase / pkg の是正）
  - cli 層の純コア化（`cmd/` と `internal/cli/*` 分離）とテスト網羅
  - スクリプト基盤の ESM 正規パッケージ化（zod / commander / commitlint）
  - CI / Docker の堅牢化、debug/cookie サンプル撤去、新スキル追加
  - HTTP ステータス分類・リソースリーク等の不具合修正
- 実装・設定コードの変更は含みません（ドキュメント追加のみ）。

## 動作確認方法

1. `.github/release/v1.3.0.md` の内容が `v1.1.0.md` のセクション構成に沿っていること
2. `make md-lint` で当該ファイルが lint クリーンであること（確認済み: 0 error）
3. コミット数 / ファイル変更数 / 不具合修正の記載が `git log v1.2.0..` と整合していること

## 補足

- 規模・不具合修正の集計はリリースノート作成時点（`v1.2.0..` の release ブランチ tip）に基づきます。以降の auto-docs 自動更新コミット（`[skip ci]`）は集計の本質に影響しません。
- 実 API（`v1/users` 等）の OpenAPI スキーマに破壊的変更はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)