### PR TITLE
Build: godoc 生成を deterministic 化して PR ノイズを抑制

### DIFF
--- a/.makefiles/docs/gen.mk
+++ b/.makefiles/docs/gen.mk
@@ -41,5 +41,7 @@ gen-godoc-ci:
 		--exclude="$(GODOC_EXCLUDE)" \
 		--site-name="go-boilerplate godoc" \
 		--destination=$(GODOC_OUT) \
+		--zip="" \
 		.
-
+	# godoc-static が書き出すファイル一覧の mtime セル（CI 実行時刻ごとに変わり PR ノイズの原因）を空にして deterministic に
+	find $(GODOC_OUT) -name 'index.html' -exec sed -i -E 's|<td align="left">[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:.]+ \+0000 UTC</td>|<td align="left"></td>|g' {} +


### PR DESCRIPTION
# 概要

Auto-generate Docs ジョブが毎回 `docs/godoc/` を再生成し、各 `index.html` の mtime セルと `docs.zip` の binary 差分で auto-docs PR が 147 ファイル規模のノイズを抱える問題への対処。godoc 出力を deterministic 化し、同一ソース = bit-for-bit 同一出力に揃える。

## 変更内容

- `.makefiles/docs/gen.mk` の `gen-godoc-ci`:
  - `--zip=""` で godoc-static の `docs.zip` 出力を無効化（consumer なし、binary 差分の原因）
  - godoc-static 生成後に `sed` で `<td align="left">YYYY-MM-DD HH:MM:SS.ffffff +0000 UTC</td>` を空セルに置換。CI 実行時刻ごとに変わる唯一のノイズ源を除去
- ローカルで 2 回連続生成して `diff -rq` が無差分になることを確認済

## 動作確認方法

- ローカル: `make gen-godoc` を 2 回実行し、`diff -rq /tmp/snapshot1 docs/godoc` が空であることを確認
- マージ後: 直後の Auto-generate Docs CI 実行で `docs/godoc/` がノイズ無しに再生成される。auto-docs PR には「全 `index.html` から mtime セル削除 + `docs.zip` 削除」の 1 回限りの baseline reset 差分が出る。それ以降はソース変更時のみ実差分が出る

## 関連

- 現状 OPEN の auto-docs PR (#381) は baseline reset PR に取って代わられるため、別途クローズしてよい