### PR TITLE
Dockerfile を検証する hadolint を追加

### DIFF
--- a/.github/workflows/docker-lint.yaml
+++ b/.github/workflows/docker-lint.yaml
@@ -1,0 +1,67 @@
+name: Dockerfile Lint
+
+on:
+  pull_request:
+    paths:
+      - 'docker/**/Dockerfile'
+      - '.hadolint.yaml'
+      - 'mise.toml'
+      - '.makefiles/docker/lint.mk'
+      - '.github/workflows/docker-lint.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker-lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build go tool runner
+        run: docker compose build go_tool_runner
+
+      - name: Run hadolint
+        id: hadolint
+        shell: bash
+        run: |
+          set +e
+
+          make docker-lint 2>&1 | tee /tmp/hadolint.log
+
+          code=${PIPESTATUS[0]}
+
+          if [ "$code" -eq 0 ]; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+            echo "title=## ✅ Dockerfile lint: PASS (hadolint)" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "title=## ❌ Dockerfile lint: FAIL (hadolint)" >> "$GITHUB_OUTPUT"
+          fi
+
+          exit 0
+
+      - name: Comment Dockerfile lint result on PR
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: ./.github/actions/upsert-pr-comment
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          marker: '<!-- dockerfile-lint-result -->'
+          title: ${{ steps.hadolint.outputs.title }}
+          body-file: /tmp/hadolint.log
+          details-summary: 'hadolint log'
+
+      - name: Fail if hadolint failed
+        if: always() && steps.hadolint.outputs.status != 'success'
+        run: exit 1

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,9 +1,5 @@
 # hadolint 設定
 # https://github.com/hadolint/hadolint#configure
-#
-# DL3018 (apk) / DL3008 (apt) のバージョン固定は意図的に無効化する。
-# base / ツールイメージのパッケージは alpine / debian リポジトリの流動性が高く、
-# 固定すると再現性より保守コストが上回るため。
 ignored:
-  - DL3018
-  - DL3008
+  - DL3018 # apk のバージョン固定: alpine リポジトリの流動性が高く、固定は保守コストが過大なため無効化
+  - DL3008 # apt のバージョン固定: debian リポジトリの流動性が高く、固定は保守コストが過大なため無効化

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,9 @@
+# hadolint 設定
+# https://github.com/hadolint/hadolint#configure
+#
+# DL3018 (apk) / DL3008 (apt) のバージョン固定は意図的に無効化する。
+# base / ツールイメージのパッケージは alpine / debian リポジトリの流動性が高く、
+# 固定すると再現性より保守コストが上回るため。
+ignored:
+  - DL3018
+  - DL3008

--- a/.lefthook.yaml
+++ b/.lefthook.yaml
@@ -15,6 +15,11 @@ pre-commit:
         - ".github/workflows/*.{yml,yaml}"
         - ".github/actions/**/*.{yml,yaml}"
       run: make actions-lint
+    docker-lint:
+      glob:
+        - "docker/**/Dockerfile"
+        - ".hadolint.yaml"
+      run: make docker-lint
     migration-check-version:
       glob: "database/migrations/*.sql"
       run: make check-migration-up-version check-migration-down-version

--- a/.makefiles/docker/lint.mk
+++ b/.makefiles/docker/lint.mk
@@ -1,0 +1,13 @@
+## Dockerfile に対するLintコマンド群
+# -----Dockerコンテナ内で実行するコマンド群-----
+.PHONY: docker-lint ## Dockerfile の Lint を実行
+# -----CI内で実行するコマンド群-----
+.PHONY: docker-lint-ci ## Dockerfile の Lint を実行(CI用)
+
+# -----Dockerコンテナ内で実行するコマンド群-----
+docker-lint:
+	@docker compose run --rm go_tool_runner make docker-lint-ci
+
+# -----CI内で実行するコマンド群-----
+docker-lint-ci:
+	hadolint docker/*/Dockerfile

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -40,11 +40,10 @@ FROM alpine:3.23 AS runtime
 # デプロイ対象環境（prd/stg/dev）。当該 env ファイルのみ焼き込み、ENV として固定する。
 ARG APP_ENV=prd
 
-RUN apk upgrade --no-cache
-
-RUN apk add --no-cache ca-certificates tzdata
-
-RUN addgroup -S app && adduser -S app -G app
+RUN apk upgrade --no-cache \
+    && apk add --no-cache ca-certificates tzdata \
+    && addgroup -S app \
+    && adduser -S app -G app
 USER app
 
 COPY --from=builder --chown=app:app /app/bin/server /app/server
@@ -74,6 +73,9 @@ FROM golang:1.26.4-alpine AS tooling_builder
 
 # CGO_ENABLED=0: `go:` backend のツールを静的バイナリにする（go_tools_builder と対称）
 ENV CGO_ENABLED=0
+
+# パイプを含む RUN（mise インストール）の失敗を確実に検知するため pipefail を有効化（hadolint DL4006）
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 RUN apk add --no-cache bash ca-certificates curl git
 

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -10,6 +10,9 @@ FROM golang:1.26.4-alpine AS go_tools_builder
 # CGO_ENABLED=0: `go:` backend で install されるツール（mockgen）を静的バイナリにする
 ENV CGO_ENABLED=0
 
+# パイプを含む RUN（mise インストール）の失敗を確実に検知するため pipefail を有効化（hadolint DL4006）
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
 RUN apk add --no-cache bash ca-certificates curl git
 
 ARG MISE_VERSION
@@ -28,7 +31,8 @@ RUN mise install aqua:golang-migrate/migrate \
     && mise install oapi-codegen \
     && mise install sqlc \
     && mise install aqua:aquasecurity/trivy \
-    && mise install actionlint
+    && mise install actionlint \
+    && mise install hadolint
 
 RUN mkdir /out \
     && cp "$(mise which migrate)" /out/ \
@@ -36,10 +40,11 @@ RUN mkdir /out \
     && cp "$(mise which oapi-codegen)" /out/ \
     && cp "$(mise which sqlc)" /out/ \
     && cp "$(mise which trivy)" /out/ \
-    && cp "$(mise which actionlint)" /out/
+    && cp "$(mise which actionlint)" /out/ \
+    && cp "$(mise which hadolint)" /out/
 
 # ------------------------------
-# Go ツールボックス：migrate / mockgen / oapi-codegen / sqlc / trivy / actionlint を mise.toml のバージョンで提供
+# Go ツールボックス：migrate / mockgen / oapi-codegen / sqlc / trivy / actionlint / hadolint を mise.toml のバージョンで提供
 # Go ランタイムは golang 公式 base image を使用（mise.toml の go 値と `make sync-go-version` で同期）
 # ------------------------------
 FROM golang:1.26.4-alpine AS go_tools
@@ -69,6 +74,9 @@ CMD []
 # ローカル node_modules にインストールしておく
 # ------------------------------
 FROM node:24.14-alpine AS node_tools
+
+# パイプを含む RUN（mise インストール）の失敗を確実に検知するため pipefail を有効化（hadolint DL4006）
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 RUN apk add --no-cache \
     bash \
@@ -123,6 +131,10 @@ RUN apt-get update \
         make \
         pipx \
     && rm -rf /var/lib/apt/lists/*
+
+# パイプを含む RUN（mise インストール）の失敗を確実に検知するため pipefail を有効化（hadolint DL4006）
+# bash は上の apt-get で導入済み（python:slim は debian ベースで /bin/ash を持たない）
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG MISE_VERSION
 ENV PATH="/root/.local/bin:/root/.local/share/mise/shims:$PATH" \

--- a/makefile
+++ b/makefile
@@ -43,6 +43,8 @@ include .makefiles/sql/lint.mk
 include .makefiles/markdown/lint.mk
 # セキュリティ関連
 include .makefiles/security/trivy.mk
+# Docker関連
+include .makefiles/docker/lint.mk
 
 # 一括実行系ファイル
 # GitHub関連

--- a/mise.toml
+++ b/mise.toml
@@ -19,6 +19,8 @@ lefthook = "2.1.8"
 air = "1.65.3"
 golines = "0.13.0"
 gofumpt = "0.10.0"
+# Dockerfile linter（Haskell 製、標準レジストリで解決可）
+hadolint = "2.14.0"
 
 # Go ベース（backend 明示）
 "aqua:golang-migrate/migrate" = "4.19.1"


### PR DESCRIPTION
# 概要

Dockerfile を静的検証する hadolint を追加する。実行は actionlint と同じく **docker tool-runner（go_tool_runner）経由**とし、mise はバージョン宣言（SSOT）に限定する（実行時の mise exec / mise install には依存しない）。導入にあたり既存 Dockerfile を hadolint 準拠へ修正した。

## 変更内容

### ツール導入（Build）
- `mise.toml`: `hadolint 2.14.0` をピン留め（Haskell 製、標準レジストリ解決）
- `docker/tools/Dockerfile`: `go_tools_builder` で hadolint を install し、バイナリのみ `go_tools` へ抽出（最終イメージは mise 非依存）
- `.makefiles/docker/lint.mk`（新規）: 二層ターゲット `docker-lint`（ホスト=runner 起動）/ `docker-lint-ci`（コンテナ内=`hadolint docker/*/Dockerfile`）。`makefile` に include
- `.hadolint.yaml`（新規）: バージョン固定ルール `DL3018`(apk)/`DL3008`(apt) を意図的に無効化（alpine/debian リポジトリの流動性が高く固定は保守コスト過大）

### 既存 Dockerfile の hadolint 準拠修正
- **DL4006**: パイプを含む mise インストール RUN の前に pipefail SHELL を設定（alpine 各 stage は `/bin/ash`、`python:slim` は bash 導入後に `/bin/bash`）
- **DL3059**: `docker/server` runtime ステージの連続 RUN を統合

### CI 配線
- `.github/workflows/docker-lint.yaml`（新規）: `docker compose build go_tool_runner` → `make docker-lint`（actions-lint.yaml と同型）。marker 付き `upsert-pr-comment` で PR コメント、末尾で fail
- `.lefthook.yaml`: pre-commit に `docker-lint` を追加（glob: `docker/**/Dockerfile` / `.hadolint.yaml`）

## 動作確認（実機）

- 全 Dockerfile が hadolint クリア（`make docker-lint` exit 0）
- **ビルド成功を実機確認**: go_tool_runner（hadolint 2.14.0 同梱）/ node_tool_runner / python_tool_runner / `docker/server` の tooling・migration 全 stage
- lefthook: Dockerfile 変更時のみ `docker-lint` 発火、`.go` のみは skip
- `actionlint` + `shellcheck` + `lefthook validate` いずれも clean

## 補足
- workflows README への `Dockerfile Lint` 行追加は、README 同期 PR(#366) もしくは別途で対応します（本ブランチは release/v1.4.0 起点で #366 未マージのため）。