### PR TITLE
local-review にPRインラインコメント投稿（オプトアウト）を追加

### DIFF
--- a/.claude/skills/local-review/SKILL.ja.md
+++ b/.claude/skills/local-review/SKILL.ja.md
@@ -2,7 +2,7 @@
 
 # Local Review
 
-実装者とは**別モデル**で回す、ローカルの敵対的・低バイアスなコードレビュー。Copilot もクラウド `/code-review` も使わない。実装者自身のモデルには盲点があり、その盲点を別モデルで拾うのが本質。`/code-review` の finder → verify パターンを下敷きにしつつ、すべてローカルで完結させ、さらにモック単体テストでは構造的に届かない **ランタイム（curl + o11y）検証** を足す。
+実装者とは**別モデル**で回す、ローカルの敵対的・低バイアスなコードレビュー。Copilot もクラウド `/code-review` も使わない。実装者自身のモデルには盲点があり、その盲点を別モデルで拾うのが本質。`/code-review` の finder → verify パターンを下敷きにしつつ、すべてローカルで完結させ、さらにモック単体テストでは構造的に届かない **ランタイム（curl + o11y）検証** を足す。既定では、verifier を通過した CONFIRMED / PLAUSIBLE の指摘を、ブランチの PR に各指摘の行へアンカーした**インラインレビューコメント**として投稿する（`--no-comment` でオプトアウト。PR が無ければローカルレポートのみにフォールバック）。
 
 ## 使うとき
 
@@ -37,6 +37,10 @@
   - 特定のパス/ファイルを指定
   - キャンセル
 ```
+
+### フラグ
+
+- `--no-comment` — Step 6 を抑止（PR に投稿せず）ローカルレポートのみ。**既定はオプトアウト**: ブランチに open な PR があれば、このフラグが無い限り Step 6 が残った指摘をインラインコメントとして投稿する。
 
 ## Step 1 — コンテキスト収集
 
@@ -103,6 +107,63 @@
 
 重大度順、CONFIRMED を PLAUSIBLE より先に。ランタイムで何を検査し何をスキップしたかは必ず明記（黙って省くと「全部見た」と誤読される）。
 
+## Step 6 — 指摘を PR にインラインコメント投稿（既定。`--no-comment` でオプトアウト）
+
+既定では Step 5 の後、残った **CONFIRMED + PLAUSIBLE** の指摘を、ブランチの PR に **インラインレビューコメント**として投稿する — 1指摘につき1コメント、その `path:行` にアンカーし、1つの長文コメントにまとめない。**REFUTED は投稿しない。** Step 5 のローカルレポートは常に出す（本ステップは追加動作）。
+
+以下のときは本ステップを丸ごとスキップ:
+
+- `--no-comment` 指定時、または
+- ブランチに open な PR が無い（`gh pr view` が空）— ローカルレポートのみとし、必要なら PR 作成を提案。
+
+GitHub への投稿は外向きアクションなので、投稿前に **一度だけ** 確認する — 件数と対象 PR を提示（`AskUserQuestion`: 「<N> 件の指摘を PR #<番号> にインラインコメントとして投稿しますか？」/「投稿する」「投稿しない（ローカルレポートのみ）」）。
+
+### 手順
+
+1. PR 番号・リポジトリ・コメントをアンカーする commit を解決:
+
+   ```sh
+   gh pr view --json number,url -q '.number'
+   gh repo view --json nameWithOwner -q '.nameWithOwner'
+   git rev-parse HEAD                                # アンカー SHA
+   git rev-parse @{u}                                # push 済み head — HEAD と異なれば警告
+   ```
+
+   アンカー commit は PR に push 済みの commit でなければならない。ローカル `HEAD` ≠ `@{u}` なら先に push するよう警告（`commit_id` が PR に無いコメントは API が拒否する）。
+
+2. どの指摘をインラインにできるか判定。GitHub のインラインコメントは PR diff に含まれる行にしか付けられない。diff の hunk を解析（`gh pr diff <PR> --patch` か `git diff <base>...HEAD`）:
+   - `(path, line)` が追加/文脈の hunk 内 → インライン、`side: "RIGHT"`。
+   - `(path, line)` が削除行 → インライン、`side: "LEFT"`。
+   - diff 外（reviewer が未変更の文脈を参照）→ インライン不可。レビュー要約 `body` にまとめる。
+
+3. 1つのレビューに全コメントをまとめて atomic に投稿（N 個の単発コメントにしない）:
+
+   ```sh
+   gh api --method POST repos/<owner>/<repo>/pulls/<PR>/reviews --input payload.json
+   ```
+
+   `payload.json`:
+
+   ```json
+   {
+     "commit_id": "<SHA>",
+     "event": "COMMENT",
+     "body": "🔎 local-review (reviewer: <model>) — CONFIRMED <n> / PLAUSIBLE <m>\n\ndiff 外で行アンカー不可の指摘:\n- <path>: <要約>",
+     "comments": [
+       {
+         "path": "<file>",
+         "line": <n>,
+         "side": "RIGHT",
+         "body": "🔎 [CONFIRMED · high] <問題の要約>\n\n根拠: <...>\n修正案: <...>\n検証: <verifier 判定>"
+       }
+     ]
+   }
+   ```
+
+   `event: "COMMENT"` を使う — これは助言的レビューであり `REQUEST_CHANGES` / `APPROVE` にしない。各コメント本文の先頭に `🔎 local-review`（または `🔎 [判定 · 重大度]` タグ）を付け、人間のレビューと区別できるようにする。
+
+4. 堅牢性: API がバッチを拒否（422 — 行が diff に無い）したら、該当コメントを要約 `body` へ移して再投稿。最後にインライン投稿分と要約分を報告 — 指摘を黙って落とさない。
+
 ## やる / やらない
 
 - ✅ reviewer モデル ≠ implementer モデルを保証（本セッションが sonnet なら既定を上書き）。
@@ -110,6 +171,9 @@
 - ✅ レポート前に全 finding を独立 verify、REFUTED は落とす。
 - ✅ 触られたエンドポイントはランタイム検証、共有スキーマ編集なら全 consumer に拡大。
 - ✅ 復旧手段が `make db-init` しかない破壊系 curl は事前にユーザー確認。
+- ✅ 既定で CONFIRMED + PLAUSIBLE をブランチの PR にインラインコメント投稿（Step 6）。`--no-comment` か PR 無しのとき抑止。
+- ✅ PR 投稿前に一度だけ確認（外向きアクション）。各コメントは `path:行` にアンカーし、diff 外の指摘はレビュー要約にまとめる。
+- ❌ REFUTED を投稿する / `REQUEST_CHANGES`・`APPROVE` を使う — 投稿レビューは助言的 `COMMENT` のみ。
 - ❌ 修正を当てる — 本スキルは指摘まで（reviewer は構造的に read-only）。
 - ❌ reviewer を implementer と同一モデルで回す。
 - ❌ 思いつきの style nit を finding として出す / 網羅に見せるための水増し。
@@ -123,3 +187,4 @@
 - [ ] 全 finding を独立 verify、REFUTED は除外（件数は保持）。
 - [ ] 触られたエンドポイントの curl + o11y 実施（共有スキーマ → 全 consumer）、破壊系は確認済み。
 - [ ] 1つの日本語レポート: CONFIRMED → PLAUSIBLE、ランタイムのカバー範囲を明記。
+- [ ] `--no-comment` / PR 無し以外: 一度確認のうえ CONFIRMED + PLAUSIBLE をインライン PR コメント投稿（diff 外 → 要約 body）、REFUTED は除外、`event: COMMENT`。

--- a/.claude/skills/local-review/SKILL.md
+++ b/.claude/skills/local-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: local-review
-description: Local adversarial, low-bias code review of the current change, run by subagents on a DIFFERENT model than the implementer. Mirrors `/code-review`'s finder → verify shape but keeps everything local and adds a runtime (curl + o11y) stage that mocked tests cannot cover. Confirms scope via `AskUserQuestion` (changed files vs branch-vs-base diff vs specific paths), fans out `adversarial-reviewer` subagents — one per lens (correctness / security / architecture / runtime-gap), each on `sonnet` by default so reviewer ≠ an Opus implementer — then verifies each finding with an independent `review-verifier` subagent (CONFIRMED / PLAUSIBLE / REFUTED), optionally runs the runtime curl + o11y check for touched endpoints (orchestrator-driven, per `scaffold-endpoint` Step 3.5), and synthesizes a single Japanese report. Read-only on source: reviewers cannot edit code (no fix is applied), and any destructive runtime curl is confirmed with the user first. Use before commit / PR to get an independent second opinion that the implementer's own model would not surface.
+description: Local adversarial, low-bias code review of the current change, run by subagents on a DIFFERENT model than the implementer. Mirrors `/code-review`'s finder → verify shape but keeps everything local and adds a runtime (curl + o11y) stage that mocked tests cannot cover. Confirms scope via `AskUserQuestion` (changed files vs branch-vs-base diff vs specific paths), fans out `adversarial-reviewer` subagents — one per lens (correctness / security / architecture / runtime-gap), each on `sonnet` by default so reviewer ≠ an Opus implementer — then verifies each finding with an independent `review-verifier` subagent (CONFIRMED / PLAUSIBLE / REFUTED), optionally runs the runtime curl + o11y check for touched endpoints (orchestrator-driven, per `scaffold-endpoint` Step 3.5), and synthesizes a single Japanese report. Read-only on source: reviewers cannot edit code (no fix is applied), and any destructive runtime curl is confirmed with the user first. By default the surviving CONFIRMED / PLAUSIBLE findings are posted to the branch's PR as inline review comments anchored to each finding's line (opt out with `--no-comment`; falls back to the local report when no open PR exists). Use before commit / PR to get an independent second opinion that the implementer's own model would not surface.
 ---
 
 # Local Review
@@ -42,6 +42,10 @@ Call `AskUserQuestion` immediately. Default-detect scope by checking branch vs b
   - 特定のパス/ファイルを指定
   - キャンセル
 ```
+
+### Flags
+
+- `--no-comment` — suppress Step 6 (do not post to the PR); produce the local report only. **Default is opt-out**: when an open PR exists for the current branch, Step 6 posts the surviving findings as inline review comments unless this flag is given.
 
 ## Step 1 — Gather Context
 
@@ -108,6 +112,63 @@ Produce one Japanese report:
 
 Order by severity, CONFIRMED before PLAUSIBLE. Always state what runtime checks ran and what was skipped — silent omission reads as "covered everything" when it was not.
 
+## Step 6 — Post Findings as Inline PR Comments (default; opt out with `--no-comment`)
+
+By default, after Step 5, post the surviving **CONFIRMED + PLAUSIBLE** findings to the branch's PR as **inline review comments** — one per finding, anchored to its `path:line`, instead of a single wall-of-text comment. **Never post REFUTED.** The Step 5 local report is still produced regardless; this step is additive.
+
+Skip this step entirely when:
+
+- invoked with `--no-comment`, OR
+- no open PR exists for the current branch (`gh pr view` returns nothing) — keep the local report only and optionally offer to open a PR.
+
+Posting to GitHub is an outward-facing action, so confirm **once** before posting — show the count and the target PR (`AskUserQuestion`: 「<N> 件の指摘を PR #<番号> にインラインコメントとして投稿しますか？」/「投稿する」「投稿しない（ローカルレポートのみ）」).
+
+### Procedure
+
+1. Resolve PR number, repo, and the commit the comments anchor to:
+
+   ```sh
+   gh pr view --json number,url -q '.number'        # PR number
+   gh repo view --json nameWithOwner -q '.nameWithOwner'
+   git rev-parse HEAD                                # anchor SHA
+   git rev-parse @{u}                                # pushed head — warn if it differs from HEAD
+   ```
+
+   The anchor commit MUST be the commit pushed to the PR. If local `HEAD` ≠ `@{u}`, warn the user to push first (the API rejects comments whose `commit_id` is not on the PR).
+
+2. Decide which findings can be inline. A GitHub inline comment must target a line present in the PR diff. Parse the diff hunks (`gh pr diff <PR> --patch` or `git diff <base>...HEAD`):
+   - `(path, line)` inside an added/context hunk → inline comment, `side: "RIGHT"`.
+   - `(path, line)` on a removed line → inline comment, `side: "LEFT"`.
+   - Off-diff (the reviewer referenced unchanged context) → **cannot** be inline; fold it into the review summary `body`.
+
+3. Build one review and post all comments atomically (a single review, not N standalone comments):
+
+   ```sh
+   gh api --method POST repos/<owner>/<repo>/pulls/<PR>/reviews --input payload.json
+   ```
+
+   `payload.json`:
+
+   ```json
+   {
+     "commit_id": "<SHA>",
+     "event": "COMMENT",
+     "body": "🔎 local-review (reviewer: <model>) — CONFIRMED <n> / PLAUSIBLE <m>\n\ndiff 外で行アンカー不可の指摘:\n- <path>: <要約>",
+     "comments": [
+       {
+         "path": "<file>",
+         "line": <n>,
+         "side": "RIGHT",
+         "body": "🔎 [CONFIRMED · high] <問題の要約>\n\n根拠: <...>\n修正案: <...>\n検証: <verifier 判定>"
+       }
+     ]
+   }
+   ```
+
+   Use `event: "COMMENT"` — this is an advisory review, never `REQUEST_CHANGES` / `APPROVE`. Prefix every comment body with `🔎 local-review` (or the `🔎 [verdict · severity]` tag) so the posts are distinguishable from human review.
+
+4. Robustness: if the API rejects the batch (422 — a line is not in the diff), move the offending comment(s) to the summary `body` and retry. Report afterward what was posted inline vs. summarized — never silently drop a finding.
+
 ## Do / Do NOT
 
 - ✅ Guarantee reviewer model ≠ implementer model (override defaults if this session is sonnet).
@@ -115,6 +176,9 @@ Order by severity, CONFIRMED before PLAUSIBLE. Always state what runtime checks 
 - ✅ Independently verify every finding before reporting; drop REFUTED.
 - ✅ Run the runtime stage for touched endpoints; widen to all consumers on a shared-schema edit.
 - ✅ Confirm with the user before any destructive curl whose only restore path is `make db-init`.
+- ✅ By default, post CONFIRMED + PLAUSIBLE findings to the branch's PR as inline review comments (Step 6); suppress with `--no-comment` or when no open PR exists.
+- ✅ Confirm once before posting to the PR (outward action); anchor each comment to its `path:line`, fold off-diff findings into the review summary.
+- ❌ Post REFUTED findings, or use `REQUEST_CHANGES` / `APPROVE` — the posted review is advisory `COMMENT` only.
 - ❌ Apply fixes — this skill reports; the user fixes (reviewers are read-only by construction).
 - ❌ Let a reviewer run on the same model as the implementer.
 - ❌ Report speculative style nits as findings, or pad the list to look thorough.
@@ -128,3 +192,4 @@ Order by severity, CONFIRMED before PLAUSIBLE. Always state what runtime checks 
 - [ ] Every finding independently verified; REFUTED dropped (count kept).
 - [ ] Runtime curl + o11y done for touched endpoints (shared-schema → all consumers); destructive curls confirmed.
 - [ ] Single Japanese report: CONFIRMED → PLAUSIBLE, with runtime coverage stated.
+- [ ] Unless `--no-comment` / no PR: confirmed once, then posted CONFIRMED + PLAUSIBLE as inline PR comments (off-diff → summary body); REFUTED excluded; `event: COMMENT`.


### PR DESCRIPTION
# 概要

`local-review` スキルに、レビュー結果を PR へ**インラインコメント**として投稿する機能を追加します。既定はオプトアウト（PR があれば自動投稿、`--no-comment` で抑止）。

## 変更内容

- `.claude/skills/local-review/SKILL.md`（canonical）に **Step 6: PRインラインコメント投稿** を追加
  - verifier を通過した CONFIRMED / PLAUSIBLE のみを各指摘の `path:行` にアンカーして投稿（REFUTED は投稿しない）
  - 1レビューに全コメントを atomic 投稿（`gh api .../pulls/<n>/reviews`、`event: COMMENT`）
  - diff 外の指摘はレビュー要約 body へフォールバック、投稿前に一度ユーザー確認
  - `--no-comment` フラグ／PR 無し時はローカルレポートのみ
- frontmatter description・Flags・やる/やらない・チェックリストを更新
- `.claude/skills/local-review/SKILL.ja.md`（参考訳）を同期

## 動作確認方法

1. このスキル拡張は PR #354 のレビューで実際に使用し、8件の指摘を対象行へインライン投稿できることを確認済み（https://github.com/Tomy-ch/go-boilerplate/pull/354#pullrequestreview-4490990449 ）
2. ドキュメント変更のみのため `make` 系のビルド/テストへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)