### PR TITLE
シークレットスキャン（gitleaks）を追加

### DIFF
--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -1,0 +1,61 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build go tool runner
+        run: docker compose build go_tool_runner
+
+      - name: Run gitleaks
+        id: gitleaks
+        shell: bash
+        run: |
+          set +e
+
+          make secret-scan 2>&1 | tee /tmp/gitleaks.log
+
+          code=${PIPESTATUS[0]}
+
+          if [ "$code" -eq 0 ]; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+            echo "title=## ✅ Secret scan: PASS (gitleaks)" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "title=## ❌ Secret scan: FAIL (gitleaks)" >> "$GITHUB_OUTPUT"
+          fi
+
+          exit 0
+
+      - name: Comment secret scan result on PR
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: ./.github/actions/upsert-pr-comment
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          marker: '<!-- secret-scan-result -->'
+          title: ${{ steps.gitleaks.outputs.title }}
+          body-file: /tmp/gitleaks.log
+          details-summary: 'gitleaks log'
+
+      - name: Fail if gitleaks failed
+        if: always() && steps.gitleaks.outputs.status != 'success'
+        run: exit 1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+# gitleaks 設定
+# https://github.com/gitleaks/gitleaks#configuration
+[extend]
+useDefault = true
+
+[allowlist]
+description = "生成ファイルは機械生成で秘密の置き場所ではないため除外する"
+paths = [
+  '''.*\.gen\.go$''',
+  '''.*\.sql\.go$''',
+  '''.*_mock\.go$''',
+  '''.*/mock_.*\.go$''',
+  '''openapi/openapi\.gen\.yaml$''',
+]

--- a/.lefthook.yaml
+++ b/.lefthook.yaml
@@ -20,6 +20,9 @@ pre-commit:
         - "docker/**/Dockerfile"
         - ".hadolint.yaml"
       run: make docker-lint
+    secret-scan:
+      # 秘密はどのファイルにも入りうるため glob で絞らず全コミットで実行する
+      run: make secret-scan
     migration-check-version:
       glob: "database/migrations/*.sql"
       run: make check-migration-up-version check-migration-down-version

--- a/.makefiles/security/gitleaks.mk
+++ b/.makefiles/security/gitleaks.mk
@@ -1,0 +1,14 @@
+## シークレットスキャン（gitleaks）
+# -----Dockerコンテナ内で実行するコマンド群-----
+.PHONY: secret-scan ## ワーキングツリーのシークレットスキャンを実行
+# -----CI内で実行するコマンド群-----
+.PHONY: secret-scan-ci ## シークレットスキャンを実行(CI用)
+
+# -----Dockerコンテナ内で実行するコマンド群-----
+secret-scan:
+	@docker compose run --rm go_tool_runner make secret-scan-ci
+
+# -----CI内で実行するコマンド群-----
+# --redact: 検出値をログ/PRコメントに出さない（漏洩二次被害の防止）
+secret-scan-ci:
+	gitleaks dir . --no-banner --redact

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -32,7 +32,8 @@ RUN mise install aqua:golang-migrate/migrate \
     && mise install sqlc \
     && mise install aqua:aquasecurity/trivy \
     && mise install actionlint \
-    && mise install hadolint
+    && mise install hadolint \
+    && mise install gitleaks
 
 RUN mkdir /out \
     && cp "$(mise which migrate)" /out/ \
@@ -41,10 +42,11 @@ RUN mkdir /out \
     && cp "$(mise which sqlc)" /out/ \
     && cp "$(mise which trivy)" /out/ \
     && cp "$(mise which actionlint)" /out/ \
-    && cp "$(mise which hadolint)" /out/
+    && cp "$(mise which hadolint)" /out/ \
+    && cp "$(mise which gitleaks)" /out/
 
 # ------------------------------
-# Go ツールボックス：migrate / mockgen / oapi-codegen / sqlc / trivy / actionlint / hadolint を mise.toml のバージョンで提供
+# Go ツールボックス：migrate / mockgen / oapi-codegen / sqlc / trivy / actionlint / hadolint / gitleaks を mise.toml のバージョンで提供
 # Go ランタイムは golang 公式 base image を使用（mise.toml の go 値と `make sync-go-version` で同期）
 # ------------------------------
 FROM golang:1.26.4-alpine AS go_tools

--- a/makefile
+++ b/makefile
@@ -43,6 +43,7 @@ include .makefiles/sql/lint.mk
 include .makefiles/markdown/lint.mk
 # セキュリティ関連
 include .makefiles/security/trivy.mk
+include .makefiles/security/gitleaks.mk
 # Docker関連
 include .makefiles/docker/lint.mk
 

--- a/mise.toml
+++ b/mise.toml
@@ -21,6 +21,8 @@ golines = "0.13.0"
 gofumpt = "0.10.0"
 # Dockerfile linter（Haskell 製、標準レジストリで解決可）
 hadolint = "2.14.0"
+# secret scanner（標準レジストリで解決可）
+gitleaks = "8.30.1"
 
 # Go ベース（backend 明示）
 "aqua:golang-migrate/migrate" = "4.19.1"


### PR DESCRIPTION
# 概要

コミット内のシークレット混入を検知する gitleaks を追加する。CodeQL（コード）/ Trivy（依存・イメージ）に続くセキュリティレイヤとして、secret scanning を CI とコミット前フックに導入する。実行は actionlint / hadolint と同じく **docker tool-runner（go_tool_runner）経由**、mise はバージョン宣言（SSOT）に限定する。

## 事前調査（ベースライン）

- `gitleaks dir`（現ファイルツリー）: **検出 0**（env / docker-compose のダミー認証情報も誤検知なし）
- `gitleaks git`（全1386コミット履歴）: 1件のみ＝**生成ファイル `internal/.../validate.gen.go` 内の高エントロピー base64 の誤検知**（実シークレットではない）
- → 生成ファイルは秘密の置き場所ではない（カバレッジ / lint でも除外）ため `.gitleaks.toml` で allowlist

## 変更内容

### ツール導入（Build）
- `mise.toml`: `gitleaks 8.30.1` をピン留め
- `docker/tools/Dockerfile`: `go_tools_builder` で gitleaks を install しバイナリのみ `go_tools` へ抽出
- `.makefiles/security/gitleaks.mk`（新規）: 二層ターゲット `secret-scan`（runner 起動）/ `secret-scan-ci`（`gitleaks dir . --no-banner --redact`）。`makefile` に include
- `.gitleaks.toml`（新規）: `useDefault=true` で既定ルールを継承しつつ、生成ファイル（`*.gen.go` / `*.sql.go` / `*_mock.go` / `openapi.gen.yaml`）を allowlist
- `--redact`: 検出値をログ / PR コメントに出さない（漏洩二次被害の防止）

### CI 配線
- `.github/workflows/secret-scan.yaml`（新規）: **全 PR で発火**（秘密は任意ファイルに入りうるため paths 限定なし）。`docker compose build go_tool_runner` → `make secret-scan`、marker 付き `upsert-pr-comment` で投稿、検出時に fail
- `.lefthook.yaml`: pre-commit に `secret-scan` を追加（glob 無し＝全コミットで実行）

## 動作確認（実機）

- go_tool_runner ビルド成功（gitleaks 8.30.1 同梱）、`make secret-scan` exit 0（clean）
- **ゲート発火検証**: ダミー秘密 `AKIA...` を仕込んだ通常ファイル → **検出・exit 1**
- **allowlist 検証**: 同じ秘密を `*.gen.go` に仕込む → **検出されず**（生成ファイル除外が機能）
- lefthook: 任意コミットで `secret-scan` が発火
- `actionlint` + `shellcheck` + `lefthook validate` clean

## 補足
- workflows README への `Secret Scan` 行追加は README 同期 PR(#366) 等で別途対応。