### PR TITLE
CI: auto-generate-docs に gen-godoc step を追加

### DIFF
--- a/.github/workflows/auto-generate-docs.yaml
+++ b/.github/workflows/auto-generate-docs.yaml
@@ -86,6 +86,9 @@ jobs:
           make gen-portal-docs
           make gen-docs-json
 
+      - name: Generate godoc
+        run: make gen-godoc
+
       - name: Fix permissions
         run: |
           sudo chown -R $USER:$USER docs


### PR DESCRIPTION
# 概要

`auto-generate-docs.yaml` に `make gen-godoc` ステップを追加する。直前にマージされた #378 で `.gitignore` の `docs/godoc/` 除外は外しているため、本変更により godoc 静的 HTML が auto-docs ジョブで自動的に生成・追跡 commit されるようになる。

## 変更内容

- `.github/workflows/auto-generate-docs.yaml` の `Generate Portal Docs` と `Fix permissions` の間に `Generate godoc: run: make gen-godoc` を追加
  - `make gen-godoc` は `go_tool_runner` 経由で `godoc-static` を呼び出すため、既存の docker-compose ベースの doc 生成ステップ（`gen-portal-docs` 等）と整合
  - 後段の `Fix permissions` (`sudo chown -R $USER:$USER docs`) が docker 由来の root 所有を吸収するため、追加ハンドリング不要
  - 後段の `Detect changes` が `git add -A` で生成物を拾うため、`docs/godoc/**` が auto/docs-update PR に自動で含まれる

## 動作確認方法

- ローカルで `docker compose run --rm node_tool_runner mise exec aqua:rhysd/actionlint -- actionlint .github/workflows/auto-generate-docs.yaml` を実行し、構文 OK を確認済
- マージ後、release/v1.4.0 への次回 push をトリガーに `Auto-generate Docs` ワークフローが走り、`auto/docs-update/release/v1.4.0-<run_id>` ブランチで `docs/godoc/**` が含まれた PR が作成されることを確認

## 関連

- #378 (`.gitignore` から `docs/godoc/` 除外、マージ済)