### PR TITLE
Build: godoc の静的HTML生成 (docs/godoc/) を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ node_modules/
 # ビルド済みのバイナリファイル
 tmp/
 
+# godoc の静的HTML生成物（make gen-godoc で再生成するためコミットしない）
+docs/godoc/
+
 # -----ファイル-----
 # ディレクトリの表示管理ファイル
 .DS_Store

--- a/.makefiles/README.ja.md
+++ b/.makefiles/README.ja.md
@@ -270,6 +270,8 @@ CI のセキュリティ指摘をローカルで再現するためのスキャ�
 | `make gen-docs-json` | Portal 用ドキュメントリンク JSON を生成します。 | なし |
 | `make gen-portal-docs-ci` | Node.js スクリプトで Portal 用ドキュメントを直接生成します。 | CI 用ターゲットです。 |
 | `make gen-docs-json-ci` | Node.js スクリプトで Portal 用 JSON を直接生成します。 | CI 用ターゲットです。 |
+| `make gen-godoc` | godoc の静的 HTML を `docs/godoc/` に生成します。 | なし |
+| `make gen-godoc-ci` | godoc-static を直接実行して静的 HTML を生成します。 | CI 用ターゲットです。 |
 
 ## `.makefiles/gen` 系
 

--- a/.makefiles/README.md
+++ b/.makefiles/README.md
@@ -270,6 +270,8 @@ This group lints Dockerfiles with hadolint via the `go_tool_runner` container.
 | `make gen-docs-json` | Generates Portal documentation link JSON. | None |
 | `make gen-portal-docs-ci` | Generates Portal documentation directly via Node.js script. | CI target |
 | `make gen-docs-json-ci` | Generates Portal JSON directly via Node.js script. | CI target |
+| `make gen-godoc` | Generates static godoc HTML into `docs/godoc/`. | None |
+| `make gen-godoc-ci` | Runs godoc-static directly to generate static HTML. | CI target |
 
 ## `.makefiles/gen` group
 

--- a/.makefiles/docs/gen.mk
+++ b/.makefiles/docs/gen.mk
@@ -8,7 +8,7 @@
 
 GODOC_OUT := docs/godoc
 # --disable-filter なしだと internal/ 配下が全て除外されるため必須。exclude は index からのみ除外される。
-GODOC_EXCLUDE = $(shell go list ./... | grep -E '/(gen|mock)$$|^go-boilerplate/cmd$$' | tr '\n' ' ')
+GODOC_EXCLUDE = $(shell go list ./... | grep -E '/(gen|mock)$$|^[^/]+/(cmd|scripts)(/|$$)' | tr '\n' ' ')
 
 gen-docs-json:
 	@echo "🔍 Portal用のドキュメントリンクのJSONを生成します..."

--- a/.makefiles/docs/gen.mk
+++ b/.makefiles/docs/gen.mk
@@ -3,6 +3,12 @@
 .PHONY: gen-docs-json ## Portal用のドキュメントリンクのJSONを生成する
 .PHONY: gen-portal-docs-ci ## Portal用のドキュメントを生成する（CI用）
 .PHONY: gen-docs-json-ci ## Portal用のドキュメントリンクのJSONを生成する（CI用）
+.PHONY: gen-godoc ## godoc の静的HTMLを docs/godoc/ に生成する
+.PHONY: gen-godoc-ci ## godoc の静的HTMLを docs/godoc/ に生成する（CI用）
+
+GODOC_OUT := docs/godoc
+# --disable-filter なしだと internal/ 配下が全て除外されるため必須。exclude は index からのみ除外される。
+GODOC_EXCLUDE = $(shell go list ./... | grep -E '/(gen|mock)$$|^go-boilerplate/cmd$$' | tr '\n' ' ')
 
 gen-docs-json:
 	@echo "🔍 Portal用のドキュメントリンクのJSONを生成します..."
@@ -19,4 +25,21 @@ gen-docs-json-ci:
 
 gen-portal-docs-ci:
 	node scripts/gen-portal-docs.mjs
+
+gen-godoc:
+	@echo "🔍 godoc の静的HTMLの生成を開始します..."
+	docker compose run --rm go_tool_runner make gen-godoc-ci
+	@echo "✅ godoc の静的HTMLの生成が完了しました（$(GODOC_OUT)/）。"
+
+gen-godoc-ci:
+	rm -rf $(GODOC_OUT)
+	mkdir -p $(GODOC_OUT)
+	godoc-static \
+		--listen=127.0.0.1:9001 \
+		--go-root="$(shell go env GOROOT)" \
+		--disable-filter \
+		--exclude="$(GODOC_EXCLUDE)" \
+		--site-name="go-boilerplate godoc" \
+		--destination=$(GODOC_OUT) \
+		.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,7 @@ Conditions:
     - `docs/openapi/**` (redocly build output)
     - `docs/coverage/**` (test coverage report)
     - `docs/db-schema/**` (SchemaSpy output)
+    - `docs/godoc/**` (`make gen-godoc` output — godoc static HTML)
     - `docs/portal/docs.json` (`make gen-docs-json` output)
     - `docs/portal/guides/**` (`make gen-portal-docs` output — cleaned and regenerated on every run)
   - Anything listed under `permissions.deny` in `.claude/settings.json`
@@ -561,6 +562,7 @@ Finally, run `make lint` to check for any errors.
   - `docs/openapi/**` (redocly build output)
   - `docs/coverage/**` (test coverage report)
   - `docs/db-schema/**` (SchemaSpy output)
+  - `docs/godoc/**` (`make gen-godoc` output — godoc static HTML)
   - `docs/portal/docs.json` (`make gen-docs-json` output)
   - `docs/portal/guides/**` (`make gen-portal-docs` output)
 

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -33,7 +33,9 @@ RUN mise install aqua:golang-migrate/migrate \
     && mise install aqua:aquasecurity/trivy \
     && mise install actionlint \
     && mise install hadolint \
-    && mise install gitleaks
+    && mise install gitleaks \
+    && mise install go:golang.org/x/tools/cmd/godoc \
+    && mise install go:codeberg.org/tslocum/godoc-static
 
 RUN mkdir /out \
     && cp "$(mise which migrate)" /out/ \
@@ -43,10 +45,12 @@ RUN mkdir /out \
     && cp "$(mise which trivy)" /out/ \
     && cp "$(mise which actionlint)" /out/ \
     && cp "$(mise which hadolint)" /out/ \
-    && cp "$(mise which gitleaks)" /out/
+    && cp "$(mise which gitleaks)" /out/ \
+    && cp "$(mise which godoc)" /out/ \
+    && cp "$(mise which godoc-static)" /out/
 
 # ------------------------------
-# Go ツールボックス：migrate / mockgen / oapi-codegen / sqlc / trivy / actionlint / hadolint / gitleaks を mise.toml のバージョンで提供
+# Go ツールボックス：migrate / mockgen / oapi-codegen / sqlc / trivy / actionlint / hadolint / gitleaks / godoc / godoc-static を mise.toml のバージョンで提供
 # Go ランタイムは golang 公式 base image を使用（mise.toml の go 値と `make sync-go-version` で同期）
 # ------------------------------
 FROM golang:1.26.4-alpine AS go_tools

--- a/mise.toml
+++ b/mise.toml
@@ -35,6 +35,9 @@ gitleaks = "8.30.1"
 "go:github.com/cweill/gotests/gotests" = "1.9.0"
 "go:golang.org/x/tools/gopls" = "0.22.0"
 "go:github.com/josharian/impl" = "1.5.0"
+# godoc は x/tools 本体から分離済みで v0.1.0-deprecated が最新タグ（通常 semver は無い）
+"go:golang.org/x/tools/cmd/godoc" = "0.1.0-deprecated"
+"go:codeberg.org/tslocum/godoc-static" = "1.0.0"
 
 # Node ベース
 "npm:@redocly/cli" = "2.31.4"


### PR DESCRIPTION
# 概要

godoc コメントから静的 HTML ドキュメントを生成し `docs/godoc/` へ出力する仕組みを追加しました。coverage / db-schema / openapi と同様に docs_viewer(nginx) で閲覧でき、生成物はコミットせず .gitignore 運用とします。

## 変更内容

- **ツール導入** (`mise.toml` / `docker/tools/Dockerfile`): `godoc`（x/tools から分離済み・`v0.1.0-deprecated`）と `godoc-static@v1.0.0` を pin し、`go_tools` イメージへ同梱
- **Make ターゲット** (`.makefiles/docs/gen.mk`): `make gen-godoc`（go_tool_runner 経由）/ `gen-godoc-ci` を追加。対象は internal/ + pkg/、生成専用の gen/mock/cmd は index から除外。internal/ を残すため godoc-static は `--disable-filter` で実行
- **生成物の除外** (`.gitignore`): `docs/godoc/` を追加
- **ドキュメント** (`.makefiles/README.md` / `README.ja.md`): `.makefiles/docs` グループ表に新ターゲットを追記

## 動作確認方法

1. `docker compose build go_tool_runner`（新ツールを取り込む）
2. `make gen-godoc`
3. `docs/godoc/index.html` が生成され、internal/ + pkg/ がリンクされ gen/mock が index に出ないことを確認（docs_viewer: http://localhost:8082/godoc/）