### PR TITLE
mise-action の mise バージョンを固定し 404 を回避

### DIFF
--- a/.github/workflows/gen-db-artifacts-check.yaml
+++ b/.github/workflows/gen-db-artifacts-check.yaml
@@ -57,6 +57,9 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v2
         with:
+          # mise 本体のバージョンを固定（latest 追従だと未公開リリースを掴んで 404 になるため）。
+          # docker/tools/Dockerfile の MISE_VERSION と揃える。
+          version: 2026.6.0
           install: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/gen-db-artifacts-check.yaml
+++ b/.github/workflows/gen-db-artifacts-check.yaml
@@ -57,8 +57,6 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v2
         with:
-          # mise 本体のバージョンを固定（latest 追従だと未公開リリースを掴んで 404 になるため）。
-          # docker/tools/Dockerfile の MISE_VERSION と揃える。
           version: 2026.6.0
           install: false
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,6 +36,9 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v2
         with:
+          # mise 本体のバージョンを固定（latest 追従だと未公開リリースを掴んで 404 になるため）。
+          # docker/tools/Dockerfile の MISE_VERSION と揃える。
+          version: 2026.6.0
           install: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,8 +36,6 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v2
         with:
-          # mise 本体のバージョンを固定（latest 追従だと未公開リリースを掴んで 404 になるため）。
-          # docker/tools/Dockerfile の MISE_VERSION と揃える。
           version: 2026.6.0
           install: false
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -34,8 +34,6 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v2
         with:
-          # mise 本体のバージョンを固定（latest 追従だと未公開リリースを掴んで 404 になるため）。
-          # docker/tools/Dockerfile の MISE_VERSION と揃える。
           version: 2026.6.0
           install: false
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -34,6 +34,9 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v2
         with:
+          # mise 本体のバージョンを固定（latest 追従だと未公開リリースを掴んで 404 になるため）。
+          # docker/tools/Dockerfile の MISE_VERSION と揃える。
+          version: 2026.6.0
           install: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,8 @@
 #
 # go / node / python の version は `make sync-versions` が go.mod・各 Dockerfile の
 # FROM タグ・関連 README へ伝播する。短い名前で解決できないツールは backend を明示する。
+min_version = "2026.6.0"
+
 [tools]
 # 言語ランタイム
 go = "1.26.4"

--- a/scripts/sync-versions/main.go
+++ b/scripts/sync-versions/main.go
@@ -33,16 +33,19 @@ var (
 	nodeFromRe   = regexp.MustCompile(`(?m)^[^#]*?(FROM\s+node:)\d+(?:\.\d+){0,2}(-[\w.-]+)`)
 	pythonFromRe = regexp.MustCompile(`(?m)^[^#]*?(FROM\s+python:)\d+(?:\.\d+){0,2}(-[\w.-]+)`)
 	// バッククォートを capture に含めることで置換後も保持する。
-	golangImageRe = regexp.MustCompile("(`golang:)" + `\d+(?:\.\d+){0,2}` + "(-[\\w.-]+`)")
-	nodeImageRe   = regexp.MustCompile("(`node:)" + `\d+(?:\.\d+){0,2}` + "(-[\\w.-]+`)")
-	pythonImageRe = regexp.MustCompile("(`python:)" + `\d+(?:\.\d+){0,2}` + "(-[\\w.-]+`)")
+	golangImageRe    = regexp.MustCompile("(`golang:)" + `\d+(?:\.\d+){0,2}` + "(-[\\w.-]+`)")
+	nodeImageRe      = regexp.MustCompile("(`node:)" + `\d+(?:\.\d+){0,2}` + "(-[\\w.-]+`)")
+	pythonImageRe    = regexp.MustCompile("(`python:)" + `\d+(?:\.\d+){0,2}` + "(-[\\w.-]+`)")
+	miseDockerfileRe = regexp.MustCompile(`(MISE_VERSION=v)\d+(?:\.\d+){0,2}()`)
+	miseActionRe     = regexp.MustCompile(`(?m)^([ \t]+version: )\d+(?:\.\d+){0,2}([ \t]*)$`)
 )
 
-// runtimeVersions は mise.toml [tools] から抽出した go / node / python のバージョン文字列。
+// runtimeVersions は mise.toml から抽出したバージョン文字列。
 type runtimeVersions struct {
 	Go     string
 	Node   string
 	Python string
+	Mise   string
 }
 
 // rule はファイル内の regex マッチ箇所を 1 つの version で置換する単位。
@@ -115,11 +118,15 @@ func parseMiseTOML(path string) (runtimeVersions, error) {
 			currentSection = m[1]
 			continue
 		}
-		if currentSection != "tools" {
-			continue
-		}
 		m := miseKeyRe.FindStringSubmatch(line)
 		if m == nil {
+			continue
+		}
+		if currentSection == "" && m[1] == "min_version" {
+			v.Mise = m[2]
+			continue
+		}
+		if currentSection != "tools" {
 			continue
 		}
 		switch m[1] {
@@ -139,9 +146,10 @@ func parseMiseTOML(path string) (runtimeVersions, error) {
 
 func printSource(v runtimeVersions) {
 	log.Println("Source: mise.toml")
-	log.Printf("  go     = %s", emptyAs(v.Go, "(unset)"))
-	log.Printf("  node   = %s", emptyAs(v.Node, "(unset)"))
-	log.Printf("  python = %s", emptyAs(v.Python, "(unset)"))
+	log.Printf("  go          = %s", emptyAs(v.Go))
+	log.Printf("  node        = %s", emptyAs(v.Node))
+	log.Printf("  python      = %s", emptyAs(v.Python))
+	log.Printf("  min_version = %s", emptyAs(v.Mise))
 }
 
 func dockerfileRule(file, label string, re *regexp.Regexp, version string, count int) rule {
@@ -212,6 +220,16 @@ func buildRules(v runtimeVersions) []rule {
 			"docker/tools/README.ja.md (node image)", nodeImageRe, v.Node, 1),
 		readmeRule("docker/tools/README.ja.md",
 			"docker/tools/README.ja.md (python image)", pythonImageRe, v.Python, 1),
+		dockerfileRule("docker/tools/Dockerfile",
+			"docker/tools/Dockerfile (mise version)", miseDockerfileRe, v.Mise, 1),
+		dockerfileRule("docker/server/Dockerfile",
+			"docker/server/Dockerfile (mise version)", miseDockerfileRe, v.Mise, 1),
+		dockerfileRule(".github/workflows/lint.yaml",
+			"lint.yaml (mise-action version)", miseActionRe, v.Mise, 1),
+		dockerfileRule(".github/workflows/gen-db-artifacts-check.yaml",
+			"gen-db-artifacts-check.yaml (mise-action version)", miseActionRe, v.Mise, 1),
+		dockerfileRule(".github/workflows/vulnerability-check.yaml",
+			"vulnerability-check.yaml (mise-action version)", miseActionRe, v.Mise, 1),
 	}
 }
 
@@ -232,7 +250,7 @@ func validateRules(rules []rule, root string) []string {
 	for _, r := range rules {
 		if r.version == "" {
 			errs = append(errs, fmt.Sprintf(
-				"%s: mise.toml [tools] に対応する key が未設定", r.label))
+				"%s: mise.toml に対応する version が未設定", r.label))
 		}
 	}
 	for _, r := range rules {
@@ -305,9 +323,9 @@ func reportAndExit(title string, errs []string) {
 	os.Exit(1)
 }
 
-func emptyAs(s, fallback string) string {
+func emptyAs(s string) string {
 	if s == "" {
-		return fallback
+		return "(unset)"
 	}
 	return s
 }


### PR DESCRIPTION
# 概要

`jdx/mise-action@v2` を **version 無指定（latest 追従）**で使っているワークフローが、Setup mise の段階で **404** で失敗している。

```
curl -fsSL https://mise.jdx.dev/VERSION         -> 2026.6.7
curl .../releases/download/v2026.6.7/mise-...tar.zst -> 404 Not Found
```

mise 上流が `VERSION` で `2026.6.7` を案内しているのに、その GitHub リリース資産が未公開のため download が 404 になる。`version` を `2026.6.0`（リリース存在＝302・`docker/tools/Dockerfile` の `MISE_VERSION=v2026.6.0` と同一）に固定して回避する。

## 影響範囲

mise-action を version 無指定で使う 3 ワークフロー（現在いずれも失敗）:
- `lint.yaml`（Go Lint）
- `gen-db-artifacts-check.yaml`（Generated Database Artifacts Check）
- `vulnerability-check.yaml`（Vulnerability Scan）

> #369 の失敗もこれが原因（`.makefiles/**` 変更で gen-db-check がトリガーされ、Setup mise の 404 で fail）。コード自体の問題ではない。

## 変更内容

- 上記 3 ワークフローの `jdx/mise-action@v2` の `with:` に `version: 2026.6.0` を追加

## 補足
- 本 fix をマージ後、他の open PR（#369 等）は base(release/v1.4.0) を取り込めば pull_request 実行時に修正版ワークフローで再評価され green になる。
- 上流が将来 `2026.6.7`（以降）の資産を公開したら version を追従更新可能。