### PR TITLE
Chore: docs/godoc を .gitignore から除外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,6 @@ node_modules/
 # ビルド済みのバイナリファイル
 tmp/
 
-# godoc の静的HTML生成物（make gen-godoc で再生成するためコミットしない）
-docs/godoc/
-
 # -----ファイル-----
 # ディレクトリの表示管理ファイル
 .DS_Store


### PR DESCRIPTION
# 概要

`docs/godoc/` を `.gitignore` から除外する。CI の auto-docs ジョブが godoc 生成物をリポジトリに含めて commit できるようにするための調整で、生成物本体（`docs/godoc/**`）の初回チェックインは CI に委ねる。

## 変更内容

- `.gitignore` から `docs/godoc/` の除外行（コメント込み3行）を削除
  - 以降、CI auto-docs ジョブが `make gen-godoc` の出力をそのまま `git add` できる
  - 一度 tracked 化されれば `.gitignore` ルールを残す必要はないため、追加の死文ルールは置かない

## 動作確認方法

- `.gitignore` のみの変更で実行時挙動への影響はなし
- ローカルで `git check-ignore -v docs/godoc/` を実行し、除外ルールにマッチしなくなることを確認
- 次回 CI auto-docs ジョブ実行時に `docs/godoc/**` 配下が初回 commit されることを確認