### PR TITLE
サンプルAPI削除を自動化するスクリプトと make ターゲットを追加

### DIFF
--- a/.makefiles/README.ja.md
+++ b/.makefiles/README.ja.md
@@ -307,6 +307,7 @@ CI のセキュリティ指摘をローカルで再現するための Trivy 依�
 | `make setup-replace-app-metadata APP_NAME=<name> OPENAPI_TITLE=<title> COPILOT_TITLE=<title>` | アプリケーション名や OpenAPI タイトルなどのメタデータを一括置換します。 | README や OpenAPI 定義などに反映されます。 |
 | `make setup-replace-repository-reference REPOSITORY=<org/repo>` | リポジトリ参照（GitHub URL など）を一括置換します。 | README やドキュメント内のリンクを更新します。 |
 | `make setup-replace-license-copyright COPYRIGHT_HOLDER=<name> [COPYRIGHT_YEAR=<year>]` | LICENSE の著作権表記を更新します。 | 年は省略可能です。 |
+| `make setup-remove-sample-api` | サンプルAPI(`user`/`product`/`order`)を一括削除します。 | `node_tool_runner` で削除後、`gen-api` → `gen-query` → `fix` → `lint` を実行します。`DRY_RUN=1` で変更せずプレビューできます。 |
 
 ### リリースブランチ関連
 

--- a/.makefiles/README.ja.md
+++ b/.makefiles/README.ja.md
@@ -307,7 +307,7 @@ CI のセキュリティ指摘をローカルで再現するための Trivy 依�
 | `make setup-replace-app-metadata APP_NAME=<name> OPENAPI_TITLE=<title> COPILOT_TITLE=<title>` | アプリケーション名や OpenAPI タイトルなどのメタデータを一括置換します。 | README や OpenAPI 定義などに反映されます。 |
 | `make setup-replace-repository-reference REPOSITORY=<org/repo>` | リポジトリ参照（GitHub URL など）を一括置換します。 | README やドキュメント内のリンクを更新します。 |
 | `make setup-replace-license-copyright COPYRIGHT_HOLDER=<name> [COPYRIGHT_YEAR=<year>]` | LICENSE の著作権表記を更新します。 | 年は省略可能です。 |
-| `make setup-remove-sample-api` | サンプルAPI(`user`/`product`/`order`)を一括削除します。 | `node_tool_runner` で削除後、`gen-api` → `gen-query` → `fix` → `lint` を実行します。`DRY_RUN=1` で変更せずプレビューできます。 |
+| `make setup-remove-sample-api` | サンプルAPI(`user`/`product`/`order`)を一括削除します。 | `node_tool_runner` で削除後、`gen-api` → `gen-query` → `fix` → `lint` を実行します。**DB コンテナ(`database`)の起動が必要**（`gen-query` がライブスキーマをダンプ）。削除後は `make db-init-local db-init-test && make gen-query` で再構築し、削除済みテーブルが生成モデルに残らないようにします。`DRY_RUN=1` で変更せずプレビューできます。 |
 
 ### リリースブランチ関連
 

--- a/.makefiles/README.ja.md
+++ b/.makefiles/README.ja.md
@@ -307,7 +307,7 @@ CI のセキュリティ指摘をローカルで再現するための Trivy 依�
 | `make setup-replace-app-metadata APP_NAME=<name> OPENAPI_TITLE=<title> COPILOT_TITLE=<title>` | アプリケーション名や OpenAPI タイトルなどのメタデータを一括置換します。 | README や OpenAPI 定義などに反映されます。 |
 | `make setup-replace-repository-reference REPOSITORY=<org/repo>` | リポジトリ参照（GitHub URL など）を一括置換します。 | README やドキュメント内のリンクを更新します。 |
 | `make setup-replace-license-copyright COPYRIGHT_HOLDER=<name> [COPYRIGHT_YEAR=<year>]` | LICENSE の著作権表記を更新します。 | 年は省略可能です。 |
-| `make setup-remove-sample-api` | サンプルAPI(`user`/`product`/`order`)を一括削除します。 | `node_tool_runner` で削除後、`gen-api` → `gen-query` → `fix` → `lint` を実行します。**DB コンテナ(`database`)の起動が必要**（`gen-query` がライブスキーマをダンプ）。削除後は `make db-init-local db-init-test && make gen-query` で再構築し、削除済みテーブルが生成モデルに残らないようにします。`DRY_RUN=1` で変更せずプレビューできます。 |
+| `make setup-remove-sample-api` | サンプルAPI(`user`/`product`/`order`)を一括削除します。 | `node_tool_runner` で削除後、`gen-api` → `gen-query` → `fix` → `lint` を実行します。**DB コンテナ(`database`)の起動が必要**（`gen-query` がライブスキーマをダンプ）。削除後は `make db-init-local db-init-test && make gen-query` で再構築し、削除済みテーブルが生成モデルに残らないようにします。`DRY_RUN=1` で変更せずプレビューできます（`0` を含む空でない値はすべてプレビュー扱いになるため、実行時は変数自体を付けません）。 |
 
 ### リリースブランチ関連
 

--- a/.makefiles/README.md
+++ b/.makefiles/README.md
@@ -307,6 +307,7 @@ This is an initial setup command when launching a new repository as a boilerplat
 | `make setup-replace-app-metadata APP_NAME=<name> OPENAPI_TITLE=<title> COPILOT_TITLE=<title>` | Replaces application name and OpenAPI title in batch. | Reflected in README and OpenAPI definitions. |
 | `make setup-replace-repository-reference REPOSITORY=<org/repo>` | Replaces repository references (GitHub URLs, etc.) in batch. | Updates links in README and documentation. |
 | `make setup-replace-license-copyright COPYRIGHT_HOLDER=<name> [COPYRIGHT_YEAR=<year>]` | Updates LICENSE copyright notation. | Year is optional. |
+| `make setup-remove-sample-api` | Removes the sample API (`user`/`product`/`order`) in batch. | Deletes via `node_tool_runner`, then runs `gen-api` → `gen-query` → `fix` → `lint`. Use `DRY_RUN=1` to preview without changes. |
 
 ### Release branch related
 

--- a/.makefiles/README.md
+++ b/.makefiles/README.md
@@ -307,7 +307,7 @@ This is an initial setup command when launching a new repository as a boilerplat
 | `make setup-replace-app-metadata APP_NAME=<name> OPENAPI_TITLE=<title> COPILOT_TITLE=<title>` | Replaces application name and OpenAPI title in batch. | Reflected in README and OpenAPI definitions. |
 | `make setup-replace-repository-reference REPOSITORY=<org/repo>` | Replaces repository references (GitHub URLs, etc.) in batch. | Updates links in README and documentation. |
 | `make setup-replace-license-copyright COPYRIGHT_HOLDER=<name> [COPYRIGHT_YEAR=<year>]` | Updates LICENSE copyright notation. | Year is optional. |
-| `make setup-remove-sample-api` | Removes the sample API (`user`/`product`/`order`) in batch. | Deletes via `node_tool_runner`, then runs `gen-api` → `gen-query` → `fix` → `lint`. **Requires the DB container (`database`) running** (`gen-query` dumps the live schema). After removal, rebuild with `make db-init-local db-init-test && make gen-query` so dropped tables don't linger in generated models. Use `DRY_RUN=1` to preview without changes. |
+| `make setup-remove-sample-api` | Removes the sample API (`user`/`product`/`order`) in batch. | Deletes via `node_tool_runner`, then runs `gen-api` → `gen-query` → `fix` → `lint`. **Requires the DB container (`database`) running** (`gen-query` dumps the live schema). After removal, rebuild with `make db-init-local db-init-test && make gen-query` so dropped tables don't linger in generated models. Use `DRY_RUN=1` to preview without changes — any non-empty value (including `0`) enables preview, so omit the variable to actually run. |
 
 ### Release branch related
 

--- a/.makefiles/README.md
+++ b/.makefiles/README.md
@@ -307,7 +307,7 @@ This is an initial setup command when launching a new repository as a boilerplat
 | `make setup-replace-app-metadata APP_NAME=<name> OPENAPI_TITLE=<title> COPILOT_TITLE=<title>` | Replaces application name and OpenAPI title in batch. | Reflected in README and OpenAPI definitions. |
 | `make setup-replace-repository-reference REPOSITORY=<org/repo>` | Replaces repository references (GitHub URLs, etc.) in batch. | Updates links in README and documentation. |
 | `make setup-replace-license-copyright COPYRIGHT_HOLDER=<name> [COPYRIGHT_YEAR=<year>]` | Updates LICENSE copyright notation. | Year is optional. |
-| `make setup-remove-sample-api` | Removes the sample API (`user`/`product`/`order`) in batch. | Deletes via `node_tool_runner`, then runs `gen-api` → `gen-query` → `fix` → `lint`. Use `DRY_RUN=1` to preview without changes. |
+| `make setup-remove-sample-api` | Removes the sample API (`user`/`product`/`order`) in batch. | Deletes via `node_tool_runner`, then runs `gen-api` → `gen-query` → `fix` → `lint`. **Requires the DB container (`database`) running** (`gen-query` dumps the live schema). After removal, rebuild with `make db-init-local db-init-test && make gen-query` so dropped tables don't linger in generated models. Use `DRY_RUN=1` to preview without changes. |
 
 ### Release branch related
 

--- a/.makefiles/github/operation/setup-repository.mk
+++ b/.makefiles/github/operation/setup-repository.mk
@@ -4,6 +4,7 @@
 .PHONY: setup-replace-app-metadata ## node_tool_runnerでAPP_NAMEやOpenAPIタイトルの置換を実行
 .PHONY: setup-replace-repository-reference ## node_tool_runnerでリポジトリ参照の置換を実行
 .PHONY: setup-replace-license-copyright ## node_tool_runnerでLICENSEの著作権表示更新を実行
+.PHONY: setup-remove-sample-api ## サンプルAPI(user/product/order)を一括削除し再生成・検証まで実行
 
 SETUP_DRY_RUN_FLAG := $(if $(DRY_RUN),--dry-run,)
 
@@ -130,3 +131,16 @@ setup-replace-license-copyright:
 		--holder "$(COPYRIGHT_HOLDER)" \
 		$(if $(COPYRIGHT_YEAR),--year $(COPYRIGHT_YEAR),) \
 		$(SETUP_DRY_RUN_FLAG)
+
+# サンプルAPIの削除はコンテナ内（node_tool_runner）で行い、削除後の再生成・整形・検証は
+# Go ツールチェーンが必要なためホスト側の make ターゲットを連鎖させる。
+# プレビューは DRY_RUN=1 を付ける（削除も再生成も行わない）。
+setup-remove-sample-api:
+	@docker compose run --rm node_tool_runner node scripts/setup/remove-sample-api.mjs $(SETUP_DRY_RUN_FLAG)
+	@if [ -n "$(DRY_RUN)" ]; then \
+		echo "🟡 DRY_RUN のため再生成・整形・検証はスキップしました。"; \
+	else \
+		echo "🔧 再生成・整形・検証を実行します..."; \
+		$(MAKE) gen-api gen-query fix lint; \
+		echo "✅ サンプルAPIの削除と再生成・検証が完了しました。"; \
+	fi

--- a/docs/ja/maintenance/setup-repository.ja.md
+++ b/docs/ja/maintenance/setup-repository.ja.md
@@ -166,17 +166,28 @@ AI駆動開発を活用する場合は、サンプルAPIを残しておくと、
 
 自動コマンドを使用します。[scripts/setup/lib/sample-api.mjs](scripts/setup/lib/sample-api.mjs) に宣言されたサンプルAPI（`user` / `product` / `order`）を削除し、共有ファイル（DI 4 モジュール＋ `openapi.yaml`）の `sample-api` マーカーブロックを除去したうえで、再生成・整形・Lint まで実行します。
 
+> 実行前に **DB コンテナが起動している必要があります** — 末尾の `gen-query` は `pg_dump` で**ライブ**スキーマをダンプするため、DB 停止状態では `connection refused` で失敗します。
+
 ```bash
+# 0. DB コンテナを起動（gen-query がライブスキーマをダンプするため）
+docker compose up -d database
+
 # 削除内容のプレビュー（変更は行いません）
 DRY_RUN=1 make setup-remove-sample-api
 
-# 削除して再生成・整形・Lint（make gen-api → gen-query → fix → lint を実行）
+# サンプル削除（ファイル削除＋マーカー除去 → gen-api → gen-query → fix → lint）
 make setup-remove-sample-api
+
+# サンプル削除後のマイグレーション集合で DB を再構築しスキーマを再ダンプ
+# （削除済みの users テーブルが models.gen.go に残らないようにする）
+make db-init-local db-init-test
+make gen-query
 ```
 
 補足:
 
 - 基盤マスタデータ `prefecture`（マイグレーション `000001` など）は**残します**。
+- `gen-query` は**ライブ** DB の `pg_dump` から Go モデルを再生成します。上記の DB 再構築を省くと、残存する `users` テーブルが再ダンプされ `models.gen.go` に古い `Users` 型が再生成されます。再構築＋再 `gen-query` が実際に型を消す手順です。
 - 共有生成物（`*.gen.go` / `openapi.gen.yaml` など）は直接削除せず、再生成ステップで更新されます。
 - サンプルは3ドメイン構成です。`user` はフルスタック、`product` / `order` は現状 DB スタブ（マイグレーション＋商品 seed）のみです。`product` / `order` を本格的な API に拡張したら、`sample-api.mjs` の該当ドメインブロックに新しいパスを追記し、共有ファイル内に混在するサンプル行を `// sample-api:begin` … `// sample-api:end`（または行末の `// sample-api:line`）で囲んでください。同じコマンドで自動的に削除対象に含まれます。
 

--- a/docs/ja/maintenance/setup-repository.ja.md
+++ b/docs/ja/maintenance/setup-repository.ja.md
@@ -164,6 +164,25 @@ AI駆動開発を活用する場合は、サンプルAPIを残しておくと、
 
 ### 削除手順
 
+自動コマンドを使用します。[scripts/setup/lib/sample-api.mjs](scripts/setup/lib/sample-api.mjs) に宣言されたサンプルAPI（`user` / `product` / `order`）を削除し、共有ファイル（DI 4 モジュール＋ `openapi.yaml`）の `sample-api` マーカーブロックを除去したうえで、再生成・整形・Lint まで実行します。
+
+```bash
+# 削除内容のプレビュー（変更は行いません）
+DRY_RUN=1 make setup-remove-sample-api
+
+# 削除して再生成・整形・Lint（make gen-api → gen-query → fix → lint を実行）
+make setup-remove-sample-api
+```
+
+補足:
+
+- 基盤マスタデータ `prefecture`（マイグレーション `000001` など）は**残します**。
+- 共有生成物（`*.gen.go` / `openapi.gen.yaml` など）は直接削除せず、再生成ステップで更新されます。
+- サンプルは3ドメイン構成です。`user` はフルスタック、`product` / `order` は現状 DB スタブ（マイグレーション＋商品 seed）のみです。`product` / `order` を本格的な API に拡張したら、`sample-api.mjs` の該当ドメインブロックに新しいパスを追記し、共有ファイル内に混在するサンプル行を `// sample-api:begin` … `// sample-api:end`（または行末の `// sample-api:line`）で囲んでください。同じコマンドで自動的に削除対象に含まれます。
+
+<details>
+<summary>手動手順（参考・現在は不要）</summary>
+
 1. [openapi.yaml](openapi/openapi.yaml) のサンプルAPI定義の削除
     - `サンプルAPI用のパス` の下に書かれているPath定義を削除し、そのリンク先のyamlファイルも削除してください。
     - `サンプルAPI用のパラメーター定義` の下に書かれているParameter定義を削除し、そのリンク先のyamlファイルも削除してください。
@@ -185,3 +204,5 @@ AI駆動開発を活用する場合は、サンプルAPIを残しておくと、
     4. サンプル用のInfraコードがエラーになるので、そのコードとそのテストコードを削除する。
 4. サンプルAPIのドメインコードの削除。
     - [internal/domain/](internal/domain/) の配下のサンプルAPIで使っているコードとそのテストコードを削除してください。このディレクトリの配下のディレクトリはサンプルAPIのドメインコードのみなので、配下のディレクトリごと削除しても構いません。
+
+</details>

--- a/docs/maintenance/setup-repository.md
+++ b/docs/maintenance/setup-repository.md
@@ -161,6 +161,25 @@ If you use AI-driven development, keeping sample APIs helps AI understand code s
 
 ### Removal Procedure
 
+Use the automated command. It deletes the sample API (`user` / `product` / `order`) declared in [scripts/setup/lib/sample-api.mjs](scripts/setup/lib/sample-api.mjs), strips the `sample-api` marker blocks from the shared files (4 DI modules + `openapi.yaml`), and then regenerates / formats / lints.
+
+```bash
+# Preview what will be removed (no changes are made)
+DRY_RUN=1 make setup-remove-sample-api
+
+# Remove, then regenerate / format / lint (runs make gen-api → gen-query → fix → lint)
+make setup-remove-sample-api
+```
+
+Notes:
+
+- The base master data `prefecture` (migration `000001`, etc.) is **kept**.
+- Shared generated files (`*.gen.go`, `openapi.gen.yaml`, etc.) are not deleted directly — they are refreshed by the regeneration step.
+- The sample is split into three domains: `user` is full-stack, while `product` / `order` currently exist only as DB stubs (migrations + product seeds). When you flesh `product` / `order` out into full APIs, append their new paths to the matching domain block in `sample-api.mjs`, and wrap any sample lines interleaved in the shared files with `// sample-api:begin` … `// sample-api:end` (or a trailing `// sample-api:line`). They are then covered by the same command automatically.
+
+<details>
+<summary>Manual procedure (reference — no longer required)</summary>
+
 1. Remove sample API definitions from [openapi.yaml](openapi/openapi.yaml)
     - Remove Path definitions under `サンプルAPI用のパス` and delete the referenced YAML files.
     - Remove Parameter definitions under `サンプルAPI用のパラメーター定義` and delete the referenced YAML files.
@@ -182,3 +201,5 @@ If you use AI-driven development, keeping sample APIs helps AI understand code s
     4. Remove sample Infra code and its test code that now cause errors.
 4. Remove sample API domain code
     - Delete code used by the sample API and its test code under [internal/domain/](internal/domain/). Since directories under this path contain only sample domain code, you may delete entire directories.
+
+</details>

--- a/docs/maintenance/setup-repository.md
+++ b/docs/maintenance/setup-repository.md
@@ -163,17 +163,28 @@ If you use AI-driven development, keeping sample APIs helps AI understand code s
 
 Use the automated command. It deletes the sample API (`user` / `product` / `order`) declared in [scripts/setup/lib/sample-api.mjs](scripts/setup/lib/sample-api.mjs), strips the `sample-api` marker blocks from the shared files (4 DI modules + `openapi.yaml`), and then regenerates / formats / lints.
 
+> **The DB container must be running** before you run this — the final `gen-query` step dumps the **live** schema with `pg_dump`, so a stopped DB fails with `connection refused`.
+
 ```bash
+# 0. Start the DB container (gen-query dumps the live schema)
+docker compose up -d database
+
 # Preview what will be removed (no changes are made)
 DRY_RUN=1 make setup-remove-sample-api
 
-# Remove, then regenerate / format / lint (runs make gen-api → gen-query → fix → lint)
+# Remove the sample (deletes files + strips markers, then gen-api → gen-query → fix → lint)
 make setup-remove-sample-api
+
+# Rebuild the DB from the now sample-free migrations and re-dump the schema,
+# so the dropped `users` table does not linger in models.gen.go
+make db-init-local db-init-test
+make gen-query
 ```
 
 Notes:
 
 - The base master data `prefecture` (migration `000001`, etc.) is **kept**.
+- `gen-query` regenerates Go models from a `pg_dump` of the **live** DB. If you skip the DB rebuild above, the still-present `users` table is re-dumped and a stale `Users` type is regenerated into `models.gen.go` — the rebuild + re-`gen-query` is what actually drops it.
 - Shared generated files (`*.gen.go`, `openapi.gen.yaml`, etc.) are not deleted directly — they are refreshed by the regeneration step.
 - The sample is split into three domains: `user` is full-stack, while `product` / `order` currently exist only as DB stubs (migrations + product seeds). When you flesh `product` / `order` out into full APIs, append their new paths to the matching domain block in `sample-api.mjs`, and wrap any sample lines interleaved in the shared files with `// sample-api:begin` … `// sample-api:end` (or a trailing `// sample-api:line`). They are then covered by the same command automatically.
 

--- a/internal/di/module/controller.go
+++ b/internal/di/module/controller.go
@@ -5,9 +5,9 @@ import (
 	"go-boilerplate/internal/controller/handler/healthz"
 	"go-boilerplate/internal/controller/handler/metrics"
 	"go-boilerplate/internal/controller/handler/ready"
-	"go-boilerplate/internal/controller/handler/v1/users"
-	"go-boilerplate/internal/controller/handler/v1/users/detail"
-	"go-boilerplate/internal/controller/handler/v1/users/search"
+	"go-boilerplate/internal/controller/handler/v1/users"        // sample-api:line
+	"go-boilerplate/internal/controller/handler/v1/users/detail" // sample-api:line
+	"go-boilerplate/internal/controller/handler/v1/users/search" // sample-api:line
 	"go-boilerplate/internal/controller/handler/version"
 
 	"go.uber.org/fx"
@@ -22,10 +22,12 @@ func ControllerModule() fx.Option {
 			ready.BindHandler,
 			version.BindHandler,
 			metrics.BindHandler,
+			// sample-api:begin
 			// サンプルのハンドラー
 			users.BindHandler,
 			detail.BindHandler,
 			search.BindHandler,
+			// sample-api:end
 		),
 	)
 }

--- a/internal/di/module/infrastructure.go
+++ b/internal/di/module/infrastructure.go
@@ -1,9 +1,9 @@
 package module
 
 import (
-	userqs "go-boilerplate/internal/infrastructure/rdb/query_service/user"
+	userqs "go-boilerplate/internal/infrastructure/rdb/query_service/user" // sample-api:line
 	"go-boilerplate/internal/infrastructure/rdb/repository/prefecture"
-	"go-boilerplate/internal/infrastructure/rdb/repository/user"
+	"go-boilerplate/internal/infrastructure/rdb/repository/user" // sample-api:line
 	"go-boilerplate/internal/infrastructure/rdb/system_query/healthcheck"
 	"go-boilerplate/internal/infrastructure/security"
 	"go-boilerplate/internal/infrastructure/system"
@@ -16,16 +16,20 @@ func InfrastructureModule() fx.Option {
 	return fx.Module("infrastructure",
 		fx.Module("repository",
 			fx.Provide(
+				// sample-api:begin
 				// サンプルのリポジトリ
 				user.New,
+				// sample-api:end
 				prefecture.New,
 			),
 		),
+		// sample-api:begin
 		fx.Module("query_service",
 			fx.Provide(
 				userqs.New,
 			),
 		),
+		// sample-api:end
 		fx.Module("system_query",
 			fx.Provide(
 				healthcheck.New,

--- a/internal/di/module/job.go
+++ b/internal/di/module/job.go
@@ -2,7 +2,7 @@ package module
 
 import (
 	"go-boilerplate/internal/controller/job"
-	"go-boilerplate/internal/controller/job/usercount"
+	"go-boilerplate/internal/controller/job/usercount" // sample-api:line
 	dijob "go-boilerplate/internal/di/job"
 	"go-boilerplate/internal/di/job/hook"
 
@@ -13,7 +13,7 @@ func JobModule() fx.Option {
 	return fx.Module("job",
 		provideJobs(
 			// ここにジョブのコンストラクタを追加します。
-			usercount.New,
+			usercount.New, // sample-api:line
 		),
 		fx.Provide(
 			dijob.ProvideRunner,

--- a/internal/di/module/usecase.go
+++ b/internal/di/module/usecase.go
@@ -2,8 +2,8 @@ package module
 
 import (
 	"go-boilerplate/internal/usecase/healthcheck"
-	"go-boilerplate/internal/usecase/user"
-	"go-boilerplate/internal/usecase/user/search"
+	"go-boilerplate/internal/usecase/user"        // sample-api:line
+	"go-boilerplate/internal/usecase/user/search" // sample-api:line
 
 	"go.uber.org/fx"
 )
@@ -13,9 +13,11 @@ func UsecaseModule() fx.Option {
 	return fx.Module("usecase",
 		fx.Provide(
 			healthcheck.New,
+			// sample-api:begin
 			// サンプルのユースケース
 			user.New,
 			search.New,
+			// sample-api:end
 		),
 	)
 }

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -43,6 +43,7 @@ paths:
   # For error type generation
   /_internal/types/error-response:
     $ref: './paths/internal/types/error_response.yaml'
+  # sample-api:begin
   # サンプルAPI用のパス
   /v1/users:
     $ref: './paths/v1/users.yaml'
@@ -52,12 +53,14 @@ paths:
     $ref: './paths/v1/users/me/password.yaml'
   /v1/users/search:
     $ref: './paths/v1/users/search.yaml'
+  # sample-api:end
 components:
   parameters:
     PageParam:
       $ref: './components/parameters/pagination/PageParam.yaml'
     PerPageParam:
       $ref: './components/parameters/pagination/PerPageParam.yaml'
+    # sample-api:begin
     # サンプルAPI用のパラメーター定義
     KeywordParam:
       $ref: './components/parameters/search/KeywordParam.yaml'
@@ -65,6 +68,7 @@ components:
       $ref: './components/parameters/search/ActiveParam.yaml'
     UserIdParam:
       $ref: './components/parameters/user/UserIdParam.yaml'
+    # sample-api:end
   securitySchemes:
     BearerAuth:
       $ref: './components/schemas/BearerAuth.yaml'
@@ -79,6 +83,7 @@ components:
       $ref: './components/responses/health-check/ReadyResponse.yaml'
     ResponseVersion:
       $ref: './components/responses/version/VersionResponse.yaml'
+    # sample-api:begin
     # サンプルAPI用の型定義
     UserBaseInputRequest:
       $ref: './components/schemas/UserBaseInputRequest.yaml'
@@ -98,3 +103,4 @@ components:
       $ref: './components/requests/users/UserPutRequest.yaml'
     RequestPatchV1User:
       $ref: './components/requests/users/UserPatchRequest.yaml'
+    # sample-api:end

--- a/scripts/README.ja.md
+++ b/scripts/README.ja.md
@@ -19,7 +19,8 @@ scripts/
     ├── replace-app-metadata.mjs
     ├── replace-license-copyright.mjs
     ├── replace-repository-reference.mjs
-    └── lib/                   # setup スクリプト共通ユーティリティ
+    ├── remove-sample-api.mjs  # サンプルAPI(user/product/order)を削除
+    └── lib/                   # setup スクリプト共通ユーティリティ（sample-api.mjs manifest を含む）
 ```
 
 ## スクリプトカテゴリ
@@ -64,8 +65,11 @@ scripts/
 |`replace-app-metadata.mjs`|env ファイルと OpenAPI 仕様のアプリ名・説明を置換|
 |`replace-license-copyright.mjs`|LICENSE の著作権者名と年を置換|
 |`replace-repository-reference.mjs`|README と OpenAPI の GitHub リポジトリ参照を置換|
+|`remove-sample-api.mjs`|サンプルAPI(`user`/`product`/`order`)を削除。`lib/sample-api.mjs` に宣言したパスを削除し、共有 DI モジュールと `openapi.yaml` の `sample-api` マーカーブロックを除去する。再生成・整形・Lint まで行うには `make setup-remove-sample-api` 経由で実行する。|
 
 すべての setup スクリプトはプレビュー用の `--dry-run` をサポートしています。
+
+`remove-sample-api.mjs` の削除対象とマーカーは [`lib/sample-api.mjs`](setup/lib/sample-api.mjs) に宣言されています。サンプルは3ドメイン構成（`user` はフルスタック、`product`/`order` は拡張予定の DB スタブ）で、拡張時は該当ドメインブロックにパスを追記し、混在行を `// sample-api:begin … :end`（または `// sample-api:line`）で囲むだけで対象に含まれます。
 
 ## 注意点
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,7 +19,8 @@ scripts/
     ├── replace-app-metadata.mjs
     ├── replace-license-copyright.mjs
     ├── replace-repository-reference.mjs
-    └── lib/                   # Shared utilities for setup scripts
+    ├── remove-sample-api.mjs  # Remove the sample API (user/product/order)
+    └── lib/                   # Shared utilities for setup scripts (incl. sample-api.mjs manifest)
 ```
 
 ## Script Categories
@@ -64,8 +65,11 @@ Scripts for configuring the boilerplate when creating a new project from this te
 |`replace-app-metadata.mjs`|Replace app name/description in env files and OpenAPI spec|
 |`replace-license-copyright.mjs`|Replace LICENSE copyright holder and year|
 |`replace-repository-reference.mjs`|Replace GitHub repository references in READMEs and OpenAPI|
+|`remove-sample-api.mjs`|Remove the sample API (`user`/`product`/`order`): deletes paths declared in `lib/sample-api.mjs` and strips `sample-api` marker blocks from the shared DI modules and `openapi.yaml`. Run via `make setup-remove-sample-api` to also regenerate/format/lint.|
 
 All setup scripts support `--dry-run` for preview.
+
+The deletion targets and markers for `remove-sample-api.mjs` are declared in [`lib/sample-api.mjs`](setup/lib/sample-api.mjs). The sample spans three domains (`user` is full-stack; `product`/`order` are DB stubs to be expanded), so expanding the sample only requires appending paths to the matching domain block and wrapping interleaved lines with `// sample-api:begin … :end` (or `// sample-api:line`).
 
 ## Notes
 

--- a/scripts/setup/lib/sample-api.mjs
+++ b/scripts/setup/lib/sample-api.mjs
@@ -88,37 +88,42 @@ export const MARKER_FILES = [
 // 削除後に再生成・整形・検証するための make ターゲット（順番に実行）。
 export const BUILD_STEPS = ["gen-api", "gen-query", "fix", "lint"]
 
-const BLOCK_BEGIN = /sample-api:begin\b/
-const BLOCK_END = /sample-api:end\b/
-const LINE_MARKER = /sample-api:line\b/
+// マーカーはコメント（// または #）に書かれる前提。コメント記号を必須にして、
+// 文字列リテラルやドキュメント本文中の同一トークンを誤って拾わないようにする。
+const BLOCK_BEGIN = /(?:\/\/|#)\s*sample-api:begin\b/
+const BLOCK_END = /(?:\/\/|#)\s*sample-api:end\b/
+const LINE_MARKER = /(?:\/\/|#)\s*sample-api:line\b/
 
 // `sample-api:begin`〜`sample-api:end` で囲まれた行と、行末に `sample-api:line` を持つ行を除去する。
-// マーカー記号（// または #）に依存せずトークンの有無で判定する。
+// ネストにも対応するため depth カウンターで管理し、対応の取れないマーカーは throw する。
 export function stripSampleMarkers(content) {
   const lines = content.split("\n")
   const out = []
-  let inBlock = false
+  let depth = 0
   let removed = 0
 
   for (const line of lines) {
     if (BLOCK_BEGIN.test(line)) {
-      inBlock = true
+      depth++
       removed++
       continue
     }
     if (BLOCK_END.test(line)) {
-      inBlock = false
+      if (depth === 0) {
+        throw new Error("sample-api:end に対応する sample-api:begin が見つかりません。")
+      }
+      depth--
       removed++
       continue
     }
-    if (inBlock || LINE_MARKER.test(line)) {
+    if (depth > 0 || LINE_MARKER.test(line)) {
       removed++
       continue
     }
     out.push(line)
   }
 
-  if (inBlock) {
+  if (depth > 0) {
     throw new Error("sample-api:begin に対応する sample-api:end が見つかりません。")
   }
 

--- a/scripts/setup/lib/sample-api.mjs
+++ b/scripts/setup/lib/sample-api.mjs
@@ -1,0 +1,126 @@
+// サンプルAPI削除の対象を宣言する manifest と、マーカー除去ロジック。
+// 拡張時は該当ドメインの paths にパスを追記し、共有ファイルの混在行を
+// sample-api マーカーで囲めば、同じコマンドの削除対象に含まれる。
+// 基盤データ prefecture は Sample ではないため対象外。
+
+export const SAMPLE_DOMAINS = {
+  user: {
+    description: "サンプル User API（フルスタック）",
+    paths: [
+      "internal/domain/user",
+      "internal/usecase/user",
+      "internal/infrastructure/rdb/repository/user",
+      "internal/infrastructure/rdb/query_service/user",
+      "internal/controller/handler/v1/users",
+      "internal/controller/job/usercount",
+      "internal/integration/v1_users_test.go",
+      "internal/integration/v1_users_detail_test.go",
+      "internal/integration/v1_users_search_test.go",
+
+      // サンプル専用の生成物は再生成で復活しないため明示削除する
+      "internal/infrastructure/rdb/sqlc/gen/user_repository.gen.sql.go",
+      "internal/infrastructure/rdb/sqlc/gen/user_query_service.gen.sql.go",
+      "database/gen/user_repository.gen.sql",
+      "database/gen/user_query_service.gen.sql",
+
+      "openapi/paths/v1/users.yaml",
+      "openapi/paths/v1/users",
+      "openapi/components/parameters/user",
+      "openapi/components/parameters/search",
+      "openapi/components/requests/users",
+      "openapi/components/responses/users",
+      "openapi/components/schemas/UserBaseInputRequest.yaml",
+      "openapi/components/schemas/UserResponse.yaml",
+
+      "database/dml/repository/user",
+      "database/dml/query_service/user",
+      "database/migrations/000002_create_users.up.sql",
+      "database/migrations/000002_create_users.down.sql",
+      "database/migrations/000009_users_table_search_text_column.up.sql",
+      "database/migrations/000009_users_table_search_text_column.down.sql",
+      "database/seed/000001_users.sql",
+
+      "docs/spec/user",
+      "docs/spec/user-search",
+    ],
+  },
+
+  product: {
+    description: "サンプル 商品ドメイン（現状: DB スタブのみ。Go 層実装時に追記）",
+    paths: [
+      "database/migrations/000003_create_product_statuses.up.sql",
+      "database/migrations/000003_create_product_statuses.down.sql",
+      "database/migrations/000004_create_product_categories.up.sql",
+      "database/migrations/000004_create_product_categories.down.sql",
+      "database/migrations/000005_create_products.up.sql",
+      "database/migrations/000005_create_products.down.sql",
+      "database/seed/000002_products_electronic_equipment.sql",
+      "database/seed/000003_products_books.sql",
+      "database/seed/000004_products_clothing.sql",
+      "database/seed/000005_products_food_first.sql",
+      "database/seed/000006_products_food_latter.sql",
+      "database/seed/000007_products_furniture.sql",
+    ],
+  },
+
+  order: {
+    description: "サンプル 注文ドメイン（現状: DB スタブのみ。Go 層実装時に追記）",
+    paths: [
+      "database/migrations/000006_create_purchase_statuses.up.sql",
+      "database/migrations/000006_create_purchase_statuses.down.sql",
+      "database/migrations/000007_create_purchases.up.sql",
+      "database/migrations/000007_create_purchases.down.sql",
+      "database/migrations/000008_create_purchase_details.up.sql",
+      "database/migrations/000008_create_purchase_details.down.sql",
+    ],
+  },
+}
+
+// サンプル行が残す行と混在するため、行単位でマーカー除去する共有ファイル。
+export const MARKER_FILES = [
+  "openapi/openapi.yaml",
+  "internal/di/module/controller.go",
+  "internal/di/module/usecase.go",
+  "internal/di/module/infrastructure.go",
+  "internal/di/module/job.go",
+]
+
+// 削除後に再生成・整形・検証するための make ターゲット（順番に実行）。
+export const BUILD_STEPS = ["gen-api", "gen-query", "fix", "lint"]
+
+const BLOCK_BEGIN = /sample-api:begin\b/
+const BLOCK_END = /sample-api:end\b/
+const LINE_MARKER = /sample-api:line\b/
+
+// `sample-api:begin`〜`sample-api:end` で囲まれた行と、行末に `sample-api:line` を持つ行を除去する。
+// マーカー記号（// または #）に依存せずトークンの有無で判定する。
+export function stripSampleMarkers(content) {
+  const lines = content.split("\n")
+  const out = []
+  let inBlock = false
+  let removed = 0
+
+  for (const line of lines) {
+    if (BLOCK_BEGIN.test(line)) {
+      inBlock = true
+      removed++
+      continue
+    }
+    if (BLOCK_END.test(line)) {
+      inBlock = false
+      removed++
+      continue
+    }
+    if (inBlock || LINE_MARKER.test(line)) {
+      removed++
+      continue
+    }
+    out.push(line)
+  }
+
+  if (inBlock) {
+    throw new Error("sample-api:begin に対応する sample-api:end が見つかりません。")
+  }
+
+  return { content: out.join("\n"), removed }
+}

--- a/scripts/setup/remove-sample-api.mjs
+++ b/scripts/setup/remove-sample-api.mjs
@@ -1,0 +1,138 @@
+import fs from "node:fs"
+import { ROOT_DIR, newSetupCommand } from "./lib/runtime.mjs"
+import { toAbsolutePath, updateFile } from "./lib/file-utils.mjs"
+import {
+  SAMPLE_DOMAINS,
+  MARKER_FILES,
+  BUILD_STEPS,
+  stripSampleMarkers,
+} from "./lib/sample-api.mjs"
+
+// 再生成・整形・検証（make gen-api / gen-query / fix / lint）は Go ツールチェーンが要るため
+// ここでは行わず、ホスト側の make ターゲット（setup-remove-sample-api）が担当する。
+
+// 既に存在しないパスはスキップする（再実行や部分実装でも安全に動かすため）。
+function deletePaths(dryRun) {
+  const deleted = []
+  const missing = []
+
+  for (const [domain, def] of Object.entries(SAMPLE_DOMAINS)) {
+    for (const relativePath of def.paths) {
+      const absolutePath = toAbsolutePath(relativePath)
+
+      if (!fs.existsSync(absolutePath)) {
+        missing.push(relativePath)
+        continue
+      }
+
+      if (!dryRun) {
+        fs.rmSync(absolutePath, { recursive: true, force: true })
+      }
+
+      deleted.push({ domain, relativePath })
+    }
+  }
+
+  return { deleted, missing }
+}
+
+function stripMarkerFiles(dryRun) {
+  const changed = []
+
+  for (const relativePath of MARKER_FILES) {
+    let removedLines = 0
+
+    const updated = updateFile(relativePath, original => {
+      const result = stripSampleMarkers(original)
+      removedLines = result.removed
+      return result.content
+    }, dryRun)
+
+    if (updated) {
+      changed.push({ relativePath, removedLines })
+    }
+  }
+
+  return changed
+}
+
+function report({ deleted, missing }, stripped, dryRun) {
+  const label = dryRun ? "【Dry Run】削除対象" : "削除完了"
+
+  console.log(`\n${label}: ${deleted.length} パス`)
+  for (const domain of Object.keys(SAMPLE_DOMAINS)) {
+    const items = deleted.filter(d => d.domain === domain)
+    if (items.length === 0) {
+      continue
+    }
+    console.log(`\n[${domain}] ${SAMPLE_DOMAINS[domain].description}`)
+    for (const item of items) {
+      console.log(`  - ${item.relativePath}`)
+    }
+  }
+
+  if (missing.length > 0) {
+    console.log(`\n🟡 既に存在しない（スキップ）: ${missing.length} パス`)
+    for (const relativePath of missing) {
+      console.log(`  - ${relativePath}`)
+    }
+  }
+
+  console.log(
+    `\n${dryRun ? "【Dry Run】マーカー除去対象" : "マーカー除去完了"}: ${stripped.length} ファイル`
+  )
+  for (const item of stripped) {
+    console.log(`  - ${item.relativePath} (${item.removedLines} 行)`)
+  }
+}
+
+function run({ dryRun }) {
+  console.log("🧹 サンプルAPI（user / product / order）の削除を開始します。")
+  console.log(`   ルート: ${ROOT_DIR}`)
+  if (dryRun) {
+    console.log("   モード: dry-run（ファイルは変更しません）")
+  }
+
+  const deletion = deletePaths(dryRun)
+  const stripped = stripMarkerFiles(dryRun)
+  report(deletion, stripped, dryRun)
+
+  const buildHint = `make ${BUILD_STEPS.join(" ")}`
+  if (dryRun) {
+    console.log(
+      `\n次の手順:\n  実削除  : DRY_RUN を外して再実行\n  再生成等: 削除後に \`${buildHint}\`（make setup-remove-sample-api 経由なら自動実行）`
+    )
+    return
+  }
+
+  console.log(
+    `\n✅ 削除とマーカー除去が完了しました。\n   続けて再生成・整形・検証を行ってください: \`${buildHint}\`\n   （make setup-remove-sample-api 経由で実行した場合は自動で続行されます）`
+  )
+}
+
+const program = newSetupCommand("remove-sample-api")
+program
+  .description("ボイラープレートのサンプルAPI（user / product / order）を一括削除する")
+  .addHelpText(
+    "after",
+    `
+動作:
+  1. manifest（scripts/setup/lib/sample-api.mjs）の宣言パスを丸ごと削除
+  2. 共有ファイル（DI 4 ファイル + openapi.yaml）の sample-api マーカー行を除去
+
+削除後は ${BUILD_STEPS.map(s => `make ${s}`).join(" → ")} で再生成・整形・検証してください
+（このスクリプトは Go ツールチェーンを持たない node_tool_runner で動くため再生成は行いません。
+ make setup-remove-sample-api 経由ならホスト側で自動的に続行されます）。
+
+基盤データ prefecture（migration 000001 等）は削除しません。
+共有生成物（*.gen.go / openapi.gen.yaml 等）は再生成に任せます。
+拡張時は sample-api.mjs の各ドメイン paths への追記とマーカー付与だけで対象に含まれます。`
+  )
+  .action(options => {
+    try {
+      run({ dryRun: options.dryRun })
+    } catch (error) {
+      program.error(`エラー: ${error.message}`)
+    }
+  })
+  .parse()

--- a/scripts/setup/remove-sample-api.mjs
+++ b/scripts/setup/remove-sample-api.mjs
@@ -1,4 +1,5 @@
 import fs from "node:fs"
+import path from "node:path"
 import { ROOT_DIR, newSetupCommand } from "./lib/runtime.mjs"
 import { toAbsolutePath, updateFile } from "./lib/file-utils.mjs"
 import {
@@ -11,6 +12,16 @@ import {
 // 再生成・整形・検証（make gen-api / gen-query / fix / lint）は Go ツールチェーンが要るため
 // ここでは行わず、ホスト側の make ターゲット（setup-remove-sample-api）が担当する。
 
+const ROOT_WITH_SEP = ROOT_DIR.endsWith(path.sep) ? ROOT_DIR : ROOT_DIR + path.sep
+
+// manifest の追記ミス（`..`・空文字・絶対パス）で ROOT_DIR 外や ROOT_DIR 自体を
+// rmSync しないための安全策。dry-run でも検証されるよう削除前に必ず通す。
+function assertWithinRoot(absolutePath, relativePath) {
+  if (absolutePath === ROOT_DIR || !absolutePath.startsWith(ROOT_WITH_SEP)) {
+    throw new Error(`削除対象が ROOT_DIR の外（または ROOT_DIR 自体）を指しています: "${relativePath}"`)
+  }
+}
+
 // 既に存在しないパスはスキップする（再実行や部分実装でも安全に動かすため）。
 function deletePaths(dryRun) {
   const deleted = []
@@ -19,6 +30,7 @@ function deletePaths(dryRun) {
   for (const [domain, def] of Object.entries(SAMPLE_DOMAINS)) {
     for (const relativePath of def.paths) {
       const absolutePath = toAbsolutePath(relativePath)
+      assertWithinRoot(absolutePath, relativePath)
 
       if (!fs.existsSync(absolutePath)) {
         missing.push(relativePath)
@@ -93,8 +105,10 @@ function run({ dryRun }) {
     console.log("   モード: dry-run（ファイルは変更しません）")
   }
 
-  const deletion = deletePaths(dryRun)
+  // マーカー除去を先に行う。マーカー不整合があればここで throw し、
+  // ファイル削除前に中断できる（削除済み・マーカー未除去の半端な状態を避ける）。
   const stripped = stripMarkerFiles(dryRun)
+  const deletion = deletePaths(dryRun)
   report(deletion, stripped, dryRun)
 
   const buildHint = `make ${BUILD_STEPS.join(" ")}`


### PR DESCRIPTION
# 概要

新規プロジェクト開始時に、ボイラープレートのサンプルAPI(user / product / order)を機械的に一括削除する仕組みを追加します。削除対象を宣言的に管理し、残す行と混在する共有ファイルはマーカーで行単位に除去、削除後に再生成・整形・検証まで連鎖させます。

## 変更内容

- スクリプト追加: `scripts/setup/remove-sample-api.mjs`（削除＋マーカー除去）と宣言 manifest `scripts/setup/lib/sample-api.mjs`（user / product / order をドメイン単位で定義）
- マーカー付与: DI 4モジュール（controller / usecase / infrastructure / job）と `openapi.yaml` に `sample-api:begin/end`・`sample-api:line` を付与（コメントのみ・挙動不変）
- make ターゲット: `setup-remove-sample-api` を追加（コンテナで削除 → ホストで gen-api / gen-query / fix / lint を連鎖、`DRY_RUN=1` でプレビュー）
- ドキュメント: setup-repository の Phase 10 を自動コマンド主体に刷新（旧手動手順は折りたたみ保持）、scripts README と .makefiles README を更新（en / ja 両方）

## 動作確認方法

1. `DRY_RUN=1 make setup-remove-sample-api` で削除対象（48パス＋マーカー5ファイル）をプレビュー
2. `make lint` / `make test-cached` が通ること（本PRで確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)