### PR TITLE
workflows README をワークフロー実態に同期

### DIFF
--- a/.github/workflows/README.ja.md
+++ b/.github/workflows/README.ja.md
@@ -19,38 +19,49 @@
 
 |ワークフロー|ファイル|説明|
 |---|---|---|
-|Golang Lint|`lint.yaml`|golangci-lint による Go コードの静的解析|
-|Golang Test|`test.yaml`|Go テスト実行とカバレッジレポート|
-|Go Module Consistency|`tidy-check.yaml`|go.mod / go.sum の整合性検証|
+|Go Lint|`lint.yaml`|golangci-lint による Go コードの静的解析|
+|Go Test|`test.yaml`|Go テスト実行とカバレッジレポート|
+|Module Tidy Check|`tidy-check.yaml`|go.mod / go.sum の整合性検証|
 |SQL Lint|`sql-lint.yaml`|sqlfluff による migration / DML / seed SQL の検証|
 |Migration Check|`migration-check.yaml`|マイグレーションファイルの検証（重複、欠番、up/down ペア）|
-|Generated Go Artifacts|`gen-go-artifacts-check.yaml`|生成済み Go コードとコミット済み成果物の一致検証|
-|Generated DB Artifacts|`gen-db-artifacts-check.yaml`|生成済み sqlc コードとコミット済み成果物の一致検証|
-|Generated OpenAPI Artifacts|`gen-oapi-artifacts-check.yaml`|OpenAPI バンドルとドキュメントの一致検証|
-|Application Boot|`app-di-startup-check.yaml`|DB 付きでアプリケーションが正常に起動するか検証|
+|Sync Versions Check|`sync-versions-check.yaml`|mise.toml のバージョンが go.mod / 各 Dockerfile / README へ伝播済みか検証|
+|Generated Go Artifacts Check|`gen-go-artifacts-check.yaml`|生成済み Go コードとコミット済み成果物の一致検証|
+|Generated Database Artifacts Check|`gen-db-artifacts-check.yaml`|生成済み sqlc コードとコミット済み成果物の一致検証|
+|Generated OpenAPI Artifacts Check|`gen-oapi-artifacts-check.yaml`|OpenAPI バンドルとドキュメントの一致検証|
+|App Boot Check|`app-di-startup-check.yaml`|DB 付きでアプリケーションサーバが正常に起動するか検証|
+|Job Boot Check|`job-boot-check.yaml`|ジョブのエントリポイントが起動し、未知のジョブを拒否するか検証|
 
 ### セキュリティ
 
 |ワークフロー|ファイル|説明|
 |---|---|---|
-|Code Security Scan|`code-ql.yaml`|CodeQL によるセキュリティ脆弱性分析|
-|Dependency Vulnerability Scan|`trivy-fs.yaml`|Trivy によるライブラリ脆弱性スキャン(開発者向け)|
-|Release Dependency Vulnerability Scan|`trivy-release-gate.yaml`|develop/staging/production 向け PR での Trivy 依存スキャン|
-|Docker Image Scan|`image-scan.yaml`|Docker イメージビルド + SBOM 生成 + Trivy スキャン|
-|Go Vulnerability Analysis|`vulnerability-check.yaml`|govulncheck による Go パッケージ脆弱性検出|
+|CodeQL Scan|`code-ql.yaml`|CodeQL によるセキュリティ脆弱性分析|
+|Dependency Scan|`trivy-fs.yaml`|Trivy によるライブラリ脆弱性スキャン(開発者向け)|
+|Release Dependency Scan|`trivy-release-gate.yaml`|develop/staging/production 向け PR での Trivy 依存スキャン|
+|Image Scan|`image-scan.yaml`|Docker イメージビルド + SBOM 生成 + Trivy スキャン|
+|Vulnerability Scan|`vulnerability-check.yaml`|govulncheck による Go パッケージ脆弱性検出|
 
 ### デプロイ（Push）
 
 |ワークフロー|ファイル|トリガー|説明|
 |---|---|---|---|
-|Application Deployment|`deploy-app.yaml`|production/staging/develop への push|Docker イメージのビルド・プッシュ、マイグレーション実行、デプロイ|
-|Deploy Docs Portal|`deploy-docs.yaml`|production への push（docs 変更時）|ドキュメントポータルを GitHub Pages にデプロイ|
+|Deploy App|`deploy-app.yaml`|production/staging/develop への push|Docker イメージのビルド・プッシュ、マイグレーション実行、デプロイ|
+|Deploy Docs|`deploy-docs.yaml`|production への push（docs 変更時）|ドキュメントポータルを GitHub Pages にデプロイ|
 
 ### ドキュメント生成（Push）
 
 |ワークフロー|ファイル|トリガー|説明|
 |---|---|---|---|
-|Auto-generate Docs PR|`auto-generate-docs.yaml`|release/* への push|OpenAPI ドキュメント、ER 図、ポータルドキュメントを自動生成|
+|Auto-generate Docs|`auto-generate-docs.yaml`|release/* への push|OpenAPI ドキュメント、ER 図、ポータルドキュメントを自動生成|
+
+## 共通 Composite Action
+
+再利用可能な composite action は [`.github/actions/`](../actions/) に配置しています：
+
+|アクション|目的|
+|---|---|
+|`setup-postgres`|Postgres サービスコンテナの待機・初期化（DB 依存ジョブで使用）|
+|`upsert-pr-comment`|マーカーで既存コメントを検出して update / create する PR コメントの upsert。Commit / UpdatedAt フッターを共通付与し、結果コメント系ワークフローで使用|
 
 ## 補足
 

--- a/.github/workflows/README.ja.md
+++ b/.github/workflows/README.ja.md
@@ -23,6 +23,7 @@
 |Go Test|`test.yaml`|Go テスト実行とカバレッジレポート|
 |Module Tidy Check|`tidy-check.yaml`|go.mod / go.sum の整合性検証|
 |SQL Lint|`sql-lint.yaml`|sqlfluff による migration / DML / seed SQL の検証|
+|Actions Lint|`actions-lint.yaml`|actionlint による GitHub Actions 定義（ワークフロー / composite action）の検証（go_tool_runner 経由）|
 |Migration Check|`migration-check.yaml`|マイグレーションファイルの検証（重複、欠番、up/down ペア）|
 |Sync Versions Check|`sync-versions-check.yaml`|mise.toml のバージョンが go.mod / 各 Dockerfile / README へ伝播済みか検証|
 |Generated Go Artifacts Check|`gen-go-artifacts-check.yaml`|生成済み Go コードとコミット済み成果物の一致検証|

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,6 +23,7 @@ This directory contains GitHub Actions workflow definitions for CI/CD. Workflows
 |Go Test|`test.yaml`|Run Go tests with coverage reporting|
 |Module Tidy Check|`tidy-check.yaml`|Verify go.mod / go.sum are tidied|
 |SQL Lint|`sql-lint.yaml`|Run sqlfluff on migration / DML / seed SQL files|
+|Actions Lint|`actions-lint.yaml`|Run actionlint on workflow / composite-action definitions (via go_tool_runner)|
 |Migration Check|`migration-check.yaml`|Validate migration files (duplicates, gaps, up/down pairing)|
 |Sync Versions Check|`sync-versions-check.yaml`|Verify mise.toml versions are propagated to go.mod / Dockerfiles / READMEs|
 |Generated Go Artifacts Check|`gen-go-artifacts-check.yaml`|Verify generated Go code matches committed artifacts|

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,38 +19,49 @@ This directory contains GitHub Actions workflow definitions for CI/CD. Workflows
 
 |Workflow|File|Description|
 |---|---|---|
-|Golang Lint|`lint.yaml`|Run golangci-lint on Go code|
-|Golang Test|`test.yaml`|Run Go tests with coverage reporting|
-|Go Module Consistency|`tidy-check.yaml`|Verify go.mod / go.sum are tidied|
+|Go Lint|`lint.yaml`|Run golangci-lint on Go code|
+|Go Test|`test.yaml`|Run Go tests with coverage reporting|
+|Module Tidy Check|`tidy-check.yaml`|Verify go.mod / go.sum are tidied|
 |SQL Lint|`sql-lint.yaml`|Run sqlfluff on migration / DML / seed SQL files|
 |Migration Check|`migration-check.yaml`|Validate migration files (duplicates, gaps, up/down pairing)|
-|Generated Go Artifacts|`gen-go-artifacts-check.yaml`|Verify generated Go code matches committed artifacts|
-|Generated DB Artifacts|`gen-db-artifacts-check.yaml`|Verify generated sqlc code matches committed artifacts|
-|Generated OpenAPI Artifacts|`gen-oapi-artifacts-check.yaml`|Verify OpenAPI bundle and docs match committed artifacts|
-|Application Boot|`app-di-startup-check.yaml`|Verify application starts successfully with DB|
+|Sync Versions Check|`sync-versions-check.yaml`|Verify mise.toml versions are propagated to go.mod / Dockerfiles / READMEs|
+|Generated Go Artifacts Check|`gen-go-artifacts-check.yaml`|Verify generated Go code matches committed artifacts|
+|Generated Database Artifacts Check|`gen-db-artifacts-check.yaml`|Verify generated sqlc code matches committed artifacts|
+|Generated OpenAPI Artifacts Check|`gen-oapi-artifacts-check.yaml`|Verify OpenAPI bundle and docs match committed artifacts|
+|App Boot Check|`app-di-startup-check.yaml`|Verify the application server starts successfully with DB|
+|Job Boot Check|`job-boot-check.yaml`|Verify the job entrypoint boots and rejects an unknown job|
 
 ### Security
 
 |Workflow|File|Description|
 |---|---|---|
-|Code Security Scan|`code-ql.yaml`|CodeQL analysis for security vulnerabilities|
-|Dependency Vulnerability Scan|`trivy-fs.yaml`|Trivy filesystem scan for library vulnerabilities (developer-facing)|
-|Release Dependency Vulnerability Scan|`trivy-release-gate.yaml`|Trivy filesystem scan on PRs into develop/staging/production|
-|Docker Image Scan|`image-scan.yaml`|Build image, generate SBOM, run Trivy scan|
-|Go Vulnerability Analysis|`vulnerability-check.yaml`|govulncheck for actionable Go vulnerabilities|
+|CodeQL Scan|`code-ql.yaml`|CodeQL analysis for security vulnerabilities|
+|Dependency Scan|`trivy-fs.yaml`|Trivy filesystem scan for library vulnerabilities (developer-facing)|
+|Release Dependency Scan|`trivy-release-gate.yaml`|Trivy filesystem scan on PRs into develop/staging/production|
+|Image Scan|`image-scan.yaml`|Build image, generate SBOM, run Trivy scan|
+|Vulnerability Scan|`vulnerability-check.yaml`|govulncheck for actionable Go vulnerabilities|
 
 ### Deployment (Push)
 
 |Workflow|File|Trigger|Description|
 |---|---|---|---|
-|Application Deployment|`deploy-app.yaml`|push to production/staging/develop|Build and push Docker images, run migration and deploy|
-|Deploy Docs Portal|`deploy-docs.yaml`|push to production (docs changes)|Deploy documentation portal to GitHub Pages|
+|Deploy App|`deploy-app.yaml`|push to production/staging/develop|Build and push Docker images, run migration and deploy|
+|Deploy Docs|`deploy-docs.yaml`|push to production (docs changes)|Deploy documentation portal to GitHub Pages|
 
 ### Documentation (Push)
 
 |Workflow|File|Trigger|Description|
 |---|---|---|---|
-|Auto-generate Docs PR|`auto-generate-docs.yaml`|push to release/* branches|Auto-generate OpenAPI docs, ER diagrams, portal docs|
+|Auto-generate Docs|`auto-generate-docs.yaml`|push to release/* branches|Auto-generate OpenAPI docs, ER diagrams, portal docs|
+
+## Shared Composite Actions
+
+Reusable composite actions live under [`.github/actions/`](../actions/):
+
+|Action|Purpose|
+|---|---|
+|`setup-postgres`|Wait for and initialize the Postgres service container (used by DB-dependent jobs)|
+|`upsert-pr-comment`|Marker-based PR comment upsert (detect existing → update / create) with a shared Commit / UpdatedAt footer, used by the result-commenting workflows|
 
 ## Notes
 


### PR DESCRIPTION
# 概要

`.github/workflows/README.md` / `README.ja.md` が実際のワークフロー定義からドリフトしていたため同期する。マージ済み #362（ワークフロー名・ステップ名の統一）の名称変更に追従し、欠落していた行と共通アクションの記載を補う。

## 変更内容

- **ワークフロー名を新名称へ更新**: Golang Lint→Go Lint / Golang Test→Go Test / Go Module Consistency→Module Tidy Check / Code Security Scan→CodeQL Scan / Dependency Vulnerability Scan→Dependency Scan / Docker Image Scan→Image Scan / Go Vulnerability Analysis→Vulnerability Scan / Application Deployment→Deploy App / Deploy Docs Portal→Deploy Docs / Auto-generate Docs PR→Auto-generate Docs / Application Boot→App Boot Check
- **欠落行を追加**: CI Checks に `Sync Versions Check` / `Job Boot Check`（以前から README 未記載だった）
- `Generated * Artifacts` を実 `name:`（`... Check`）に合わせて明記
- **共通 Composite Action の節を新設**: `.github/actions/`（`setup-postgres` / `upsert-pr-comment`）。`.github/actions/` 自体に README は無いためここで案内
- `README.md` / `README.ja.md` を同期（差分は README 2 ファイルのみ）

## 動作確認方法

- 旧名称の残存なしを grep で確認
- release/v1.4.0 の全19ワークフローと README 記載が一致

## 補足（別 PR との関係）

- **Actions Lint 行は含めていません**。`actions-lint.yaml` は actionlint 追加 PR(#364)で追加されるため、その行は #364 側で補うのが整合的です。
- PR コメント共通化(#365)で `upsert-pr-comment` が結果コメント系の標準になった点も本 README の Composite Action 節に反映済みです。