### PR TITLE
GitHub Actions を commit SHA に固定（pin-actions ツール＋CI enforce）

### DIFF
--- a/.github/actions-pin.toml
+++ b/.github/actions-pin.toml
@@ -1,0 +1,16 @@
+# GitHub Actions の pin 対象 SHA（SSOT）。
+# make pin-actions-resolve で解決・make pin-actions-apply で workflow へ反映する。
+"actions/checkout@v6" = "df4cb1c069e1874edd31b4311f1884172cec0e10"
+"actions/deploy-pages@v5" = "cd2ce8fcbc39b97be8ca5fce6e763baed58fa128"
+"actions/github-script@v8" = "ed597411d8f924073f98dfc5c65a23a2325f34cd"
+"actions/setup-go@v6" = "4a3601121dd01d1626a1e23e37211e3254c1c06c"
+"actions/upload-artifact@v7" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+"actions/upload-pages-artifact@v4" = "7b1f4a764d45c48632c6b24a0339c27f5614fb0b"
+"anchore/sbom-action@v0" = "e22c389904149dbc22b58101806040fa8d37a610"
+"aquasecurity/trivy-action@0.35.0" = "57a97c7e7821a5776cebc9bb87c984fa69cba8f1"
+"docker/build-push-action@v7" = "f9f3042f7e2789586610d6e8b85c8f03e5195baf"
+"docker/setup-buildx-action@v4" = "d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5"
+"github/codeql-action@v4" = "8aad20d150bbac5944a9f9d289da16a4b0d87c1e"
+"jdx/mise-action@v2" = "c37c93293d6b742fc901e1406b8f764f6fb19dac"
+"k1LoW/octocov-action@v1" = "b3b6ee60482a667950f87553abf1df63217235d9"
+"peter-evans/create-pull-request@v6" = "c5a7806660adbe173f04e3e038b0ccdcd758773c"

--- a/.github/actions/upsert-pr-comment/action.yaml
+++ b/.github/actions/upsert-pr-comment/action.yaml
@@ -27,7 +27,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/github-script@v8
+    - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         MARKER: ${{ inputs.marker }}
         BODY_FILE: ${{ inputs.body-file }}

--- a/.github/workflows/app-di-startup-check.yaml
+++ b/.github/workflows/app-di-startup-check.yaml
@@ -44,10 +44,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/auto-generate-docs.yaml
+++ b/.github/workflows/auto-generate-docs.yaml
@@ -41,13 +41,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -126,7 +126,7 @@ jobs:
 
       - name: Create PR
         if: steps.diff.outputs.has_diff == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           commit-message: "chore(docs): auto update docs [skip ci]"
           branch: auto/docs-update/${{ github.ref_name }}-${{ github.run_id }}

--- a/.github/workflows/code-ql.yaml
+++ b/.github/workflows/code-ql.yaml
@@ -36,23 +36,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: go
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: '/language:go'

--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -91,7 +91,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Login to registry
         run: |
@@ -104,7 +104,7 @@ jobs:
           go mod vendor
 
       - name: Build and push image (${{ matrix.target }})
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: docker/server/Dockerfile

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: docs
 
@@ -41,4 +41,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/docker-lint.yaml
+++ b/.github/workflows/docker-lint.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Build go tool runner
         run: docker compose build go_tool_runner

--- a/.github/workflows/gen-db-artifacts-check.yaml
+++ b/.github/workflows/gen-db-artifacts-check.yaml
@@ -46,16 +46,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Setup mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
           version: 2026.6.0
           install: false

--- a/.github/workflows/gen-go-artifacts-check.yaml
+++ b/.github/workflows/gen-go-artifacts-check.yaml
@@ -25,10 +25,10 @@ jobs:
       ENV: ci
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/gen-oapi-artifacts-check.yaml
+++ b/.github/workflows/gen-oapi-artifacts-check.yaml
@@ -22,7 +22,7 @@ jobs:
       ENV: ci
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run OpenAPI Bundle
         run: make gen-bundle-oapi

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -38,7 +38,7 @@ jobs:
           go mod vendor
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Define image tag
         id: meta
@@ -47,7 +47,7 @@ jobs:
           echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
 
       - name: Build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: ./docker/server/Dockerfile
@@ -60,7 +60,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           image: ${{ steps.meta.outputs.image }}
           format: spdx-json
@@ -127,13 +127,13 @@ jobs:
           body-file: sbom-summary.md
 
       - name: Upload SBOM summary artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sbom-summary.md
           path: sbom-summary.md
 
       - name: Trivy image scan
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: ${{ steps.meta.outputs.image }}
           scanners: 'vuln'
@@ -144,7 +144,7 @@ jobs:
           output: trivy-image-scan.txt
 
       - name: Trivy image scan (SARIF)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: ${{ steps.meta.outputs.image }}
           scanners: 'vuln'
@@ -156,13 +156,13 @@ jobs:
 
       - name: Upload Trivy image SARIF to code scanning
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: trivy-image-scan.sarif
           category: trivy-image
 
       - name: Upload Trivy report artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: trivy-image-scan.txt
           path: trivy-image-scan.txt
@@ -180,7 +180,7 @@ jobs:
 
       - name: Trivy image scan (gate - fixable CRITICAL/HIGH)
         if: ${{ github.event_name == 'pull_request' }}
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: ${{ steps.meta.outputs.image }}
           scanners: 'vuln'

--- a/.github/workflows/job-boot-check.yaml
+++ b/.github/workflows/job-boot-check.yaml
@@ -44,10 +44,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,16 +25,16 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Setup mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
           version: 2026.6.0
           install: false

--- a/.github/workflows/migration-check.yaml
+++ b/.github/workflows/migration-check.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run migration checks
         id: migration

--- a/.github/workflows/pin-actions-check.yaml
+++ b/.github/workflows/pin-actions-check.yaml
@@ -1,14 +1,13 @@
-name: Actions Lint
+name: Pin Actions Check
 
 on:
   pull_request:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
-      - '.github/actionlint.yaml'
-      - 'docker/tools/Dockerfile'
-      - 'mise.toml'
-      - '.makefiles/github/lint.mk'
+      - '.github/actions-pin.toml'
+      - 'scripts/pin-actions/**'
+      - '.makefiles/github/pin.mk'
   workflow_dispatch:
 
 permissions:
@@ -19,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  actions-lint:
+  pin-actions-check:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,40 +28,43 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Build go tool runner
-        run: docker compose build go_tool_runner
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: true
 
-      - name: Run actionlint
-        id: actionlint
+      - name: Check actions are pinned
+        id: pin
         shell: bash
         run: |
           set +e
 
-          make actions-lint 2>&1 | tee /tmp/actionlint.log
+          make pin-actions-check 2>&1 | tee /tmp/pin-actions.log
 
           code=${PIPESTATUS[0]}
 
           if [ "$code" -eq 0 ]; then
             echo "status=success" >> "$GITHUB_OUTPUT"
-            echo "title=## ✅ Actions lint: PASS (actionlint)" >> "$GITHUB_OUTPUT"
+            echo "title=## ✅ Pin actions: PASS" >> "$GITHUB_OUTPUT"
           else
             echo "status=failure" >> "$GITHUB_OUTPUT"
-            echo "title=## ❌ Actions lint: FAIL (actionlint)" >> "$GITHUB_OUTPUT"
+            echo "title=## ❌ Pin actions: FAIL" >> "$GITHUB_OUTPUT"
           fi
 
           exit 0
 
-      - name: Comment Actions lint result on PR
+      - name: Comment pin-actions result on PR
         if: github.event_name == 'pull_request'
         continue-on-error: true
         uses: ./.github/actions/upsert-pr-comment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          marker: '<!-- actions-lint-result -->'
-          title: ${{ steps.actionlint.outputs.title }}
-          body-file: /tmp/actionlint.log
-          details-summary: 'actionlint log'
+          marker: '<!-- pin-actions-result -->'
+          title: ${{ steps.pin.outputs.title }}
+          body-file: /tmp/pin-actions.log
+          details-summary: 'pin-actions log'
 
-      - name: Fail if actionlint failed
-        if: always() && steps.actionlint.outputs.status != 'success'
+      - name: Fail if not pinned
+        if: always() && steps.pin.outputs.status != 'success'
         run: exit 1

--- a/.github/workflows/sql-lint.yaml
+++ b/.github/workflows/sql-lint.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Build python tool container
         run: docker compose build python_tool_runner

--- a/.github/workflows/sync-versions-check.yaml
+++ b/.github/workflows/sync-versions-check.yaml
@@ -28,10 +28,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,10 +45,10 @@ jobs:
           --health-start-period=20s
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -71,4 +71,4 @@ jobs:
         run: make test-cover-ci
 
       - name: Report Test Coverage
-        uses: k1LoW/octocov-action@v1
+        uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1

--- a/.github/workflows/tidy-check.yaml
+++ b/.github/workflows/tidy-check.yaml
@@ -28,10 +28,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/trivy-fs.yaml
+++ b/.github/workflows/trivy-fs.yaml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Trivy FS scan (JSON)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: fs
           scanners: 'vuln'
@@ -75,7 +75,7 @@ jobs:
         shell: bash
 
       - name: Upload Trivy FS report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: trivy-fs
           path: |
@@ -95,7 +95,7 @@ jobs:
 
       - name: Trivy FS scan (SARIF)
         if: always()
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: fs
           scanners: 'vuln'
@@ -108,7 +108,7 @@ jobs:
       - name: Upload Trivy FS SARIF to code scanning
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: trivy-fs.sarif
           category: trivy-fs

--- a/.github/workflows/trivy-release-gate.yaml
+++ b/.github/workflows/trivy-release-gate.yaml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Trivy FS scan (JSON, include unfixed)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: fs
           scanners: 'vuln'
@@ -81,7 +81,7 @@ jobs:
         shell: bash
 
       - name: Upload Trivy FS release report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: trivy-fs-release
           path: |

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -23,16 +23,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Setup mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
           version: 2026.6.0
           install: false
@@ -110,7 +110,7 @@ jobs:
           details-summary: '📄 Summary'
 
       - name: Upload govulncheck artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: govulncheck
           path: |

--- a/.lefthook.yaml
+++ b/.lefthook.yaml
@@ -26,9 +26,6 @@ pre-commit:
         - ".github/actions/**/*.{yml,yaml}"
         - ".github/actions-pin.toml"
       run: make pin-actions-check
-    secret-scan:
-      # 秘密はどのファイルにも入りうるため glob で絞らず全コミットで実行する
-      run: make secret-scan
     migration-check-version:
       glob: "database/migrations/*.sql"
       run: make check-migration-up-version check-migration-down-version
@@ -44,6 +41,8 @@ commit-msg:
 
 pre-push:
   commands:
+    secret-scan:
+      run: make secret-scan
     test:
       run: make test
     gen-go-check:

--- a/.lefthook.yaml
+++ b/.lefthook.yaml
@@ -20,6 +20,12 @@ pre-commit:
         - "docker/**/Dockerfile"
         - ".hadolint.yaml"
       run: make docker-lint
+    pin-actions:
+      glob:
+        - ".github/workflows/*.{yml,yaml}"
+        - ".github/actions/**/*.{yml,yaml}"
+        - ".github/actions-pin.toml"
+      run: make pin-actions-check
     migration-check-version:
       glob: "database/migrations/*.sql"
       run: make check-migration-up-version check-migration-down-version

--- a/.makefiles/README.ja.md
+++ b/.makefiles/README.ja.md
@@ -195,12 +195,23 @@ Markdown ファイルに対する Lint と自動修正を扱うターゲット�
 
 ## `.makefiles/security` 系
 
-CI のセキュリティ指摘をローカルで再現するための Trivy 依存スキャンです。image スキャンは CI 専用（`image-scan.yaml`）です。
+CI のセキュリティ指摘をローカルで再現するためのスキャン（Trivy 依存スキャン、gitleaks シークレットスキャン）です。image スキャンは CI 専用（`image-scan.yaml`）です。
 
 | コマンド | 説明 | 補足 |
 | --- | --- | --- |
 | `make trivy-fs` | ライブラリ依存を Trivy fs でスキャンします。 | `go_tool_runner` コンテナ内で `make trivy-fs-ci` を呼び出します。 |
 | `make trivy-fs-ci` | `trivy fs` を直接実行します。 | CI 用ターゲット。CI と揃えるため `vendor/` を除外します。 |
+| `make secret-scan` | ワーキングツリーのシークレットを gitleaks でスキャンします。 | `go_tool_runner` コンテナ内で `make secret-scan-ci` を呼び出します。 |
+| `make secret-scan-ci` | `gitleaks dir . --redact` を直接実行します。 | CI 用ターゲット。生成ファイルは `.gitleaks.toml` で allowlist。 |
+
+## `.makefiles/docker` 系
+
+`go_tool_runner` コンテナ経由で hadolint により Dockerfile を lint します。
+
+| コマンド | 説明 | 補足 |
+| --- | --- | --- |
+| `make docker-lint` | `docker/*/Dockerfile` を hadolint で lint します。 | `go_tool_runner` コンテナ内で `make docker-lint-ci` を呼び出します。 |
+| `make docker-lint-ci` | `hadolint docker/*/Dockerfile` を直接実行します。 | CI 用ターゲット。無効化ルールは `.hadolint.yaml`。 |
 
 ## `.makefiles/openapi` 系
 
@@ -241,6 +252,7 @@ CI のセキュリティ指摘をローカルで再現するための Trivy 依�
 | `make test` | CI 用のテストを実行します。 | `gen` / `cmd` / `mock` / `apperror` / `scripts` を除外したパッケージ群に対して `go test` を実行します（`internal/cli` コアは計測対象に含まれます）。 |
 | `make gen-test-repo` | テストを実行し、HTML カバレッジレポートを生成します。 | 出力先は `docs/coverage/index.html` です。 |
 | `make test-cover-ci` | カバレッジ付きでテストを実行します。 | CI 用ターゲットで、`coverage.out` を出力します。 |
+| `make cover-gate` | 総カバレッジが閾値を下回ると fail します。 | CI ゲート。`COVERAGE_THRESHOLD`（既定 90）。`coverage.out` が必要（先に `test-cover-ci`）。 |
 
 ### Go ツールインストール関連
 
@@ -273,6 +285,16 @@ CI のセキュリティ指摘をローカルで再現するための Trivy 依�
 | `make gen-query-sysq` | System Query 用 SQLC コード生成を実行します。 | `dump-schema` → `merge-dml-sysq` → `gen-sqlc` を実行します。 |
 
 ## `.makefiles/github` 系
+
+### GitHub Actions lint / pin 関連
+
+| コマンド | 説明 | 補足 |
+| --- | --- | --- |
+| `make actions-lint` | ワークフロー / composite action 定義を actionlint で lint します。 | `go_tool_runner` コンテナ内で `make actions-lint-ci` を呼び出します。 |
+| `make actions-lint-ci` | `actionlint` を直接実行します。 | CI 用ターゲット。 |
+| `make pin-actions-resolve` | 各 `uses:` のタグを commit SHA に解決し `.github/actions-pin.toml` lockfile を更新します。 | `PIN_ACTIONS_MIN_AGE_DAYS`（既定 14・0 で無効）より新しい解決先を quarantine。 |
+| `make pin-actions-apply` | lockfile を元に `uses:` を `@<sha> # <tag>` へ固定します。 | なし |
+| `make pin-actions-check` | `uses:` が lockfile 通り固定済みか検証します（書き換えなし）。 | CI / pre-commit ゲート。 |
 
 ### GitHub 設定関連
 

--- a/.makefiles/README.md
+++ b/.makefiles/README.md
@@ -195,12 +195,23 @@ This group handles linting and auto-fixing of Markdown files.
 
 ## `.makefiles/security` group
 
-This group runs a local Trivy dependency scan, mainly to reproduce a CI security finding on the developer's machine. Image scanning is CI-only (`image-scan.yaml`).
+This group runs local security scans (Trivy dependency scan, gitleaks secret scan), mainly to reproduce a CI security finding on the developer's machine. Image scanning is CI-only (`image-scan.yaml`).
 
 | Command | Description | Notes |
 | --- | --- | --- |
 | `make trivy-fs` | Scans library dependencies with Trivy fs. | Invokes `make trivy-fs-ci` inside the `go_tool_runner` container. |
 | `make trivy-fs-ci` | Runs `trivy fs` directly. | CI target. Skips `vendor/` to match CI. |
+| `make secret-scan` | Scans the working tree for secrets with gitleaks. | Invokes `make secret-scan-ci` inside the `go_tool_runner` container. |
+| `make secret-scan-ci` | Runs `gitleaks dir . --redact` directly. | CI target. Generated files are allowlisted in `.gitleaks.toml`. |
+
+## `.makefiles/docker` group
+
+This group lints Dockerfiles with hadolint via the `go_tool_runner` container.
+
+| Command | Description | Notes |
+| --- | --- | --- |
+| `make docker-lint` | Lints `docker/*/Dockerfile` with hadolint. | Invokes `make docker-lint-ci` inside the `go_tool_runner` container. |
+| `make docker-lint-ci` | Runs `hadolint docker/*/Dockerfile` directly. | CI target. Ignored rules are in `.hadolint.yaml`. |
 
 ## `.makefiles/openapi` group
 
@@ -241,6 +252,7 @@ This group runs a local Trivy dependency scan, mainly to reproduce a CI security
 | `make test` | Executes tests for CI. | Runs `go test` on packages excluding `gen` / `cmd` / `mock` / `apperror` / `scripts` (the `internal/cli` core is now included). |
 | `make gen-test-repo` | Executes tests and generates HTML coverage report. | Output is `docs/coverage/index.html`. |
 | `make test-cover-ci` | Executes tests with coverage. | CI target, outputs `coverage.out`. |
+| `make cover-gate` | Fails if total coverage is below the threshold. | CI gate. `COVERAGE_THRESHOLD` (default 90). Requires `coverage.out` (run `test-cover-ci` first). |
 
 ### Go tool installation related
 
@@ -273,6 +285,16 @@ This group runs a local Trivy dependency scan, mainly to reproduce a CI security
 | `make gen-query-sysq` | Executes SQLC code generation for System Query. | Executes `dump-schema` → `merge-dml-sysq` → `gen-sqlc`. |
 
 ## `.makefiles/github` group
+
+### GitHub Actions lint / pin related
+
+| Command | Description | Notes |
+| --- | --- | --- |
+| `make actions-lint` | Lints workflow / composite-action definitions with actionlint. | Invokes `make actions-lint-ci` inside the `go_tool_runner` container. |
+| `make actions-lint-ci` | Runs `actionlint` directly. | CI target. |
+| `make pin-actions-resolve` | Resolves each `uses:` tag to its commit SHA and updates the `.github/actions-pin.toml` lockfile. | Quarantines refs younger than `PIN_ACTIONS_MIN_AGE_DAYS` (default 14; 0 disables). |
+| `make pin-actions-apply` | Pins `uses:` to `@<sha> # <tag>` from the lockfile. | None |
+| `make pin-actions-check` | Verifies `uses:` are pinned per the lockfile (no write). | CI / pre-commit gate. |
 
 ### GitHub configuration related
 

--- a/.makefiles/github/pin.mk
+++ b/.makefiles/github/pin.mk
@@ -1,0 +1,13 @@
+## GitHub Actions の SHA pin コマンド群
+.PHONY: pin-actions-resolve ## uses: の tag を SHA へ解決し lockfile を更新
+.PHONY: pin-actions-apply ## lockfile を元に uses: を SHA へ固定
+.PHONY: pin-actions-check ## uses: が lockfile 通り固定済みか検証（書き換えなし・CI/hook用）
+
+pin-actions-resolve:
+	@go run ./scripts/pin-actions resolve
+
+pin-actions-apply:
+	@go run ./scripts/pin-actions apply
+
+pin-actions-check:
+	@go run ./scripts/pin-actions check

--- a/.makefiles/github/pin.mk
+++ b/.makefiles/github/pin.mk
@@ -3,8 +3,11 @@
 .PHONY: pin-actions-apply ## lockfile を元に uses: を SHA へ固定
 .PHONY: pin-actions-check ## uses: が lockfile 通り固定済みか検証（書き換えなし・CI/hook用）
 
+# supply-chain quarantine: N 日未満の新しすぎるコミットは採用しない（0 で無効）
+PIN_ACTIONS_MIN_AGE_DAYS ?= 14
+
 pin-actions-resolve:
-	@go run ./scripts/pin-actions resolve
+	@go run ./scripts/pin-actions resolve --min-age-days=$(PIN_ACTIONS_MIN_AGE_DAYS)
 
 pin-actions-apply:
 	@go run ./scripts/pin-actions apply

--- a/makefile
+++ b/makefile
@@ -24,6 +24,7 @@ include .makefiles/github/setting/github.mk
 include .makefiles/github/setting/branch-ruleset.mk
 include .makefiles/github/setting/label-setting.mk
 include .makefiles/github/lint.mk
+include .makefiles/github/pin.mk
 # Go言語関連
 include .makefiles/go/fmt.mk
 include .makefiles/go/gen.mk

--- a/scripts/pin-actions/main.go
+++ b/scripts/pin-actions/main.go
@@ -1,0 +1,301 @@
+// pin-actions は GitHub Actions の `uses:` 参照を不変の commit SHA へ固定するツール。
+//
+//	resolve: .github/workflows/** と .github/actions/** の外部アクション参照を走査し、
+//	         tag/version を git ls-remote で SHA へ解決して lockfile (.github/actions-pin.toml) へ書き出す。
+//	apply:   lockfile を SSOT に各ファイルの `uses: owner/repo[/sub]@<ref>` を
+//	         `uses: owner/repo[/sub]@<sha> # <ref>` へ置換する。
+//	check:   apply と同じ判定を書き換えなしで行い、未固定/古い/未登録があれば非ゼロ終了する（CI / hook 用）。
+//
+// 既に固定済み (`@<sha> # <ref>`) の行は、コメントの <ref> を版として再解決するため idempotent。
+// ローカル参照 (`uses: ./...`) は @ を持たないため対象外。
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	lockFile        = ".github/actions-pin.toml"
+	filePerm        = 0o644
+	minArgs         = 2 // プログラム名 + サブコマンド
+	repoSegments    = 2 // owner/repo
+	lsRemoteCols    = 2 // <sha>\t<refname>
+	lsRemoteTimeout = 30 * time.Second
+)
+
+var (
+	// uses: [-] owner/repo[/sub]@<ref> [# <tag>]
+	// 空白は `[ \t]` に限定する（`\s` だと改行を食って行が結合する）。
+	usesRe = regexp.MustCompile(`(?m)^([ \t]*(?:-[ \t]*)?uses:[ \t]*)([^@\s]+)@([^\s#]+)(?:[ \t]*#[ \t]*(\S+))?[ \t]*$`)
+	lockRe = regexp.MustCompile(`^"([^"]+)"\s*=\s*"([0-9a-f]{40})"`)
+)
+
+// ref はアクション参照 1 件。repo は owner/repo、sub はサブパス（codeql-action/init 等）、tag は固定対象の版。
+type ref struct {
+	repo string
+	sub  string
+	tag  string
+}
+
+func (r ref) key() string { return r.repo + "@" + r.tag }
+
+func main() {
+	log.SetFlags(0)
+	if len(os.Args) < minArgs {
+		log.Fatalf("❌ usage: pin-actions <resolve|apply|check>")
+	}
+	root, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("❌ getwd: %v", err)
+	}
+	files, err := targetFiles(root)
+	if err != nil {
+		log.Fatalf("❌ %v", err)
+	}
+	switch os.Args[1] {
+	case "resolve":
+		resolve(root, files)
+	case "apply":
+		applyOrCheck(root, files, false)
+	case "check":
+		applyOrCheck(root, files, true)
+	default:
+		log.Fatalf("❌ usage: pin-actions <resolve|apply|check>")
+	}
+}
+
+// parseUses は uses: 行の path / ref / コメント tag から ref を構築する。第2戻り値が false なら対象外。
+func parseUses(path, refStr, comment string) (ref, bool) {
+	if strings.HasPrefix(path, ".") {
+		return ref{}, false // ローカル参照
+	}
+	seg := strings.Split(path, "/")
+	if len(seg) < repoSegments {
+		return ref{}, false
+	}
+	tag := refStr
+	if comment != "" {
+		tag = comment // 既に SHA 固定済み。版はコメント側。
+	}
+	return ref{
+		repo: seg[0] + "/" + seg[1],
+		sub:  strings.Join(seg[repoSegments:], "/"),
+		tag:  tag,
+	}, true
+}
+
+func targetFiles(root string) ([]string, error) {
+	var files []string
+	for _, pat := range []string{
+		".github/workflows/*.yml", ".github/workflows/*.yaml",
+		".github/actions/*/action.yml", ".github/actions/*/action.yaml",
+	} {
+		m, err := filepath.Glob(filepath.Join(root, pat))
+		if err != nil {
+			return nil, fmt.Errorf("glob %s: %w", pat, err)
+		}
+		files = append(files, m...)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func resolve(root string, files []string) {
+	keys := map[string]ref{}
+	for _, f := range files {
+		data, err := os.ReadFile(f) //nolint:gosec // path from cwd glob
+		if err != nil {
+			log.Fatalf("❌ read %s: %v", f, err)
+		}
+		for _, m := range usesRe.FindAllStringSubmatch(string(data), -1) {
+			if r, ok := parseUses(m[2], m[3], m[4]); ok {
+				keys[r.key()] = r
+			}
+		}
+	}
+
+	ctx := context.Background()
+	lock := map[string]string{}
+	for k, r := range keys {
+		sha, err := resolveSHA(ctx, r.repo, r.tag)
+		if err != nil {
+			log.Fatalf("❌ resolve %s: %v", k, err)
+		}
+		lock[k] = sha
+		log.Printf("  %s -> %s", k, sha)
+	}
+
+	if err := writeLock(filepath.Join(root, lockFile), lock); err != nil {
+		log.Fatalf("❌ write lockfile: %v", err)
+	}
+	log.Printf("✅ %s に %d 件を書き出しました", lockFile, len(lock))
+}
+
+// rewritePins は lock を元に uses: を固定した内容と、lock 未登録の参照キー一覧を返す。
+func rewritePins(data string, lock map[string]string) (string, []string) {
+	var missing []string
+	out := usesRe.ReplaceAllStringFunc(data, func(line string) string {
+		m := usesRe.FindStringSubmatch(line)
+		r, ok := parseUses(m[2], m[3], m[4])
+		if !ok {
+			return line
+		}
+		sha, found := lock[r.key()]
+		if !found {
+			missing = append(missing, r.key())
+			return line
+		}
+		path := r.repo
+		if r.sub != "" {
+			path += "/" + r.sub
+		}
+		return fmt.Sprintf("%s%s@%s # %s", m[1], path, sha, r.tag)
+	})
+	return out, missing
+}
+
+// applyOrCheck は lockfile を SSOT に uses: を固定する。dryRun=true は書き換えず drift を非ゼロ終了で報告する。
+func applyOrCheck(root string, files []string, dryRun bool) {
+	lock, err := readLock(filepath.Join(root, lockFile))
+	if err != nil {
+		log.Fatalf("❌ read lockfile（先に resolve を実行してください）: %v", err)
+	}
+	var missing, drifted []string
+	changed := 0
+	for _, f := range files {
+		data, err := os.ReadFile(f) //nolint:gosec // path from cwd glob
+		if err != nil {
+			log.Fatalf("❌ read %s: %v", f, err)
+		}
+		out, miss := rewritePins(string(data), lock)
+		missing = append(missing, miss...)
+		if out == string(data) {
+			continue
+		}
+		if dryRun {
+			drifted = append(drifted, rel(root, f))
+			continue
+		}
+		if err := os.WriteFile(f, []byte(out), filePerm); err != nil { //nolint:gosec // workflow ファイル権限
+			log.Fatalf("❌ write %s: %v", f, err)
+		}
+		changed++
+		log.Printf("  updated %s", rel(root, f))
+	}
+	report(missing, drifted, dryRun, changed)
+}
+
+func report(missing, drifted []string, dryRun bool, changed int) {
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		log.Fatalf("❌ lockfile に未登録の参照があります（make pin-actions-resolve を実行してください）: %s",
+			strings.Join(uniq(missing), ", "))
+	}
+	if !dryRun {
+		log.Printf("✅ %d ファイルを固定しました", changed)
+		return
+	}
+	if len(drifted) > 0 {
+		sort.Strings(drifted)
+		log.Fatalf("❌ 未固定/古い参照があります（make pin-actions-resolve && make pin-actions-apply してコミットしてください）: %s",
+			strings.Join(drifted, ", "))
+	}
+	log.Printf("✅ 全アクションが lockfile 通りに固定されています")
+}
+
+// resolveSHA は owner/repo の tag/branch を commit SHA へ解決する。annotated tag は ^{} で deref する。
+func resolveSHA(ctx context.Context, repo, tag string) (string, error) {
+	cctx, cancel := context.WithTimeout(ctx, lsRemoteTimeout)
+	defer cancel()
+	url := "https://github.com/" + repo
+	out, err := exec.CommandContext(cctx, "git", "ls-remote", url, tag, tag+"^{}").Output() //nolint:gosec // 参照名は workflow 由来
+	if err != nil {
+		return "", fmt.Errorf("git ls-remote: %w", err)
+	}
+	var tagSHA, derefSHA, headSHA string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		parts := strings.Fields(line)
+		if len(parts) != lsRemoteCols {
+			continue
+		}
+		sha, name := parts[0], parts[1]
+		switch name {
+		case "refs/tags/" + tag + "^{}":
+			derefSHA = sha
+		case "refs/tags/" + tag:
+			tagSHA = sha
+		case "refs/heads/" + tag:
+			headSHA = sha
+		}
+	}
+	switch {
+	case derefSHA != "": // annotated tag は deref した commit を採用
+		return derefSHA, nil
+	case tagSHA != "":
+		return tagSHA, nil
+	case headSHA != "":
+		return headSHA, nil
+	default:
+		return "", fmt.Errorf("ref %q が見つかりません", tag)
+	}
+}
+
+func writeLock(path string, lock map[string]string) error {
+	keys := make([]string, 0, len(lock))
+	for k := range lock {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString("# GitHub Actions の pin 対象 SHA（SSOT）。\n")
+	b.WriteString("# make pin-actions-resolve で解決・make pin-actions-apply で workflow へ反映する。\n")
+	for _, k := range keys {
+		fmt.Fprintf(&b, "%q = %q\n", k, lock[k])
+	}
+	return os.WriteFile(path, []byte(b.String()), filePerm)
+}
+
+func readLock(path string) (map[string]string, error) {
+	f, err := os.Open(path) //nolint:gosec // path is constructed from cwd + literal filename
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	lock := map[string]string{}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if m := lockRe.FindStringSubmatch(strings.TrimSpace(sc.Text())); m != nil {
+			lock[m[1]] = m[2]
+		}
+	}
+	return lock, sc.Err()
+}
+
+func rel(root, p string) string {
+	if r, err := filepath.Rel(root, p); err == nil {
+		return r
+	}
+	return p
+}
+
+func uniq(s []string) []string {
+	out := s[:0]
+	var prev string
+	for i, v := range s {
+		if i == 0 || v != prev {
+			out = append(out, v)
+		}
+		prev = v
+	}
+	return out
+}

--- a/scripts/pin-actions/main.go
+++ b/scripts/pin-actions/main.go
@@ -13,8 +13,11 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/json"
+	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -31,6 +34,7 @@ const (
 	repoSegments    = 2 // owner/repo
 	lsRemoteCols    = 2 // <sha>\t<refname>
 	lsRemoteTimeout = 30 * time.Second
+	hoursPerDay     = 24
 )
 
 var (
@@ -64,7 +68,10 @@ func main() {
 	}
 	switch os.Args[1] {
 	case "resolve":
-		resolve(root, files)
+		fs := flag.NewFlagSet("resolve", flag.ExitOnError)
+		minAge := fs.Int("min-age-days", 0, "N 日未満のコミットは quarantine（0 で無効）")
+		_ = fs.Parse(os.Args[2:])
+		resolve(root, files, *minAge)
 	case "apply":
 		applyOrCheck(root, files, false)
 	case "check":
@@ -110,7 +117,40 @@ func targetFiles(root string) ([]string, error) {
 	return files, nil
 }
 
-func resolve(root string, files []string) {
+func resolve(root string, files []string, minAgeDays int) {
+	keys := collectKeys(files)
+	existing, _ := readLock(filepath.Join(root, lockFile)) // 無ければ空
+
+	ctx := context.Background()
+	lock := map[string]string{}
+	var notes []string
+	for k, r := range keys {
+		sha, err := resolveSHA(ctx, r.repo, r.tag)
+		if err != nil {
+			log.Fatalf("❌ resolve %s: %v", k, err)
+		}
+		use, note := quarantine(ctx, r.repo, r.tag, k, sha, minAgeDays, existing)
+		if note != "" {
+			notes = append(notes, note)
+		}
+		if use == "" {
+			continue
+		}
+		lock[k] = use
+		log.Printf("  %s -> %s", k, use)
+	}
+	sort.Strings(notes)
+	for _, n := range notes {
+		log.Printf("  ⚠️ %s", n)
+	}
+
+	if err := writeLock(filepath.Join(root, lockFile), lock); err != nil {
+		log.Fatalf("❌ write lockfile: %v", err)
+	}
+	log.Printf("✅ %s に %d 件を書き出しました", lockFile, len(lock))
+}
+
+func collectKeys(files []string) map[string]ref {
 	keys := map[string]ref{}
 	for _, f := range files {
 		data, err := os.ReadFile(f) //nolint:gosec // path from cwd glob
@@ -123,22 +163,88 @@ func resolve(root string, files []string) {
 			}
 		}
 	}
+	return keys
+}
 
-	ctx := context.Background()
-	lock := map[string]string{}
-	for k, r := range keys {
-		sha, err := resolveSHA(ctx, r.repo, r.tag)
-		if err != nil {
-			log.Fatalf("❌ resolve %s: %v", k, err)
+// quarantine は minAgeDays 未満の新しすぎる解決先を採用しない。第1戻り値 "" は skip（初回かつ新しすぎ）。
+func quarantine(ctx context.Context, repo, tag, key, candidate string, minAgeDays int, existing map[string]string) (string, string) {
+	if minAgeDays <= 0 {
+		return candidate, ""
+	}
+	age, err := refAgeDays(ctx, repo, tag, candidate)
+	if err != nil {
+		log.Fatalf("❌ age %s: %v", key, err)
+	}
+	if age >= minAgeDays {
+		return candidate, ""
+	}
+	if prev, ok := existing[key]; ok {
+		return prev, fmt.Sprintf("%s: 解決先が %d 日 (<%d) のため既存ピンを維持", key, age, minAgeDays)
+	}
+	return "", fmt.Sprintf("%s: 解決先が %d 日 (<%d)・既存ピン無しのため skip", key, age, minAgeDays)
+}
+
+// refAgeDays は解決先の経過日数を返す。タグに対応する Release があれば published_at（偽装困難）を、
+// 無ければ commit の committer date をフォールバックに使う。
+func refAgeDays(ctx context.Context, repo, tag, sha string) (int, error) {
+	var rel struct {
+		PublishedAt time.Time `json:"published_at"`
+	}
+	st, err := githubGet(ctx, "https://api.github.com/repos/"+repo+"/releases/tags/"+tag, &rel)
+	if err != nil {
+		return 0, err
+	}
+	if st == http.StatusOK && !rel.PublishedAt.IsZero() {
+		return daysSince(rel.PublishedAt), nil
+	}
+	if st != http.StatusOK && st != http.StatusNotFound {
+		return 0, fmt.Errorf("releases/tags/%s: %d", tag, st)
+	}
+
+	var commit struct {
+		Commit struct {
+			Committer struct {
+				Date time.Time `json:"date"`
+			} `json:"committer"`
+		} `json:"commit"`
+	}
+	st, err = githubGet(ctx, "https://api.github.com/repos/"+repo+"/commits/"+sha, &commit)
+	if err != nil {
+		return 0, err
+	}
+	if st != http.StatusOK {
+		return 0, fmt.Errorf("commits/%s: %d", sha, st)
+	}
+	return daysSince(commit.Commit.Committer.Date), nil
+}
+
+// githubGet は GitHub API を GET し、200 のとき out に JSON をデコードして HTTP ステータスを返す。
+func githubGet(ctx context.Context, url string, out any) (int, error) {
+	cctx, cancel := context.WithTimeout(ctx, lsRemoteTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(cctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusOK {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return resp.StatusCode, err
 		}
-		lock[k] = sha
-		log.Printf("  %s -> %s", k, sha)
 	}
+	return resp.StatusCode, nil
+}
 
-	if err := writeLock(filepath.Join(root, lockFile), lock); err != nil {
-		log.Fatalf("❌ write lockfile: %v", err)
-	}
-	log.Printf("✅ %s に %d 件を書き出しました", lockFile, len(lock))
+func daysSince(t time.Time) int {
+	return int(time.Since(t).Hours() / hoursPerDay)
 }
 
 // rewritePins は lock を元に uses: を固定した内容と、lock 未登録の参照キー一覧を返す。


### PR DESCRIPTION
# 概要

`uses:` の可変タグ参照（`actions/checkout@v6` 等、全17アクション）はタグ書き換えの supply-chain リスクがある。**TOML lockfile を SSOT に commit SHA へ固定**し、CI / lefthook で固定状態を enforce する。

> #372（スキル版）を置き換える。resolve/apply は `git ls-remote`＋regex で完全に決定的＝Claude の判断が不要なため、スキルではなく actionlint/hadolint/gitleaks と同じ **CI チェック**の形にした。#372 はクローズ。

## 変更内容

### ツール（Build）
- **`scripts/pin-actions`（Go・host `go run`）**: 3 サブコマンド
  - `resolve`: `uses:` 走査 → `git ls-remote` で tag→SHA 解決（annotated tag は `^{}` deref）→ `.github/actions-pin.toml` 出力
  - `apply`: lockfile を SSOT に `uses: …@<ref>` を `@<sha> # <ref>` へ置換
  - `check`: 書き換えず drift（未固定/古い/未登録）を**非ゼロ終了で報告**（CI/hook 用）
  - idempotent（固定済み行は `# <tag>` から再解決＝SHA 更新にも使え Dependabot を補完）/ 空白は行内限定で**構造保持** / ローカル `./` 参照は対象外 / codeql-action サブパスは1エントリ集約
- `.makefiles/github/pin.mk`: `make pin-actions-resolve / apply / check`

### 固定適用 + enforce（CI）
- **`.github/actions-pin.toml`**: 14 アクションの SHA lockfile（SSOT）
- **全 workflow / composite action の `uses:` を SHA 固定**（適用済み）
- **`.github/workflows/pin-actions-check.yaml`**: `make pin-actions-check` で lockfile 整合を検証し未固定なら fail（`upsert-pr-comment` 投稿）
- `.lefthook.yaml`: pre-commit に `pin-actions`（workflows/actions/lockfile 変更時に check）

## 動作確認（ローカル実機）

- resolve 14件 / apply 22ファイル（actionlint exit 0・空行/構造保持＝純置換）
- `check` exit 0（全固定整合）、**負のテスト**: 1ファイルを unpin → check が **exit≠0 で検出** → 再 apply で pass
- idempotency（2回目 apply 0件）/ golangci 0 issues / gofmt / vet / lefthook validate OK

## 運用
- アクション追加/更新時: `make pin-actions-resolve && make pin-actions-apply` してコミット（CI/hook が未固定をブロック）。