### PR TITLE
GitHub Actions のワークフロー名・ステップ名を統一

### DIFF
--- a/.github/workflows/app-di-startup-check.yaml
+++ b/.github/workflows/app-di-startup-check.yaml
@@ -1,4 +1,4 @@
-name: Application Boot Verification
+name: App Boot Check
 
 on:
   pull_request:

--- a/.github/workflows/auto-generate-docs.yaml
+++ b/.github/workflows/auto-generate-docs.yaml
@@ -1,4 +1,4 @@
-name: Auto-generate Docs Pull Request
+name: Auto-generate Docs
 
 on:
   push:

--- a/.github/workflows/code-ql.yaml
+++ b/.github/workflows/code-ql.yaml
@@ -1,4 +1,4 @@
-name: Code Security Scan Workflow
+name: CodeQL Scan
 
 on:
   push:

--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -1,4 +1,4 @@
-name: Application Deployment Workflow
+name: Deploy App
 
 on:
   push:
@@ -31,7 +31,7 @@ jobs:
             suffix: "-migration"
 
     steps:
-      - name: Fetch & Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,4 +1,4 @@
-name: Deploy Docs Portal
+name: Deploy Docs
 
 on:
   push:
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Fetch & Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Upload Pages artifact

--- a/.github/workflows/gen-db-artifacts-check.yaml
+++ b/.github/workflows/gen-db-artifacts-check.yaml
@@ -45,7 +45,7 @@ jobs:
           --health-start-period=20s
 
     steps:
-      - name: Fetch & Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Go
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install sqlc
         run: mise install sqlc
-      - name: Setup DB (wait & init)
+      - name: Setup DB
         uses: ./.github/actions/setup-postgres
         with:
           db: ${{ env.DB }}
@@ -112,7 +112,7 @@ jobs:
           else
             echo "source_modified=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: Comment changed files on PR
+      - name: Comment generated artifacts result on PR
         if: github.event_name == 'pull_request'
         continue-on-error: true
         uses: actions/github-script@v8

--- a/.github/workflows/gen-go-artifacts-check.yaml
+++ b/.github/workflows/gen-go-artifacts-check.yaml
@@ -24,7 +24,7 @@ jobs:
     env:
       ENV: ci
     steps:
-      - name: Fetch & Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Go
@@ -70,7 +70,7 @@ jobs:
             echo "source_modified=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Comment changed files on PR
+      - name: Comment generated artifacts result on PR
         if: github.event_name == 'pull_request'
         continue-on-error: true
         uses: actions/github-script@v8

--- a/.github/workflows/gen-oapi-artifacts-check.yaml
+++ b/.github/workflows/gen-oapi-artifacts-check.yaml
@@ -21,7 +21,7 @@ jobs:
     env:
       ENV: ci
     steps:
-      - name: Fetch & Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Run OpenAPI Bundle
@@ -64,7 +64,7 @@ jobs:
             echo "source_modified=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Comment generated status on PR (diff/no-diff)
+      - name: Comment generated artifacts result on PR
         if: github.event_name == 'pull_request'
         continue-on-error: true
         uses: actions/github-script@v8

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -1,4 +1,4 @@
-name: Docker Image Scan Workflow
+name: Image Scan
 
 on:
   pull_request:
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Fetch & Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Go
@@ -117,7 +117,7 @@ jobs:
           MD
           echo "Generated sbom-summary.md" && wc -c sbom-summary.md
 
-      - name: Comment SBOM Summary on PR
+      - name: Comment SBOM result on PR
         if: ${{ github.event_name == 'pull_request' }}
         continue-on-error: true
         uses: ./.github/actions/upsert-pr-comment
@@ -167,7 +167,7 @@ jobs:
           name: trivy-image-scan.txt
           path: trivy-image-scan.txt
 
-      - name: Comment Trivy result on PR
+      - name: Comment Trivy image scan result on PR
         if: ${{ github.event_name == 'pull_request' }}
         continue-on-error: true
         uses: ./.github/actions/upsert-pr-comment

--- a/.github/workflows/job-boot-check.yaml
+++ b/.github/workflows/job-boot-check.yaml
@@ -1,4 +1,4 @@
-name: Job Boot Verification
+name: Job Boot Check
 
 on:
   pull_request:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Golang Lint Workflow
+name: Go Lint
 
 on:
   pull_request:
@@ -24,7 +24,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Fetch & Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Go

--- a/.github/workflows/migration-check.yaml
+++ b/.github/workflows/migration-check.yaml
@@ -1,4 +1,4 @@
-name: migration-check
+name: Migration Check
 
 on:
   pull_request:
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@v6
 
       - name: Run migration checks
         id: migration
@@ -115,7 +116,7 @@ jobs:
             if (status === 'success') {
               body = [
                 marker,
-                '## ✅ Migration checks passed',
+                '## ✅ Migration check passed',
                 '',
                 `🔖 Commit: [\`${shortSha}\`](${commitUrl})`,
                 '',
@@ -165,6 +166,6 @@ jobs:
               });
             }
 
-      - name: Fail job if migration check failed
+      - name: Fail if migration check failed
         if: steps.migration.outputs.status != 'success'
         run: exit 1

--- a/.github/workflows/sql-lint.yaml
+++ b/.github/workflows/sql-lint.yaml
@@ -144,6 +144,6 @@ jobs:
               });
             }
 
-      - name: Fail if any lint failed
+      - name: Fail if SQL lint failed
         if: always() && steps.lint.outputs.status != 'success'
         run: exit 1

--- a/.github/workflows/sync-versions-check.yaml
+++ b/.github/workflows/sync-versions-check.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Fetch & Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Go
@@ -59,7 +59,7 @@ jobs:
           } | tee /tmp/sync-versions-drift.md
           exit 1
 
-      - name: Comment drift on PR
+      - name: Comment sync-versions result on PR
         if: github.event_name == 'pull_request' && failure() && steps.drift.outputs.status == 'drift'
         uses: actions/github-script@v8
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Golang Test Workflow
+name: Go Test
 
 on:
   pull_request:
@@ -44,7 +44,7 @@ jobs:
           --health-retries=5
           --health-start-period=20s
     steps:
-      - name: Fetch & Checkout repository
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Go
@@ -53,7 +53,7 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Setup DB (wait & init)
+      - name: Setup DB
         uses: ./.github/actions/setup-postgres
         with:
           db: ${{ env.DB }}

--- a/.github/workflows/tidy-check.yaml
+++ b/.github/workflows/tidy-check.yaml
@@ -1,4 +1,4 @@
-name: Go Module Consistency Check Workflow
+name: Module Tidy Check
 
 on:
   pull_request:
@@ -56,7 +56,7 @@ jobs:
 
           exit 0
 
-      - name: Comment go mod tidy result on PR
+      - name: Comment tidy result on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v8
         with:

--- a/.github/workflows/trivy-fs.yaml
+++ b/.github/workflows/trivy-fs.yaml
@@ -1,4 +1,4 @@
-name: Dependency Vulnerability Scan Workflow
+name: Dependency Scan
 
 on:
   pull_request:

--- a/.github/workflows/trivy-release-gate.yaml
+++ b/.github/workflows/trivy-release-gate.yaml
@@ -1,4 +1,4 @@
-name: Release Dependency Vulnerability Scan Workflow
+name: Release Dependency Scan
 
 on:
   pull_request:

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -1,4 +1,4 @@
-name: Go Vulnerability Analysis Workflow
+name: Vulnerability Scan
 
 on:
   pull_request:
@@ -95,7 +95,7 @@ jobs:
           fi
         shell: bash
 
-      - name: Comment govulncheck summary on PR
+      - name: Comment govulncheck result on PR
         if: ${{ github.event_name == 'pull_request' }}
         continue-on-error: true
         uses: actions/github-script@v8


### PR DESCRIPTION
# 概要

GitHub Actions の各ワークフロー名 (`name:`) とステップ名に存在した表記揺れを統一する。本番挙動への影響はなく、Actions ページ／PR 上の表示と CI ログの可読性・一貫性を改善する変更。

## 変更内容

- **ワークフロー名 (`name:`)**: 「Workflow」接尾辞を全廃し、役割ごとに動詞を統一（Check / Scan / Lint / Test / Deploy）。kebab-case だった `migration-check` を `Migration Check` に矯正
- **ステップ名（横断統一）**:
  - `Checkout`（旧「Fetch & Checkout repository」を吸収）
  - `Comment <subject> result on PR`（PR コメント系の表記揺れを統一）
  - `Fail if ...`（失敗判定ステップの表記揺れを統一）
  - `Setup DB`（旧「Setup DB (wait & init)」を吸収）
- **`migration-check.yaml`**: 唯一無名だった Checkout ステップに名前を付与、PR コメント見出しの単複揺れを単数に統一
- 対象は `.github/workflows/*.yaml` 19件のみ。job ID・共通アクション内部のステップ名は据え置き

## 動作確認方法

- 全 workflow を YAML パースして構文崩れがないことを確認済み（19/19 OK）
- 変更は表示名・ステップ名のみで、`uses:` / `run:` / job ID / トリガー条件は不変

> ⚠️ ブランチ保護の必須チェックがワークフロー表示名で参照されている場合は、新名称への更新が必要です（job 名ベースの必須チェックは job ID 不変のため影響なし）。