### PR TITLE
カバレッジゲートを新設（総カバレッジ 90% 未満で fail）

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,3 +72,6 @@ jobs:
 
       - name: Report Test Coverage
         uses: k1LoW/octocov-action@v1
+
+      - name: Coverage gate
+        run: make cover-gate

--- a/.makefiles/go/test.mk
+++ b/.makefiles/go/test.mk
@@ -3,9 +3,13 @@
 .PHONY: test-cached ## ローカル用テスト実行（キャッシュ有効・pre-commit向け）
 .PHONY: gen-test-repo ## テストの実行とテストレポートの生成
 .PHONY: test-cover-ci ## CI用のカバレッジ付きテスト実行
+.PHONY: cover-gate ## 総カバレッジが閾値以上か検証（CIゲート）
 
 # カバレッジ対象外パッケージ（test / test-cached / gen-test-repo / test-cover-ci で共有）
 GO_TEST_EXCLUDE := /(gen|cmd|mock|apperror|scripts)(/|$$)
+
+# カバレッジゲートの下限（CLAUDE.md の 90% フロア）
+COVERAGE_THRESHOLD := 90
 
 test:
 	@TGT_PKGS="$$(go list ./... | grep -Ev '$(GO_TEST_EXCLUDE)')"; \
@@ -36,3 +40,12 @@ test-cover-ci:
 		| tr '\n' ',' \
 		| sed 's/,$$//')"; \
 	go test $$TGT_PKGS -coverpkg=$$COVER_PKGS -coverprofile=coverage.out -covermode=atomic -count=1
+
+cover-gate:
+	@test -f coverage.out || { echo "❌ coverage.out がありません（先に make test-cover-ci を実行）"; exit 1; }
+	@total="$$(go tool cover -func=coverage.out | awk '/^total:/ {gsub("%","",$$NF); print $$NF}')"; \
+	awk -v t="$$total" -v th="$(COVERAGE_THRESHOLD)" 'BEGIN { \
+		if (t == "") { print "❌ 総カバレッジを取得できません"; exit 1 } \
+		if (t+0 < th+0) { printf "❌ 総カバレッジ %.1f%% がしきい値 %d%% を下回っています\n", t, th; exit 1 } \
+		printf "✅ 総カバレッジ %.1f%% (しきい値 %d%%)\n", t, th \
+	}'


### PR DESCRIPTION
# 概要

現状カバレッジは octocov でレポート / PR コメントされるが、閾値割れで CI を fail させる**ゲートが無い**。CLAUDE.md の「新規/変更パッケージは 90% 超・ベースラインから低下させない」を CI で担保するゲートを新設する。

## 方式の判断

octocov の `coverage.acceptable` を当初検討したが、**bare `octocov` 実行は acceptable 違反でも exit 0**（CI env 模倣・25% カバレッジでも非ゼロにならず）であることをローカル検証で確認した。確実にゲートするため、`go tool cover -func` の総%を直接判定する**明示ゲート**にした。

## 変更内容

- **`.makefiles/go/test.mk`**: `cover-gate` ターゲットを追加。`COVERAGE_THRESHOLD`(=90) を下回る、または `coverage.out` が無い場合に `exit 1`。閾値は make 変数で一元管理
- **`.github/workflows/test.yaml`**: `Report Test Coverage`（octocov）の**後**に `Coverage gate` ステップ（`make cover-gate`）を追加。低下時もカバレッジコメントは残しつつ Go Test ジョブを fail させマージブロック

## 動作確認（ローカル）

- 実カバレッジ **98.5% → ✅ pass**（exit 0）
- 閾値割れ **85.0 / 89.9% → ❌ fail**（exit 1）、**90.0% → ✅ pass**（境界 >=）
- `coverage.out` 欠如 → ❌ fail（fail-safe）
- test.yaml: YAML パース / actionlint OK

## 補足
- 閾値を変えたい場合は `COVERAGE_THRESHOLD` のみ変更。
- octocov 側（レポート/コメント/diff）は現状維持。ゲートは明示ステップが担当。