### PR TITLE
PR コメント投稿を upsert-pr-comment 共通アクションに統一

### DIFF
--- a/.github/workflows/gen-db-artifacts-check.yaml
+++ b/.github/workflows/gen-db-artifacts-check.yaml
@@ -112,107 +112,41 @@ jobs:
           else
             echo "source_modified=false" >> "$GITHUB_OUTPUT"
           fi
+      - name: Build PR comment body
+        id: comment
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=/tmp/gen-db-comment.md
+          if [ "${{ steps.gen_diff.outputs.has_diff }}" != "true" ]; then
+            echo "title=## ✅ No differences in database output were detected" >> "$GITHUB_OUTPUT"
+            echo "No differences in database output were found." > "$out"
+            exit 0
+          fi
+          if [ "${{ steps.source_mod.outputs.source_modified }}" = "true" ]; then
+            echo "title=## 🧾 Differences in database output have been detected" >> "$GITHUB_OUTPUT"
+            printf '%s\n' 'データベース生成コマンド（例: `make gen` / `make gen-query`）をローカルで実行し、変更をコミットしてください。' > "$out"
+          else
+            echo "title=## ⚠️ DB 生成物のドリフトを検知（SQL source 未変更）" >> "$GITHUB_OUTPUT"
+            printf '%s\n' '本 PR では SQL source が変更されていないため、generator 側（sqlc バージョン差・base 側の古い生成物 等）のドリフトの可能性があります。`make gen-query` をローカル実行してコミットするか、`auto-generate-docs` 経由で base 側を更新してから rebase / merge してください。' > "$out"
+          fi
+          {
+            echo ""
+            while IFS= read -r f; do
+              [ -n "$f" ] && printf -- '- `%s`\n' "$f"
+            done < /tmp/changed_files.txt
+          } >> "$out"
+
       - name: Comment generated artifacts result on PR
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: actions/github-script@v8
+        uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const marker = '<!-- generated-artifacts-filelist -->';
-
-            const hasDiff = ('${{ steps.gen_diff.outputs.has_diff }}' === 'true');
-            const sourceModified = '${{ steps.source_mod.outputs.source_modified }}' === 'true';
-
-            let files = [];
-            if (hasDiff) {
-              try {
-                const raw = fs.readFileSync('/tmp/changed_files.txt', 'utf8').trim();
-                files = raw ? raw.split('\n').filter(Boolean) : [];
-              } catch (e) {
-                files = ['(Failed to read changed_files.txt)'];
-              }
-            }
-
-            const updatedAtJST = new Date().toLocaleString('ja-JP', {
-              timeZone: 'Asia/Tokyo',
-              year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-            });
-
-            const headSha =
-              (context.payload.pull_request?.head?.sha)
-              || process.env.GITHUB_SHA
-              || context.sha;
-            const shortSha = headSha.slice(0, 7);
-
-            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            const commitUrl = `${repoUrl}/commit/${headSha}`;
-
-            // 例: 🔖 Commit: [`1a2b3c4`](https://github.com/.../commit/1a2b3c4...)
-            const commitLine = `🔖 Commit: [\`${shortSha}\`](${commitUrl})`;
-            const updatedLine = `🕒 UpdatedAt: ${updatedAtJST} (JST)`;
-
-            const diffTitle = sourceModified
-              ? '## 🧾 Differences in database output have been detected (list of modified files)'
-              : '## ⚠️ DB 生成物のドリフトを検知（本 PR で `database/` / `docker/database/` 配下の `.sql` は触られていません）';
-            const diffAction = sourceModified
-              ? 'Please run the database generation command locally (e.g., `make gen` / `make gen-query`) and commit the changes.'
-              : '本 PR では SQL source が変更されていないため、generator 側（sqlc バージョン差 / base 側の古い生成物 等）のドリフトの可能性があります。`make gen-query` をローカル実行してコミットするか、`auto-generate-docs` 経由で base 側を更新してから rebase / merge してください。';
-            const body = hasDiff
-              ? [
-                  marker,
-                  diffTitle,
-                  '',
-                  commitLine,
-                  '',
-                  ...(files.length ? files.map(f => `- \`${f}\``) : ['(no changed files)']),
-                  '',
-                  diffAction,
-                  '',
-                  updatedLine,
-                ].join('\n')
-              : [
-                  marker,
-                  '## ✅ No differences in database output were detected',
-                  '',
-                  commitLine,
-                  '',
-                  'No differences in database output were found.',
-                  '',
-                  updatedLine,
-                ].join('\n');
-
-            // 既存コメントがあれば更新（スパム防止）
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-
-            const existing = comments.find(c => (c.body || '').includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body,
-              });
-            }
+          marker: '<!-- generated-artifacts-filelist -->'
+          title: ${{ steps.comment.outputs.title }}
+          body-file: /tmp/gen-db-comment.md
       - name: Fail if diff exists
         if: steps.gen_diff.outputs.has_diff == 'true'
         run: exit 1

--- a/.github/workflows/gen-go-artifacts-check.yaml
+++ b/.github/workflows/gen-go-artifacts-check.yaml
@@ -70,106 +70,41 @@ jobs:
             echo "source_modified=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Build PR comment body
+        id: comment
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=/tmp/gen-go-comment.md
+          if [ "${{ steps.gen_diff.outputs.has_diff }}" != "true" ]; then
+            echo "title=## ✅ No differences in Go generated output were detected" >> "$GITHUB_OUTPUT"
+            echo "No differences in Go generated output were detected." > "$out"
+            exit 0
+          fi
+          if [ "${{ steps.source_mod.outputs.source_modified }}" = "true" ]; then
+            echo "title=## 🧾 Differences in Go generated output have been detected" >> "$GITHUB_OUTPUT"
+            printf '%s\n' '`make gen-go-code`（または `make gen`）をローカルで実行し、変更をコミットしてください。' > "$out"
+          else
+            echo "title=## ⚠️ Go 生成物のドリフトを検知（.go source 未変更）" >> "$GITHUB_OUTPUT"
+            printf '%s\n' '本 PR では `.go` source が変更されていないため、generator 側のドリフト（mockgen / oapi-codegen の依存バージョン差・base 側の古い生成物 等）の可能性があります。`make gen-go-code` をローカル実行してコミットするか、`auto-generate-docs` 経由で base 側を更新してから rebase / merge してください。' > "$out"
+          fi
+          {
+            echo ""
+            while IFS= read -r f; do
+              [ -n "$f" ] && printf -- '- `%s`\n' "$f"
+            done < /tmp/changed_files.txt
+          } >> "$out"
+
       - name: Comment generated artifacts result on PR
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: actions/github-script@v8
+        uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-
-            const marker = '<!-- generated-go-artifacts-filelist -->';
-            const hasDiff = ('${{ steps.gen_diff.outputs.has_diff }}' === 'true');
-            const sourceModified = '${{ steps.source_mod.outputs.source_modified }}' === 'true';
-
-            let files = [];
-            if (hasDiff) {
-              try {
-                const raw = fs.readFileSync('/tmp/changed_files.txt', 'utf8').trim();
-                files = raw ? raw.split('\n').filter(Boolean) : [];
-              } catch (e) {
-                files = ['(Failed to read changed_files.txt)'];
-              }
-            }
-
-            const updatedAtJST = new Date().toLocaleString('ja-JP', {
-              timeZone: 'Asia/Tokyo',
-              year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-            });
-
-            const headSha =
-              (context.payload.pull_request?.head?.sha)
-              || process.env.GITHUB_SHA
-              || context.sha;
-            const shortSha = headSha.slice(0, 7);
-
-            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            const commitUrl = `${repoUrl}/commit/${headSha}`;
-
-            // 例: 🔖 Commit: [`1a2b3c4`](https://github.com/.../commit/1a2b3c4...)
-            const commitLine = `🔖 Commit: [\`${shortSha}\`](${commitUrl})`;
-            const updatedLine = `🕒 UpdatedAt: ${updatedAtJST} (JST)`;
-
-            const diffTitle = sourceModified
-              ? '## 🧾 Differences in Go generated output have been detected (list of modified files)'
-              : '## ⚠️ Go 生成物のドリフトを検知（本 PR で `.go` source は触られていません）';
-            const diffAction = sourceModified
-              ? 'Please run `make gen-go-code` (or `make gen`) locally and commit the changes.'
-              : '本 PR では `.go` source が変更されていないため、generator 側のドリフト（mockgen / oapi-codegen の依存バージョン差 / base 側の古い生成物 等）の可能性があります。`make gen-go-code` をローカル実行してコミットするか、`auto-generate-docs` 経由で base 側を更新してから rebase / merge してください。';
-            const body = hasDiff
-              ? [
-                  marker,
-                  diffTitle,
-                  '',
-                  commitLine,
-                  '',
-                  ...(files.length ? files.map(f => `- \`${f}\``) : ['(no changed files)']),
-                  '',
-                  diffAction,
-                  '',
-                  updatedLine,
-                ].join('\n')
-              : [
-                  marker,
-                  '## ✅ No differences in Go generated output were detected',
-                  '',
-                  commitLine,
-                  '',
-                  'No differences in Go generated output were detected.',
-                  '',
-                  updatedLine,
-                ].join('\n');
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-
-            const existing = comments.find(c => (c.body || '').includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body,
-              });
-            }
+          marker: '<!-- generated-go-artifacts-filelist -->'
+          title: ${{ steps.comment.outputs.title }}
+          body-file: /tmp/gen-go-comment.md
 
       - name: Fail if diff exists
         if: steps.gen_diff.outputs.has_diff == 'true'

--- a/.github/workflows/gen-oapi-artifacts-check.yaml
+++ b/.github/workflows/gen-oapi-artifacts-check.yaml
@@ -64,98 +64,41 @@ jobs:
             echo "source_modified=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Build PR comment body
+        id: comment
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=/tmp/gen-oapi-comment.md
+          if [ "${{ steps.gen_diff.outputs.has_diff }}" != "true" ]; then
+            echo "title=## ✅ No differences in OpenAPI generated output were detected" >> "$GITHUB_OUTPUT"
+            echo "No differences in OpenAPI generated output were detected." > "$out"
+            exit 0
+          fi
+          if [ "${{ steps.source_mod.outputs.source_modified }}" = "true" ]; then
+            echo "title=## 🧾 Differences in OpenAPI generated output have been detected" >> "$GITHUB_OUTPUT"
+            printf '%s\n' '`make gen-bundle-oapi && make gen-api-docs` をローカルで実行し、変更をコミットしてください。' > "$out"
+          else
+            echo "title=## ⚠️ OpenAPI 生成物のドリフトを検知（openapi/ 未変更）" >> "$GITHUB_OUTPUT"
+            printf '%s\n' '本 PR では `openapi/` 配下が変更されていないため、generator 側のドリフト（非決定的出力・依存バージョン差・base 側の古い生成物 等）の可能性があります。`make gen-bundle-oapi && make gen-api-docs` をローカル実行してコミットするか、`auto-generate-docs` 経由で base 側を更新してから rebase / merge してください。' > "$out"
+          fi
+          {
+            echo ""
+            while IFS= read -r f; do
+              [ -n "$f" ] && printf -- '- `%s`\n' "$f"
+            done < /tmp/changed_files.txt
+          } >> "$out"
+
       - name: Comment generated artifacts result on PR
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: actions/github-script@v8
+        uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-
-            const marker = '<!-- generated-oapi-artifacts-filelist -->';
-
-            const raw = fs.readFileSync('/tmp/changed_files.txt', 'utf8').trim();
-            const files = raw ? raw.split('\n').filter(Boolean) : [];
-            const sourceModified = '${{ steps.source_mod.outputs.source_modified }}' === 'true';
-
-            const updatedAtJST = new Date().toLocaleString('ja-JP', {
-              timeZone: 'Asia/Tokyo',
-              year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-            });
-
-            const headSha =
-              (context.payload.pull_request?.head?.sha)
-              || process.env.GITHUB_SHA
-              || context.sha;
-            const shortSha = headSha.slice(0, 7);
-            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            const commitUrl = `${repoUrl}/commit/${headSha}`;
-
-            const commitLine = `🔖 Commit: [\`${shortSha}\`](${commitUrl})`;
-            const updatedLine = `🕒 UpdatedAt: ${updatedAtJST} (JST)`;
-
-            let body;
-            if (files.length > 0) {
-              const title = sourceModified
-                ? '## 🧾 Differences in OpenAPI generated output have been detected (list of modified files)'
-                : '## ⚠️ OpenAPI 生成物のドリフトを検知（本 PR で `openapi/` 配下は触られていません）';
-              const action = sourceModified
-                ? 'Please run `make gen-bundle-oapi && make gen-api-docs` locally and commit the changes.'
-                : '本 PR では `openapi/` 配下が変更されていないため、generator 側のドリフト（非決定的出力 / 依存バージョン差 / base 側の古い生成物 等）の可能性があります。`make gen-bundle-oapi && make gen-api-docs` をローカル実行してコミットするか、`auto-generate-docs` 経由で base 側を更新してから rebase / merge してください。';
-              body = [
-                marker,
-                title,
-                '',
-                commitLine,
-                '',
-                ...files.map(f => `- \`${f}\``),
-                '',
-                action,
-                '',
-                updatedLine,
-              ].join('\n');
-            } else {
-              body = [
-                marker,
-                '## ✅ No differences in OpenAPI generated output were detected',
-                '',
-                commitLine,
-                '',
-                'No differences in OpenAPI generated output were detected.',
-                '',
-                updatedLine,
-              ].join('\n');
-            }
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-
-            const existing = comments.find(c => (c.body || '').includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body,
-              });
-            }
+          marker: '<!-- generated-oapi-artifacts-filelist -->'
+          title: ${{ steps.comment.outputs.title }}
+          body-file: /tmp/gen-oapi-comment.md
 
       - name: Fail if diff exists
         if: steps.gen_diff.outputs.has_diff == 'true'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -64,8 +64,10 @@ jobs:
 
           if [ "$code" -eq 0 ]; then
             echo "status=success" >> "$GITHUB_OUTPUT"
+            echo "title=## ✅ Go lint: PASS (golangci-lint)" >> "$GITHUB_OUTPUT"
           else
             echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "title=## ❌ Go lint: FAIL (golangci-lint)" >> "$GITHUB_OUTPUT"
           fi
 
           exit 0
@@ -73,97 +75,13 @@ jobs:
       - name: Comment Go lint result on PR
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: actions/github-script@v8
+        uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-
-            const marker = '<!-- golangci-lint-result -->';
-            const status = '${{ steps.golangci.outputs.status }}';
-            const code = '${{ steps.golangci.outputs.exit_code }}';
-
-            const updatedAtJST = new Date().toLocaleString('ja-JP', {
-              timeZone: 'Asia/Tokyo',
-              year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-            });
-
-            const headSha =
-              (context.payload.pull_request?.head?.sha)
-              || process.env.GITHUB_SHA
-              || context.sha;
-            const shortSha = headSha.slice(0, 7);
-
-            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            const commitUrl = `${repoUrl}/commit/${headSha}`;
-
-            const read = (p) => {
-              try { return fs.readFileSync(p, 'utf8').trim(); }
-              catch (e) { return '(log not found)'; }
-            };
-
-            const trimLog = (txt) => {
-              const MAX = 45000;
-              if (txt.length <= MAX) return txt;
-              return txt.slice(0, MAX) + '\n... (truncated)';
-            };
-
-            const title = status === 'success'
-              ? '✅ Go lint: PASS (golangci-lint)'
-              : '❌ Go lint: FAIL (golangci-lint)';
-
-            const line = (code) =>
-              (code === '0')
-                ? '- ✅ golangci-lint has completed successfully.'
-                : '- ❌ Issues have been detected by golangci-lint. Please make the necessary corrections locally and commit the changes.';
-
-            const icon = (code) => (code === '0' ? '✅' : '🚨');
-
-            const body = [
-              marker,
-              `## ${title}`,
-              '',
-              line(code),
-              '',
-              `- 🔖 Commit: [\`${shortSha}\`](${commitUrl})`,
-              `- 🕒 UpdatedAt: ${updatedAtJST} (JST)`,
-              '',
-              `<details><summary> ${icon(code)} golangci-lint log</summary>`,
-              '',
-              '```text',
-              trimLog(read('/tmp/golangci-lint.log')),
-              '```',
-              '</details>',
-            ].join('\n');
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-
-            const existing = comments.find(c => (c.body || '').includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body,
-              });
-            }
+          marker: '<!-- golangci-lint-result -->'
+          title: ${{ steps.golangci.outputs.title }}
+          body-file: /tmp/golangci-lint.log
+          details-summary: 'golangci-lint log'
 
       - name: Fail if golangci-lint failed
         if: always()

--- a/.github/workflows/migration-check.yaml
+++ b/.github/workflows/migration-check.yaml
@@ -71,100 +71,22 @@ jobs:
 
           if [ $FAIL -ne 0 ]; then
             echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "title=## ❌ Migration check failed" >> "$GITHUB_OUTPUT"
           else
             echo "status=success" >> "$GITHUB_OUTPUT"
+            echo "title=## ✅ Migration check passed" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Comment migration result on PR
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: actions/github-script@v8
+        uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-
-            const marker = '<!-- migration-check-result -->';
-            const status = '${{ steps.migration.outputs.status }}';
-
-            const result = (() => {
-              try { return fs.readFileSync('/tmp/migration_result.txt', 'utf8').trim(); }
-              catch { return '(log not found)'; }
-            })();
-
-            const updatedAtJST = new Date().toLocaleString('ja-JP', {
-              timeZone: 'Asia/Tokyo',
-              year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-            });
-
-            const headSha =
-              (context.payload.pull_request?.head?.sha)
-              || process.env.GITHUB_SHA
-              || context.sha;
-
-            const shortSha = headSha.slice(0, 7);
-            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            const commitUrl = `${repoUrl}/commit/${headSha}`;
-
-            let body;
-
-            if (status === 'success') {
-              body = [
-                marker,
-                '## ✅ Migration check passed',
-                '',
-                `🔖 Commit: [\`${shortSha}\`](${commitUrl})`,
-                '',
-                'All migration validations passed.',
-                '',
-                `🕒 UpdatedAt: ${updatedAtJST} (JST)`
-              ].join('\n');
-            } else {
-              body = [
-                marker,
-                '## ❌ Migration check failed',
-                '',
-                `🔖 Commit: [\`${shortSha}\`](${commitUrl})`,
-                '',
-                '```',
-                result,
-                '```',
-                '',
-                `🕒 UpdatedAt: ${updatedAtJST} (JST)`
-              ].join('\n');
-            }
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-
-            const existing = comments
-              .filter(c => (c.body || '').includes(marker))
-              .sort((a,b) => new Date(b.updated_at) - new Date(a.updated_at))[0];
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body,
-              });
-            }
+          marker: '<!-- migration-check-result -->'
+          title: ${{ steps.migration.outputs.title }}
+          body-file: /tmp/migration_result.txt
+          details-summary: 'migration check log'
 
       - name: Fail if migration check failed
         if: steps.migration.outputs.status != 'success'

--- a/.github/workflows/sql-lint.yaml
+++ b/.github/workflows/sql-lint.yaml
@@ -44,105 +44,60 @@ jobs:
           done
           echo "status=${status}" >> "$GITHUB_OUTPUT"
 
+      - name: Build PR comment body
+        id: comment
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.lint.outputs.status }}" = "success" ]; then
+            echo "title=## ✅ SQL lint: PASS" >> "$GITHUB_OUTPUT"
+          else
+            echo "title=## ❌ SQL lint: FAIL" >> "$GITHUB_OUTPUT"
+          fi
+
+          out=/tmp/sql-lint-comment.md
+          : > "$out"
+
+          category_code() {
+            case "$1" in
+              migrations) echo '${{ steps.lint.outputs.exit_code_migrations }}' ;;
+              dml)        echo '${{ steps.lint.outputs.exit_code_dml }}' ;;
+              seed)       echo '${{ steps.lint.outputs.exit_code_seed }}' ;;
+            esac
+          }
+
+          for cat in migrations dml seed; do
+            if [ "$(category_code "$cat")" = "0" ]; then
+              printf -- '- ✅ %s\n' "$cat" >> "$out"
+            else
+              printf -- '- ❌ %s のディレクトリの SQL をローカルで修正し、差分をコミットしてください。\n' "$cat" >> "$out"
+            fi
+          done
+          echo "" >> "$out"
+
+          for cat in migrations dml seed; do
+            if [ "$(category_code "$cat")" = "0" ]; then icon="✅"; else icon="🚨"; fi
+            {
+              echo "<details><summary>${icon} ${cat} log</summary>"
+              echo ""
+              echo '```text'
+              cat "/tmp/sqlfluff_${cat}.log" 2>/dev/null || echo "(log not found)"
+              echo '```'
+              echo "</details>"
+              echo ""
+            } >> "$out"
+          done
+
       - name: Comment SQL lint result on PR
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: actions/github-script@v8
+        uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-
-            const marker = '<!-- sql-lint-result -->';
-            const status = '${{ steps.lint.outputs.status }}';
-            const categories = [
-              { name: 'migrations', code: '${{ steps.lint.outputs.exit_code_migrations }}' },
-              { name: 'dml', code: '${{ steps.lint.outputs.exit_code_dml }}' },
-              { name: 'seed', code: '${{ steps.lint.outputs.exit_code_seed }}' },
-            ];
-
-            const updatedAtJST = new Date().toLocaleString('ja-JP', {
-              timeZone: 'Asia/Tokyo',
-              year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-            });
-
-            const headSha =
-              (context.payload.pull_request?.head?.sha)
-              || process.env.GITHUB_SHA
-              || context.sha;
-            const shortSha = headSha.slice(0, 7);
-            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            const commitUrl = `${repoUrl}/commit/${headSha}`;
-
-            const read = (p) => {
-              try { return fs.readFileSync(p, 'utf8').trim(); }
-              catch (e) { return '(log not found)'; }
-            };
-
-            const trimLog = (txt) => {
-              const MAX = 18000; // 3ログ合算でコメント本文 65536 上限に収める
-              if (txt.length <= MAX) return txt;
-              return txt.slice(0, MAX) + '\n... (truncated)';
-            };
-
-            const title = status === 'success'
-              ? '✅ SQL lint: PASS'
-              : '❌ SQL lint: FAIL';
-
-            const line = (c) => c.code === '0'
-              ? `- ✅ ${c.name}`
-              : `- ❌ ${c.name}のディレクトリのsqlをローカルで修正して、差分をコミットしてください。`;
-            const icon = (code) => (code === '0' ? '✅' : '🚨');
-            const details = (c) => [
-              `<details><summary> ${icon(c.code)} ${c.name} log</summary>`,
-              '',
-              '```text',
-              trimLog(read(`/tmp/sqlfluff_${c.name}.log`)),
-              '```',
-              '</details>',
-              '',
-            ];
-
-            const body = [
-              marker,
-              `## ${title}`,
-              '',
-              ...categories.map(line),
-              '',
-              `- 🔖 Commit: [\`${shortSha}\`](${commitUrl})`,
-              `- 🕒 UpdatedAt: ${updatedAtJST} (JST)`,
-              '',
-              ...categories.flatMap(details),
-            ].join('\n');
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-
-            const existing = comments.find(c => (c.body || '').includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body,
-              });
-            }
+          marker: '<!-- sql-lint-result -->'
+          title: ${{ steps.comment.outputs.title }}
+          body-file: /tmp/sql-lint-comment.md
 
       - name: Fail if SQL lint failed
         if: always() && steps.lint.outputs.status != 'success'

--- a/.github/workflows/sync-versions-check.yaml
+++ b/.github/workflows/sync-versions-check.yaml
@@ -61,38 +61,9 @@ jobs:
 
       - name: Comment sync-versions result on PR
         if: github.event_name == 'pull_request' && failure() && steps.drift.outputs.status == 'drift'
-        uses: actions/github-script@v8
+        uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const marker = '<!-- sync-versions-drift -->';
-            const body = [
-              marker,
-              '## ❌ sync-versions: drift detected',
-              '',
-              fs.readFileSync('/tmp/sync-versions-drift.md', 'utf8'),
-            ].join('\n');
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-            const existing = comments.find(c => (c.body || '').includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body,
-              });
-            }
+          marker: '<!-- sync-versions-drift -->'
+          title: '## ❌ sync-versions: drift detected'
+          body-file: /tmp/sync-versions-drift.md

--- a/.github/workflows/tidy-check.yaml
+++ b/.github/workflows/tidy-check.yaml
@@ -50,106 +50,24 @@ jobs:
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
           if [ "$code" -eq 0 ]; then
             echo "status=success" >> "$GITHUB_OUTPUT"
+            echo "title=## ✅ go mod tidy: PASS" >> "$GITHUB_OUTPUT"
           else
             echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "title=## ❌ go mod tidy: FAIL" >> "$GITHUB_OUTPUT"
           fi
 
           exit 0
 
       - name: Comment tidy result on PR
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        continue-on-error: true
+        uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-
-            const marker = '<!-- go-mod-tidy-check-result -->';
-            const status = '${{ steps.tidy.outputs.status }}';
-            const code = '${{ steps.tidy.outputs.exit_code }}';
-
-            const updatedAtJST = new Date().toLocaleString('ja-JP', {
-              timeZone: 'Asia/Tokyo',
-              year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-            });
-
-            const headSha =
-              (context.payload.pull_request?.head?.sha)
-              || process.env.GITHUB_SHA
-              || context.sha;
-            const shortSha = headSha.slice(0, 7);
-
-            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            const commitUrl = `${repoUrl}/commit/${headSha}`;
-
-            const read = (p) => {
-              try { return fs.readFileSync(p, 'utf8').trim(); }
-              catch (e) { return ''; }
-            };
-
-            const trimLog = (txt) => {
-              const MAX = 45000;
-              if (txt.length <= MAX) return txt;
-              return txt.slice(0, MAX) + '\n... (truncated)';
-            };
-
-            const title = status === 'success'
-              ? '✅ go mod tidy: PASS'
-              : '❌ go mod tidy: FAIL';
-
-            const line = (code) =>
-              (code === '0')
-                ? '- ✅ go.mod / go.sum show no differences after running `go mod tidy`'
-                : '- ❌ go mod tidy show differences in go.mod / go.sum. Please run `go mod tidy` locally and commit the changes.';
-
-            const diff = read('/tmp/go-mod-tidy.diff');
-            const hasDiff = diff && diff.trim().length > 0;
-
-            const body = [
-              marker,
-              `## ${title}`,
-              '',
-              line(code),
-              '',
-              `- 🔖 Commit: [\`${shortSha}\`](${commitUrl})`,
-              `- 🕒 UpdatedAt: ${updatedAtJST} (JST)`,
-              '',
-              '<details><summary>📄 go.mod / go.sum diff</summary>',
-              '',
-              '```diff',
-              hasDiff ? trimLog(diff) : '(no diff)',
-              '```',
-              '</details>',
-            ].join('\n');
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-
-            const existing = comments.find(c => (c.body || '').includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body,
-              });
-            }
+          marker: '<!-- go-mod-tidy-check-result -->'
+          title: ${{ steps.tidy.outputs.title }}
+          body-file: /tmp/go-mod-tidy.diff
+          details-summary: '📄 go.mod / go.sum diff'
 
       - name: Fail if tidy check failed
         if: always()

--- a/.github/workflows/trivy-fs.yaml
+++ b/.github/workflows/trivy-fs.yaml
@@ -55,9 +55,12 @@ jobs:
           echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
 
           if [ "$COUNT" -eq 0 ]; then
+            echo "title=## ✅ Trivy FS: PASS (no vulnerabilities)" >> "$GITHUB_OUTPUT"
             echo "No vulnerabilities found." > trivy-fs-summary.md
             exit 0
           fi
+
+          echo "title=## 🚨 Trivy FS: FOUND (${COUNT})" >> "$GITHUB_OUTPUT"
 
           # Build markdown summary
           jq -r '
@@ -82,92 +85,13 @@ jobs:
       - name: Comment Trivy FS result on PR
         if: ${{ github.event_name == 'pull_request' }}
         continue-on-error: true
-        uses: actions/github-script@v8
-        env:
-          COUNT: ${{ steps.summarize.outputs.count }}
+        uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-
-            const marker = '<!-- trivy-fs-result -->';
-            const count = Number(process.env.COUNT || '0');
-
-            const updatedAtJST = new Date().toLocaleString('ja-JP', {
-              timeZone: 'Asia/Tokyo',
-              year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-            });
-
-            const headSha =
-              (context.payload.pull_request?.head?.sha)
-              || process.env.GITHUB_SHA
-              || context.sha;
-            const shortSha = headSha.slice(0, 7);
-
-            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            const commitUrl = `${repoUrl}/commit/${headSha}`;
-
-            const read = (p) => {
-              try { return fs.readFileSync(p, 'utf8').trim(); }
-              catch (e) { return '(summary not found)'; }
-            };
-
-            const trimLog = (txt) => {
-              const MAX = 45000; // コメント上限対策
-              if (txt.length <= MAX) return txt;
-              return txt.slice(0, MAX) + '\n... (truncated)';
-            };
-
-            const title = (count === 0)
-              ? '✅ Trivy FS: PASS (no vulnerabilities)'
-              : `🚨 Trivy FS: FOUND (${count})`;
-
-            const summary = read('trivy-fs-summary.md');
-
-            const body = [
-              marker,
-              `## ${title}`,
-              '',
-              `- Total vulnerabilities: **${count}**`,
-              `- 🔖 Commit: [\`${shortSha}\`](${commitUrl})`,
-              `- 🕒 UpdatedAt: ${updatedAtJST} (JST)`,
-              '',
-              '<details><summary>📄 Summary</summary>',
-              '',
-              trimLog(summary),
-              '',
-              '</details>',
-            ].join('\n');
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-
-            const existing = comments.find(c => (c.body || '').includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body,
-              });
-            }
+          marker: '<!-- trivy-fs-result -->'
+          title: ${{ steps.summarize.outputs.title }}
+          body-file: trivy-fs-summary.md
+          details-summary: '📄 Summary'
 
       - name: Trivy FS scan (SARIF)
         if: always()

--- a/.github/workflows/trivy-release-gate.yaml
+++ b/.github/workflows/trivy-release-gate.yaml
@@ -61,9 +61,12 @@ jobs:
           echo "unfixed=${UNFIXED}" >> "$GITHUB_OUTPUT"
 
           if [ "$COUNT" -eq 0 ]; then
+            echo "title=## ✅ Release Dependency Scan: PASS (no vulnerabilities)" >> "$GITHUB_OUTPUT"
             echo "No vulnerabilities found." > trivy-fs-release-summary.md
             exit 0
           fi
+
+          echo "title=## 🚨 Release Dependency Scan: FOUND (${COUNT}, unfixed ${UNFIXED})" >> "$GITHUB_OUTPUT"
 
           # Build markdown summary
           jq -r '
@@ -87,89 +90,11 @@ jobs:
 
       - name: Comment Trivy FS release result on PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v8
+        continue-on-error: true
+        uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-
-            const marker = '<!-- trivy-fs-release-result -->';
-            const count = Number('${{ steps.summarize.outputs.count }}' || '0');
-            const unfixed = Number('${{ steps.summarize.outputs.unfixed }}' || '0');
-
-            const updatedAtJST = new Date().toLocaleString('ja-JP', {
-              timeZone: 'Asia/Tokyo',
-              year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-            });
-
-            const headSha =
-              (context.payload.pull_request?.head?.sha)
-              || process.env.GITHUB_SHA
-              || context.sha;
-            const shortSha = headSha.slice(0, 7);
-
-            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            const commitUrl = `${repoUrl}/commit/${headSha}`;
-
-            const read = (p) => {
-              try { return fs.readFileSync(p, 'utf8').trim(); }
-              catch (e) { return '(summary not found)'; }
-            };
-
-            const trimLog = (txt) => {
-              const MAX = 45000; // コメント上限対策
-              if (txt.length <= MAX) return txt;
-              return txt.slice(0, MAX) + '\n... (truncated)';
-            };
-
-            const title = (count === 0)
-              ? '✅ Release Dependency Scan: PASS (no vulnerabilities)'
-              : `🚨 Release Dependency Scan: FOUND (${count})`;
-
-            const summary = read('trivy-fs-release-summary.md');
-
-            const body = [
-              marker,
-              `## ${title}`,
-              '',
-              `- Total vulnerabilities: **${count}**`,
-              `- Unfixed (no patch): **${unfixed}**`,
-              `- 🔖 Commit: [\`${shortSha}\`](${commitUrl})`,
-              `- 🕒 UpdatedAt: ${updatedAtJST} (JST)`,
-              '',
-              '<details><summary>📄 Summary</summary>',
-              '',
-              trimLog(summary),
-              '',
-              '</details>',
-            ].join('\n');
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-
-            const existing = comments.find(c => (c.body || '').includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body,
-              });
-            }
+          marker: '<!-- trivy-fs-release-result -->'
+          title: ${{ steps.summarize.outputs.title }}
+          body-file: trivy-fs-release-summary.md
+          details-summary: '📄 Summary'

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -61,6 +61,7 @@ jobs:
 
           if [ "${COUNT}" -gt 0 ]; then
             echo "has_findings=true" >> "$GITHUB_OUTPUT"
+            echo "title=## 🚨 govulncheck: FOUND (${COUNT})" >> "$GITHUB_OUTPUT"
 
             jq -r '
               map({ mod: .trace[0].module, cur: .trace[0].version, fix: .fixed_version })
@@ -91,6 +92,7 @@ jobs:
             } > govulncheck-summary.md
           else
             echo "has_findings=false" >> "$GITHUB_OUTPUT"
+            echo "title=## ✅ govulncheck: PASS (no actionable vulnerabilities)" >> "$GITHUB_OUTPUT"
             echo "No actionable vulnerabilities detected by govulncheck." > govulncheck-summary.md
           fi
         shell: bash
@@ -98,94 +100,13 @@ jobs:
       - name: Comment govulncheck result on PR
         if: ${{ github.event_name == 'pull_request' }}
         continue-on-error: true
-        uses: actions/github-script@v8
-        env:
-          HAS_FINDINGS: ${{ steps.summarize.outputs.has_findings }}
-          COUNT: ${{ steps.summarize.outputs.count }}
+        uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-
-            const marker = '<!-- govulncheck-result -->';
-            const hasFindings = (process.env.HAS_FINDINGS === 'true');
-            const count = Number(process.env.COUNT || '0');
-
-            const updatedAtJST = new Date().toLocaleString('ja-JP', {
-              timeZone: 'Asia/Tokyo',
-              year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-            });
-
-            const headSha =
-              (context.payload.pull_request?.head?.sha)
-              || process.env.GITHUB_SHA
-              || context.sha;
-            const shortSha = headSha.slice(0, 7);
-
-            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            const commitUrl = `${repoUrl}/commit/${headSha}`;
-
-            const read = (p) => {
-              try { return fs.readFileSync(p, 'utf8').trim(); }
-              catch (e) { return '(summary not found)'; }
-            };
-
-            const trimLog = (txt) => {
-              const MAX = 45000;
-              if (txt.length <= MAX) return txt;
-              return txt.slice(0, MAX) + '\n... (truncated)';
-            };
-
-            const title = hasFindings
-              ? `🚨 govulncheck: FOUND (${count})`
-              : '✅ govulncheck: PASS (no actionable vulnerabilities)';
-
-            const summary = read('govulncheck-summary.md');
-
-            const body = [
-              marker,
-              `## ${title}`,
-              '',
-              `- Actionable findings: **${count}**`,
-              `- 🔖 Commit: [\`${shortSha}\`](${commitUrl})`,
-              `- 🕒 UpdatedAt: ${updatedAtJST} (JST)`,
-              '',
-              '<details><summary>📄 Summary</summary>',
-              '',
-              trimLog(summary),
-              '',
-              '</details>',
-            ].join('\n');
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-
-            const existing = comments.find(c => (c.body || '').includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body,
-              });
-            }
+          marker: '<!-- govulncheck-result -->'
+          title: ${{ steps.summarize.outputs.title }}
+          body-file: govulncheck-summary.md
+          details-summary: '📄 Summary'
 
       - name: Upload govulncheck artifacts
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
# 概要

手書き github-script で各ワークフローに重複していた PR コメントの upsert ロジック（marker でコメント検出 → update/create、Commit / UpdatedAt フッター生成）を、既存の `./.github/actions/upsert-pr-comment` 複合アクションへ集約する。`image-scan` のみ共通化済みだった状態を全ワークフローへ展開する。

> #362（ワークフロー名・ステップ名の統一）の上に積んだ PR です。base は #362 ブランチで、#362 マージ後に自動で `release/v1.4.0` へ再ターゲットされます。

## 変更内容

対象は手書き github-script だった **11 ワークフロー**：
`lint` / `sql-lint` / `migration-check` / `sync-versions-check` / `tidy-check` / `trivy-fs` / `trivy-release-gate` / `vulnerability-check` / `gen-db` / `gen-go` / `gen-oapi`

- 各ワークフローは「見出し(title) を Run/summarize ステップの出力で算出」し、本文（ログ / サマリ / 差分一覧）を `body-file` として複合アクションへ渡すだけにした
- **lean 方針**: ステータス(PASS/FAIL)は見出しに集約。Commit / UpdatedAt フッターは共通アクションが付与（書式が全コメントで統一される）
- `gen-*` / `sql-lint` は本文（diff/no-diff の条件分岐・変更ファイル一覧・カテゴリ別ログ）を bash で `body-file` に構築
- **11 ファイルで 923 行削除 / 189 行追加**（手書き upsert を全廃）

## 動作確認方法

- 全ワークフロー YAML パース OK（11/11）
- `actionlint`（式・複合アクション参照・入力）exit 0
- shellcheck 統合検査: 新規 bash の指摘は SC2016(info)＝単一引用符内バックティックの非展開警告のみ（リテラル出力の意図どおり。実 CI の go_tool_runner には shellcheck 非搭載）
- 本 PR 自体がこれらのワークフローを発火させるため、各コメントの実レンダリングを PR 上で確認できる

> 注: `continue-on-error: true` のため、コメント投稿の失敗時も CI は緑のままです。各コメントが実際に表示されることを PR 上でご確認ください。