### PR TITLE
GitHub Actions を SHA 固定する pin-actions スキル/ツールを追加

### DIFF
--- a/.claude/skills/pin-actions/SKILL.md
+++ b/.claude/skills/pin-actions/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: pin-actions
+description: Pin GitHub Actions `uses:` references to immutable commit SHAs to harden against tag-hijacking supply-chain attacks. Backed by the `scripts/pin-actions` Go tool (run via `make pin-actions-resolve` / `make pin-actions-apply`). The `resolve` phase scans `.github/workflows/**` and `.github/actions/**` for external action references, resolves each `owner/repo@<tag>` to its commit SHA with `git ls-remote` (annotated tags are dereferenced via `^{}`), and writes them to a `.github/actions-pin.toml` lockfile that is the single source of truth. The `apply` phase rewrites each `uses: owner/repo[/sub]@<ref>` to `uses: owner/repo[/sub]@<sha> # <ref>` from the lockfile. Idempotent — already-pinned refs (`@<sha> # <tag>`) are re-resolved from the `# <tag>` comment, so re-running refreshes SHAs (complements Dependabot). Local `./` action refs have no `@ref` and are skipped; the codeql-action subpaths (init / analyze / …) collapse to one `github/codeql-action@<tag>` lockfile entry. The skill orchestrates resolve → lockfile review → apply → actionlint verification → commit. Use to first-pin all actions, when adding/updating an action, or on a routine hardening cadence.
+---
+
+# Pin GitHub Actions to commit SHAs
+
+Mutable tag references (`actions/checkout@v6`, `jdx/mise-action@v2`) let an attacker who can move a tag run arbitrary code in CI. Pinning each action to an immutable commit SHA (`@<sha> # v6`) removes that risk while keeping the human-readable tag in a trailing comment.
+
+A Japanese reference translation can be generated with the `canonicalize-doc` skill (not yet present).
+
+## When to Use
+
+- First-time hardening: pin every action across the repo.
+- After adding a new action or bumping an action's tag.
+- On a routine cadence to refresh pinned SHAs (alongside Dependabot, which updates SHA-pinned `uses:` while preserving the `# <tag>` comment).
+
+## How it works
+
+Two phases, both deterministic and backed by `scripts/pin-actions` (host `go run`, like `sync-versions`):
+
+| Phase | Command | Effect |
+| --- | --- | --- |
+| resolve | `make pin-actions-resolve` | Scan `uses:` → resolve tag→SHA via `git ls-remote` → write `.github/actions-pin.toml` (SSOT) |
+| apply | `make pin-actions-apply` | Rewrite `uses: …@<ref>` → `uses: …@<sha> # <ref>` from the lockfile |
+
+`git ls-remote` reads public repos with no auth. Whitespace handling is line-internal only, so blank lines / step structure are preserved (the apply diff is `uses:`-line-only).
+
+## Procedure
+
+1. **Resolve.** Run `make pin-actions-resolve`. It (re)writes `.github/actions-pin.toml` with one `"owner/repo@tag" = "<sha>"` entry per distinct action ref. New actions are added; already-pinned refs are re-resolved from their `# <tag>` comment (so this also *updates* SHAs).
+
+2. **Review the lockfile.** Inspect `.github/actions-pin.toml`. Sanity-check that every expected action is present, the tags look right, and each SHA is a 40-hex commit. This is the audit point — the lockfile is the single source of truth for what `apply` will write.
+
+3. **Apply.** Run `make pin-actions-apply`. It rewrites every `uses:` ref from the lockfile to `@<sha> # <tag>`. If any ref is missing from the lockfile it aborts and asks you to re-run resolve.
+
+4. **Verify.** Confirm the change is safe:
+   - `git diff --stat .github/workflows .github/actions` — insertions should equal deletions (pure line replacements; no structural churn).
+   - Run actionlint (`make actions-lint`) — the pinned workflows must still parse and validate.
+
+5. **Commit.** Commit the lockfile and the pinned workflow/action files together (e.g. `CI: GitHub Actions を commit SHA に固定`). Per `CLAUDE.md`, split scope appropriately and use the Co-Authored-By footer.
+
+## Notes
+
+- **Idempotent.** Re-running resolve → apply with no upstream tag movement produces no diff.
+- **Updating pins.** To pull newer SHAs for the same tags, just re-run resolve (it re-resolves from the `# <tag>` comment) then apply.
+- **Scope.** Only external `owner/repo[/sub]@<ref>` refs are touched. Local composite actions (`uses: ./.github/actions/...`) have no `@ref` and are skipped.
+- **Subpaths.** `github/codeql-action/init@v4`, `.../analyze@v4`, etc. share a single `github/codeql-action@v4` lockfile entry (same repo, same SHA).
+- Enforcing that actions *stay* pinned (a `pinact run --check`-style CI gate) is intentionally out of scope here; this skill applies pinning, it does not block PRs.

--- a/.makefiles/github/pin.mk
+++ b/.makefiles/github/pin.mk
@@ -1,0 +1,9 @@
+## GitHub Actions の SHA pin コマンド群
+.PHONY: pin-actions-resolve ## uses: の tag を SHA へ解決し lockfile を更新
+.PHONY: pin-actions-apply ## lockfile を元に uses: を SHA へ固定
+
+pin-actions-resolve:
+	@go run ./scripts/pin-actions resolve
+
+pin-actions-apply:
+	@go run ./scripts/pin-actions apply

--- a/makefile
+++ b/makefile
@@ -24,6 +24,7 @@ include .makefiles/github/setting/github.mk
 include .makefiles/github/setting/branch-ruleset.mk
 include .makefiles/github/setting/label-setting.mk
 include .makefiles/github/lint.mk
+include .makefiles/github/pin.mk
 # Go言語関連
 include .makefiles/go/fmt.mk
 include .makefiles/go/gen.mk

--- a/scripts/pin-actions/main.go
+++ b/scripts/pin-actions/main.go
@@ -1,0 +1,273 @@
+// pin-actions は GitHub Actions の `uses:` 参照を不変の commit SHA へ固定するツール。
+//
+//	resolve: .github/workflows/** と .github/actions/** の外部アクション参照を走査し、
+//	         tag/version を git ls-remote で SHA へ解決して lockfile (.github/actions-pin.toml) へ書き出す。
+//	apply:   lockfile を SSOT に各ファイルの `uses: owner/repo[/sub]@<ref>` を
+//	         `uses: owner/repo[/sub]@<sha> # <ref>` へ置換する。
+//
+// 既に固定済み (`@<sha> # <ref>`) の行は、コメントの <ref> を版として再解決するため idempotent。
+// ローカル参照 (`uses: ./...`) は @ を持たないため対象外。
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	lockFile        = ".github/actions-pin.toml"
+	filePerm        = 0o644
+	minArgs         = 2 // プログラム名 + サブコマンド
+	repoSegments    = 2 // owner/repo
+	lsRemoteCols    = 2 // <sha>\t<refname>
+	lsRemoteTimeout = 30 * time.Second
+)
+
+var (
+	// uses: [-] owner/repo[/sub]@<ref> [# <tag>]
+	// 空白は `[ \t]` に限定する（`\s` だと改行を食って行が結合する）。
+	usesRe = regexp.MustCompile(`(?m)^([ \t]*(?:-[ \t]*)?uses:[ \t]*)([^@\s]+)@([^\s#]+)(?:[ \t]*#[ \t]*(\S+))?[ \t]*$`)
+	lockRe = regexp.MustCompile(`^"([^"]+)"\s*=\s*"([0-9a-f]{40})"`)
+)
+
+// ref はアクション参照 1 件。repo は owner/repo、sub はサブパス（codeql-action/init 等）、tag は固定対象の版。
+type ref struct {
+	repo string
+	sub  string
+	tag  string
+}
+
+func (r ref) key() string { return r.repo + "@" + r.tag }
+
+func main() {
+	log.SetFlags(0)
+	if len(os.Args) < minArgs {
+		log.Fatalf("❌ usage: pin-actions <resolve|apply>")
+	}
+	root, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("❌ getwd: %v", err)
+	}
+	files, err := targetFiles(root)
+	if err != nil {
+		log.Fatalf("❌ %v", err)
+	}
+	switch os.Args[1] {
+	case "resolve":
+		resolve(root, files)
+	case "apply":
+		apply(root, files)
+	default:
+		log.Fatalf("❌ usage: pin-actions <resolve|apply>")
+	}
+}
+
+// parseUses は uses: 行の path / ref / コメント tag から ref を構築する。第2戻り値が false なら対象外。
+func parseUses(path, refStr, comment string) (ref, bool) {
+	if strings.HasPrefix(path, ".") {
+		return ref{}, false // ローカル参照
+	}
+	seg := strings.Split(path, "/")
+	if len(seg) < repoSegments {
+		return ref{}, false
+	}
+	tag := refStr
+	if comment != "" {
+		tag = comment // 既に SHA 固定済み。版はコメント側。
+	}
+	return ref{
+		repo: seg[0] + "/" + seg[1],
+		sub:  strings.Join(seg[repoSegments:], "/"),
+		tag:  tag,
+	}, true
+}
+
+func targetFiles(root string) ([]string, error) {
+	var files []string
+	for _, pat := range []string{
+		".github/workflows/*.yml", ".github/workflows/*.yaml",
+		".github/actions/*/action.yml", ".github/actions/*/action.yaml",
+	} {
+		m, err := filepath.Glob(filepath.Join(root, pat))
+		if err != nil {
+			return nil, fmt.Errorf("glob %s: %w", pat, err)
+		}
+		files = append(files, m...)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func resolve(root string, files []string) {
+	keys := map[string]ref{}
+	for _, f := range files {
+		data, err := os.ReadFile(f) //nolint:gosec // path from cwd glob
+		if err != nil {
+			log.Fatalf("❌ read %s: %v", f, err)
+		}
+		for _, m := range usesRe.FindAllStringSubmatch(string(data), -1) {
+			if r, ok := parseUses(m[2], m[3], m[4]); ok {
+				keys[r.key()] = r
+			}
+		}
+	}
+
+	ctx := context.Background()
+	lock := map[string]string{}
+	for k, r := range keys {
+		sha, err := resolveSHA(ctx, r.repo, r.tag)
+		if err != nil {
+			log.Fatalf("❌ resolve %s: %v", k, err)
+		}
+		lock[k] = sha
+		log.Printf("  %s -> %s", k, sha)
+	}
+
+	if err := writeLock(filepath.Join(root, lockFile), lock); err != nil {
+		log.Fatalf("❌ write lockfile: %v", err)
+	}
+	log.Printf("✅ %s に %d 件を書き出しました", lockFile, len(lock))
+}
+
+func apply(root string, files []string) {
+	lock, err := readLock(filepath.Join(root, lockFile))
+	if err != nil {
+		log.Fatalf("❌ read lockfile（先に resolve を実行してください）: %v", err)
+	}
+
+	var missing []string
+	changed := 0
+	for _, f := range files {
+		data, err := os.ReadFile(f) //nolint:gosec // path from cwd glob
+		if err != nil {
+			log.Fatalf("❌ read %s: %v", f, err)
+		}
+		out := usesRe.ReplaceAllStringFunc(string(data), func(line string) string {
+			m := usesRe.FindStringSubmatch(line)
+			r, ok := parseUses(m[2], m[3], m[4])
+			if !ok {
+				return line
+			}
+			sha, found := lock[r.key()]
+			if !found {
+				missing = append(missing, r.key())
+				return line
+			}
+			path := r.repo
+			if r.sub != "" {
+				path += "/" + r.sub
+			}
+			return fmt.Sprintf("%s%s@%s # %s", m[1], path, sha, r.tag)
+		})
+		if out == string(data) {
+			continue
+		}
+		if err := os.WriteFile(f, []byte(out), filePerm); err != nil { //nolint:gosec // workflow ファイル権限
+			log.Fatalf("❌ write %s: %v", f, err)
+		}
+		changed++
+		log.Printf("  updated %s", rel(root, f))
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		log.Fatalf("❌ lockfile に未登録の参照があります（resolve を再実行してください）: %s",
+			strings.Join(uniq(missing), ", "))
+	}
+	log.Printf("✅ %d ファイルを固定しました", changed)
+}
+
+// resolveSHA は owner/repo の tag/branch を commit SHA へ解決する。annotated tag は ^{} で deref する。
+func resolveSHA(ctx context.Context, repo, tag string) (string, error) {
+	cctx, cancel := context.WithTimeout(ctx, lsRemoteTimeout)
+	defer cancel()
+	url := "https://github.com/" + repo
+	out, err := exec.CommandContext(cctx, "git", "ls-remote", url, tag, tag+"^{}").Output() //nolint:gosec // 参照名は workflow 由来
+	if err != nil {
+		return "", fmt.Errorf("git ls-remote: %w", err)
+	}
+	var tagSHA, derefSHA, headSHA string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		parts := strings.Fields(line)
+		if len(parts) != lsRemoteCols {
+			continue
+		}
+		sha, name := parts[0], parts[1]
+		switch name {
+		case "refs/tags/" + tag + "^{}":
+			derefSHA = sha
+		case "refs/tags/" + tag:
+			tagSHA = sha
+		case "refs/heads/" + tag:
+			headSHA = sha
+		}
+	}
+	switch {
+	case derefSHA != "": // annotated tag は deref した commit を採用
+		return derefSHA, nil
+	case tagSHA != "":
+		return tagSHA, nil
+	case headSHA != "":
+		return headSHA, nil
+	default:
+		return "", fmt.Errorf("ref %q が見つかりません", tag)
+	}
+}
+
+func writeLock(path string, lock map[string]string) error {
+	keys := make([]string, 0, len(lock))
+	for k := range lock {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString("# GitHub Actions の pin 対象 SHA（SSOT）。\n")
+	b.WriteString("# make pin-actions-resolve で解決・make pin-actions-apply で workflow へ反映する。\n")
+	for _, k := range keys {
+		fmt.Fprintf(&b, "%q = %q\n", k, lock[k])
+	}
+	return os.WriteFile(path, []byte(b.String()), filePerm)
+}
+
+func readLock(path string) (map[string]string, error) {
+	f, err := os.Open(path) //nolint:gosec // path is constructed from cwd + literal filename
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	lock := map[string]string{}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if m := lockRe.FindStringSubmatch(strings.TrimSpace(sc.Text())); m != nil {
+			lock[m[1]] = m[2]
+		}
+	}
+	return lock, sc.Err()
+}
+
+func rel(root, p string) string {
+	if r, err := filepath.Rel(root, p); err == nil {
+		return r
+	}
+	return p
+}
+
+func uniq(s []string) []string {
+	out := s[:0]
+	var prev string
+	for i, v := range s {
+		if i == 0 || v != prev {
+			out = append(out, v)
+		}
+		prev = v
+	}
+	return out
+}


### PR DESCRIPTION
# 概要

`uses:` の可変タグ参照（`actions/checkout@v6` 等、現状 全17アクション）はタグ書き換えの supply-chain リスクがある。commit SHA へ固定する仕組みを **TOML lockfile を SSOT とした resolve/apply の2フェーズ**で追加し、スキルから実行できるようにする。

## 設計（TOML を SSOT に resolve → apply）

- **`scripts/pin-actions`（Go・host `go run`、sync-versions と同系統）**
  - `resolve`: `.github/workflows/**` / `.github/actions/**` の外部 `uses:` を走査し、`owner/repo@<tag>` を `git ls-remote` で commit SHA へ解決（annotated tag は `^{}` で deref）→ `.github/actions-pin.toml` へ出力
  - `apply`: lockfile を SSOT に `uses: owner/repo[/sub]@<ref>` を `@<sha> # <ref>` へ置換
  - **idempotent**（固定済み行は `# <tag>` から再解決＝SHA 更新にも使え Dependabot を補完）/ 空白は行内限定で**構造保持**（差分は `uses:` 行のみ）/ ローカル `./` 参照は対象外 / codeql-action のサブパスは1エントリに集約
- **`.makefiles/github/pin.mk`**: `make pin-actions-resolve` / `make pin-actions-apply`
- **`.claude/skills/pin-actions`**: resolve → lockfile 確認 → apply → actionlint → commit をオーケストレート

## 動作確認（ローカル実機）

- resolve: 14 ユニークアクションを SHA へ解決
- apply: 22 ファイルを `@<sha> # <tag>` へ置換、**actionlint exit 0**、空行/ステップ構造を保持（62挿入/62削除＝純置換）
- **idempotency**: 2回目の apply は 0 ファイル
- golangci-lint 0 issues / gofmt / go vet OK

> 本 PR は**ツール＋スキルのみ**。実際の pin 適用（workflow への SHA 書き込み）はスキル実行時に行うため含めない。

## 補足
- 未固定を PR でブロックする CI ゲート（`pinact run --check` 相当）は本スキルの範囲外（適用専用）。
- SKILL.ja.md は `canonicalize-doc` で生成可能。