### PR TITLE
Feat: stack を行配列で出力して Grafana で可読化する (#24)

### DIFF
--- a/.lefthook.yaml
+++ b/.lefthook.yaml
@@ -40,6 +40,7 @@ commit-msg:
       run: mise exec npm:@commitlint/cli -- commitlint --edit {1}
 
 pre-push:
+  parallel: true
   commands:
     secret-scan:
       run: make secret-scan

--- a/internal/controller/httpstack/errorhandler/http_error_handler.go
+++ b/internal/controller/httpstack/errorhandler/http_error_handler.go
@@ -125,7 +125,7 @@ func httpErrorField(
 	if he.Internal != nil {
 		additionalFields := []*logging.Field{
 			logging.String(logging.InternalErrorKey, he.Internal.Error()),
-			logging.String(logging.InternalStackTraceKey, xerrors.StackTrace(he.Internal)),
+			logging.Stacktrace(logging.InternalStackTraceKey, he.Internal),
 		}
 		fields = append(fields, additionalFields...)
 	}

--- a/internal/controller/httpstack/errorhandler/http_error_handler_test.go
+++ b/internal/controller/httpstack/errorhandler/http_error_handler_test.go
@@ -15,7 +15,6 @@ import (
 	"go-boilerplate/internal/controller/error/response/gen"
 	"go-boilerplate/internal/controller/handler/testkit/testspan"
 	"go-boilerplate/internal/logging"
-	"go-boilerplate/pkg/xerrors"
 
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/labstack/echo/v4"
@@ -563,7 +562,7 @@ func Test_httpErrorField(t *testing.T) {
 
 			assert.Contains(t, fields, logging.Strings(logging.ErrorDetailsKey, details))
 			assert.Contains(t, fields, logging.String(logging.InternalErrorKey, he.Internal.Error()))
-			assert.Contains(t, fields, logging.String(logging.InternalStackTraceKey, xerrors.StackTrace(he.Internal)))
+			assert.Contains(t, fields, logging.Stacktrace(logging.InternalStackTraceKey, he.Internal))
 		})
 	})
 }

--- a/internal/controller/httpstack/recovery/recover.go
+++ b/internal/controller/httpstack/recovery/recover.go
@@ -47,7 +47,7 @@ func newRecoverLogErrorFunc(logger logging.Logger, lf logging.LogFieldBuilder) f
 		reqIn := server.BuildHTTPRequestLogInput(c, logging.EventTypePanic)
 		recoverFields := []*logging.Field{
 			logging.String(logging.InternalErrorKey, err.Error()),
-			logging.String(logging.InternalStackTraceKey, string(stack)),
+			logging.Strings(logging.InternalStackTraceKey, logging.SplitStackLines(string(stack))),
 		}
 		fields := append(lf.BuildHTTPRequestFields(reqIn), recoverFields...)
 		logger.Named("middleware.recover").Error("panic recovered", fields...)

--- a/internal/controller/httpstack/recovery/recover_test.go
+++ b/internal/controller/httpstack/recovery/recover_test.go
@@ -111,10 +111,14 @@ func TestMiddleware_realPanic(t *testing.T) {
 			require.True(t, ok)
 			assert.Contains(t, errStr, "boom-panic")
 
-			// 実ランタイムスタックが可読文字列(Base64 でない)で出力されること。
-			stackStr, ok := cm[logging.InternalStackTraceKey].(string)
+			// 実ランタイムスタックが行配列で出力されること（Grafana 表示用に []string 化済み）。
+			// zap observer は []any として保持するため、要素ごとに string にアサートする。
+			stackLines, ok := cm[logging.InternalStackTraceKey].([]any)
 			require.True(t, ok)
-			assert.Contains(t, stackStr, "goroutine")
+			require.NotEmpty(t, stackLines)
+			first, ok := stackLines[0].(string)
+			require.True(t, ok)
+			assert.Contains(t, first, "goroutine")
 		})
 	})
 }
@@ -260,10 +264,13 @@ func TestProductionConfig_capturesStack(t *testing.T) {
 
 			entries := observed.FilterMessage("panic recovered").All()
 			require.Len(t, entries, 1)
-			stackStr, ok := entries[0].ContextMap()[logging.InternalStackTraceKey].(string)
+			stackLines, ok := entries[0].ContextMap()[logging.InternalStackTraceKey].([]any)
+			require.True(t, ok)
+			require.NotEmpty(t, stackLines)
+			first, ok := stackLines[0].(string)
 			require.True(t, ok)
 			// 本番設定(DisablePrintStack=false)でも runtime スタックが捕捉される。
-			assert.Contains(t, stackStr, "goroutine")
+			assert.Contains(t, first, "goroutine")
 		})
 	})
 }

--- a/internal/logging/README.ja.md
+++ b/internal/logging/README.ja.md
@@ -126,7 +126,7 @@ logger.Info(
 |Time|time.Time（RFC3339Nano文字列に変換）|
 |DurationMs|time.Duration（ミリ秒単位のfloat64に変換）|
 |Error|error|
-|Stacktrace|error（スタックトレース文字列に変換）|
+|Stacktrace|error（スタックトレースを行配列 []string に変換）|
 |Any|any|
 
 この設計の目的

--- a/internal/logging/README.ja.md
+++ b/internal/logging/README.ja.md
@@ -20,6 +20,7 @@
 internal/logging
 ├── logger.go
 ├── logger_core.go
+├── stacktrace_core.go
 ├── field.go
 ├── field_builder.go
 ├── const.go
@@ -33,6 +34,7 @@ internal/logging
 |---|---|
 |`logger.go`|アプリケーションが利用する Logger interface|
 |`logger_core.go`|zap.Logger の実装|
+|`stacktrace_core.go`|zap 自動付与の `Entry.Stack` を JSON 出力時に行配列へ変換する zapcore.Core ラッパ|
 |`field.go`|ログフィールドの型|
 |`field_builder.go`|HTTP / SQL / Observability ログフィールド生成|
 |`const.go`|ログキー定義|

--- a/internal/logging/README.md
+++ b/internal/logging/README.md
@@ -20,6 +20,7 @@ The main purposes are as follows.
 internal/logging
 ├── logger.go
 ├── logger_core.go
+├── stacktrace_core.go
 ├── field.go
 ├── field_builder.go
 ├── const.go
@@ -33,6 +34,7 @@ The role of each file is as follows.
 |---|---|
 |`logger.go`|Logger interface used by application|
 |`logger_core.go`|Implementation of zap.Logger|
+|`stacktrace_core.go`|zapcore.Core wrapper that converts the auto-attached `Entry.Stack` into a line array for JSON output|
 |`field.go`|Type of log fields|
 |`field_builder.go`|Generation of HTTP / SQL / Observability log fields|
 |`const.go`|Log key definitions|

--- a/internal/logging/README.md
+++ b/internal/logging/README.md
@@ -124,7 +124,7 @@ Supported types
 |Time|time.Time (converted to RFC3339Nano string)|
 |DurationMs|time.Duration (converted to float64 in milliseconds)|
 |Error|error|
-|Stacktrace|error (converted to stack trace string)|
+|Stacktrace|error (converted to stack trace lines as []string)|
 |Any|any|
 
 Purpose of this design

--- a/internal/logging/field.go
+++ b/internal/logging/field.go
@@ -132,13 +132,14 @@ func Stacktrace(key fieldKey, err error) *Field {
 }
 
 // SplitStackLines は、スタックトレース文字列を改行で分割し行配列に変換します。
-// 末尾の空行は除去し、空文字列入力では nil を返します。
+// 末尾の空行は除去し、空文字列または改行のみの入力では nil を返します。
 // 配列化により行境界が構造として表現されるため、`\t<file>:<line>` の先頭タブは除去します。
 func SplitStackLines(s string) []string {
-	if s == "" {
+	trimmed := strings.TrimRight(s, "\n")
+	if trimmed == "" {
 		return nil
 	}
-	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	lines := strings.Split(trimmed, "\n")
 	for i, line := range lines {
 		lines[i] = strings.TrimLeft(line, "\t")
 	}

--- a/internal/logging/field.go
+++ b/internal/logging/field.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"strings"
 	"time"
 
 	"go-boilerplate/pkg/xerrors"
@@ -120,12 +121,28 @@ func Error(key fieldKey, err error) *Field {
 }
 
 // Stacktrace は、エラースタックトレースのログフィールドを作成します。
+// JSON ビューア（Grafana / Loki 等）で改行が可読に表示されるよう、
+// 単一文字列ではなく行ごとに分割した []string を保持します。
 func Stacktrace(key fieldKey, err error) *Field {
 	return &Field{
-		key:         string(key),
-		kind:        fieldString,
-		stringValue: xerrors.StackTrace(err),
+		key:          string(key),
+		kind:         fieldStrings,
+		stringsValue: SplitStackLines(xerrors.StackTrace(err)),
 	}
+}
+
+// SplitStackLines は、スタックトレース文字列を改行で分割し行配列に変換します。
+// 末尾の空行は除去し、空文字列入力では nil を返します。
+// 配列化により行境界が構造として表現されるため、`\t<file>:<line>` の先頭タブは除去します。
+func SplitStackLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimLeft(line, "\t")
+	}
+	return lines
 }
 
 // Any は、任意の型のログフィールドを作成します。

--- a/internal/logging/field_test.go
+++ b/internal/logging/field_test.go
@@ -214,18 +214,74 @@ func TestStacktrace(t *testing.T) {
 	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("StackTrace文字列を保持するFieldを生成する", func(t *testing.T) {
+		t.Run("StackTraceを行配列として保持するFieldを生成する", func(t *testing.T) {
 			t.Parallel()
 
 			const expectedKey = "key"
 			expectedError := xerrors.New("something went wrong")
 			expected := &Field{
-				key:         expectedKey,
-				kind:        fieldString,
-				stringValue: xerrors.StackTrace(expectedError),
+				key:          expectedKey,
+				kind:         fieldStrings,
+				stringsValue: SplitStackLines(xerrors.StackTrace(expectedError)),
 			}
 
 			assert.Equal(t, expected, Stacktrace(expectedKey, expectedError))
+		})
+
+		t.Run("nilエラーの場合、空のFieldを生成する", func(t *testing.T) {
+			t.Parallel()
+
+			const expectedKey = "key"
+			expected := &Field{
+				key:          expectedKey,
+				kind:         fieldStrings,
+				stringsValue: nil,
+			}
+
+			assert.Equal(t, expected, Stacktrace(expectedKey, nil))
+		})
+	})
+}
+
+func TestSplitStackLines(t *testing.T) {
+	t.Parallel()
+
+	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("複数行を改行で分割し各行の先頭タブを除いた行配列を返す", func(t *testing.T) {
+			t.Parallel()
+
+			input := "frame1\n\t/path/to/file.go:10\nframe2\n\t/path/to/other.go:20"
+			expected := []string{
+				"frame1",
+				"/path/to/file.go:10",
+				"frame2",
+				"/path/to/other.go:20",
+			}
+			assert.Equal(t, expected, SplitStackLines(input))
+		})
+
+		t.Run("先頭タブが複数連続していても全て除去される", func(t *testing.T) {
+			t.Parallel()
+
+			input := "frame1\n\t\t/path/to/file.go:10"
+			expected := []string{"frame1", "/path/to/file.go:10"}
+			assert.Equal(t, expected, SplitStackLines(input))
+		})
+
+		t.Run("末尾改行は分割結果から除去される", func(t *testing.T) {
+			t.Parallel()
+
+			input := "frame1\nframe2\n"
+			expected := []string{"frame1", "frame2"}
+			assert.Equal(t, expected, SplitStackLines(input))
+		})
+
+		t.Run("空文字列の場合、nilを返す", func(t *testing.T) {
+			t.Parallel()
+
+			assert.Nil(t, SplitStackLines(""))
 		})
 	})
 }

--- a/internal/logging/logger_core.go
+++ b/internal/logging/logger_core.go
@@ -63,17 +63,21 @@ func NewDevelopmentLogger() (Logger, error) {
 // Logger（中身 nil）を返すと初回ログ出力で nil 参照 panic になる。
 // よってエラー時は Logger を返さず、nil とエラーのみを返す。
 //
-// stacktrace は zap デフォルトの単一文字列ではなく行配列で出力するため、
-// wrapStacktraceCore で Entry.Stack を []string に置き換えてエンコードする。
+// stacktrace は JSON 出力時のみ行配列に変換する（wrapStacktraceCore）。
+// console エンコーダは Entry.Stack を独自に整形（改行+インデント）するため、
+// wrap すると console 出力が一行 JSON ダンプ化して可読性が落ちるので適用しない。
+// StacktraceKey 未設定の Config（テスト用最小構成など）でも wrap をスキップする。
 func buildLogger(cfg zap.Config, stacktraceLevel zapcore.Level) (Logger, error) {
-	stacktraceKey := cfg.EncoderConfig.StacktraceKey
-	zl, err := cfg.Build(
+	opts := []zap.Option{
 		zap.AddCaller(),
 		zap.AddStacktrace(stacktraceLevel),
-		zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+	}
+	if stacktraceKey := cfg.EncoderConfig.StacktraceKey; cfg.Encoding == "json" && stacktraceKey != "" {
+		opts = append(opts, zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 			return wrapStacktraceCore(core, stacktraceKey)
-		}),
-	)
+		}))
+	}
+	zl, err := cfg.Build(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/logging/logger_core.go
+++ b/internal/logging/logger_core.go
@@ -62,9 +62,17 @@ func NewDevelopmentLogger() (Logger, error) {
 // Build 失敗時は zap が nil の *zap.Logger を返すため、それを包んだ
 // Logger（中身 nil）を返すと初回ログ出力で nil 参照 panic になる。
 // よってエラー時は Logger を返さず、nil とエラーのみを返す。
+//
+// stacktrace は zap デフォルトの単一文字列ではなく行配列で出力するため、
+// wrapStacktraceCore で Entry.Stack を []string に置き換えてエンコードする。
 func buildLogger(cfg zap.Config, stacktraceLevel zapcore.Level) (Logger, error) {
+	stacktraceKey := cfg.EncoderConfig.StacktraceKey
 	zl, err := cfg.Build(
-		zap.AddCaller(), zap.AddStacktrace(stacktraceLevel),
+		zap.AddCaller(),
+		zap.AddStacktrace(stacktraceLevel),
+		zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+			return wrapStacktraceCore(core, stacktraceKey)
+		}),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/logging/stacktrace_core.go
+++ b/internal/logging/stacktrace_core.go
@@ -9,6 +9,13 @@ import (
 // 行ごとの []string に変換して emit する zapcore.Core ラッパです。
 // Grafana / Loki などの JSON ビューアでは配列要素ごとに改行表示されるため、
 // 単一文字列のときに発生する \n のリテラル表示問題を避けられます。
+//
+// 前提: 本実装は単一の leaf Core をラップする用途のみを想定します。
+// Check は内側 Core の Check に委譲せず自身のみ登録するため、内側が Sampler や
+// 複数子の Tee の場合に Check フェーズの副作用（Sampler のカウンタ更新など）が
+// 失われます。現状の NewProductionLogger / NewDevelopmentLogger は Sampling を
+// 使わず Tee も組まないため到達しません。将来サンプリング等を導入する場合は
+// 本ラッパを Check/Write 二段階契約に沿って再設計してください。
 type stacktraceArrayCore struct {
 	zapcore.Core
 	key string

--- a/internal/logging/stacktrace_core.go
+++ b/internal/logging/stacktrace_core.go
@@ -1,0 +1,44 @@
+package logging
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// stacktraceArrayCore は zap が自動付与する stacktrace（埋め込み \n\t の単一文字列）を、
+// 行ごとの []string に変換して emit する zapcore.Core ラッパです。
+// Grafana / Loki などの JSON ビューアでは配列要素ごとに改行表示されるため、
+// 単一文字列のときに発生する \n のリテラル表示問題を避けられます。
+type stacktraceArrayCore struct {
+	zapcore.Core
+	key string
+}
+
+// wrapStacktraceCore は、与えられた Core を stacktraceArrayCore でラップします。
+// key は出力先キー名（EncoderConfig.StacktraceKey と一致させる）。
+func wrapStacktraceCore(core zapcore.Core, key string) zapcore.Core {
+	return &stacktraceArrayCore{Core: core, key: key}
+}
+
+// With は内側 Core の With を伝播しつつ、自身のラップ属性を維持します。
+func (c *stacktraceArrayCore) With(fs []zapcore.Field) zapcore.Core {
+	return &stacktraceArrayCore{Core: c.Core.With(fs), key: c.key}
+}
+
+// Check は、レベルが有効な場合に自身を CheckedEntry に登録します。
+func (c *stacktraceArrayCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(ent.Level) {
+		return ce.AddCore(ent, c)
+	}
+	return ce
+}
+
+// Write は、Entry.Stack を行配列に変換した zap.Strings フィールドへ差し替えます。
+// 元の Entry.Stack はクリアして、エンコーダが二重に文字列出力するのを防ぎます。
+func (c *stacktraceArrayCore) Write(ent zapcore.Entry, fs []zapcore.Field) error {
+	if ent.Stack != "" {
+		fs = append(fs, zap.Strings(c.key, SplitStackLines(ent.Stack)))
+		ent.Stack = ""
+	}
+	return c.Core.Write(ent, fs)
+}

--- a/internal/logging/stacktrace_core_test.go
+++ b/internal/logging/stacktrace_core_test.go
@@ -1,0 +1,97 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// newJSONStacktraceLogger は、JSON エンコード + stacktraceArrayCore ラップ付きの zap ロガーを生成する。
+func newJSONStacktraceLogger(t *testing.T, stacktraceLevel zapcore.Level) (*zap.Logger, *bytes.Buffer) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	encCfg := zap.NewProductionEncoderConfig()
+	encCfg.StacktraceKey = "stacktrace"
+	enc := zapcore.NewJSONEncoder(encCfg)
+	base := zapcore.NewCore(enc, zapcore.AddSync(&buf), zapcore.DebugLevel)
+
+	wrapped := wrapStacktraceCore(base, encCfg.StacktraceKey)
+	zl := zap.New(wrapped, zap.AddStacktrace(stacktraceLevel))
+	return zl, &buf
+}
+
+func Test_stacktraceArrayCore_Write(t *testing.T) {
+	t.Parallel()
+
+	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("stacktrace付きエントリはstacktraceが行配列としてJSON出力される", func(t *testing.T) {
+			t.Parallel()
+
+			zl, buf := newJSONStacktraceLogger(t, zapcore.ErrorLevel)
+			zl.Error("boom")
+
+			var got map[string]any
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+
+			raw, ok := got["stacktrace"]
+			require.True(t, ok, "stacktrace key must exist")
+
+			arr, ok := raw.([]any)
+			require.True(t, ok, "stacktrace must be JSON array, got %T", raw)
+			require.NotEmpty(t, arr)
+			for _, v := range arr {
+				_, ok := v.(string)
+				assert.True(t, ok, "each stacktrace element must be a string, got %T", v)
+			}
+		})
+
+		t.Run("stacktraceLevel未満のエントリはstacktraceフィールドが付与されない", func(t *testing.T) {
+			t.Parallel()
+
+			zl, buf := newJSONStacktraceLogger(t, zapcore.ErrorLevel)
+			zl.Info("just info")
+
+			var got map[string]any
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+
+			_, ok := got["stacktrace"]
+			assert.False(t, ok, "stacktrace must not be present below configured level")
+		})
+	})
+}
+
+func Test_stacktraceArrayCore_With(t *testing.T) {
+	t.Parallel()
+
+	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("Withで付与したフィールドが後続出力に伝播する", func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			encCfg := zap.NewProductionEncoderConfig()
+			encCfg.StacktraceKey = "stacktrace"
+			enc := zapcore.NewJSONEncoder(encCfg)
+			base := zapcore.NewCore(enc, zapcore.AddSync(&buf), zapcore.DebugLevel)
+
+			wrapped := wrapStacktraceCore(base, "stacktrace").
+				With([]zapcore.Field{zap.String("svc", "demo")})
+
+			zl := zap.New(wrapped)
+			zl.Info("hello")
+
+			var got map[string]any
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+			assert.Equal(t, "demo", got["svc"])
+		})
+	})
+}

--- a/internal/logging/stacktrace_core_test.go
+++ b/internal/logging/stacktrace_core_test.go
@@ -3,6 +3,9 @@ package logging
 import (
 	"bytes"
 	"encoding/json"
+	"net/url"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +13,51 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
+
+// メモリ書き込み可能な zap.Sink を 1 度だけ登録する。
+// OutputPaths に "mem://buildlogger" を指定すると、test 側で取り出したバッファに書き込まれる。
+var (
+	memSinkOnce sync.Once
+	memSinks    = sync.Map{} // key: URL.Host, val: *memSink
+)
+
+type memSink struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (m *memSink) Write(p []byte) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.buf.Write(p)
+}
+func (m *memSink) Sync() error  { return nil }
+func (m *memSink) Close() error { return nil }
+func (m *memSink) Bytes() []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]byte(nil), m.buf.Bytes()...)
+}
+
+// registerMemSink は、test 用メモリ sink スキームをプロセス内で 1 度だけ登録する。
+func registerMemSink(t *testing.T) {
+	t.Helper()
+	memSinkOnce.Do(func() {
+		require.NoError(t, zap.RegisterSink("mem", func(u *url.URL) (zap.Sink, error) {
+			s := &memSink{}
+			memSinks.Store(u.Host, s)
+			return s, nil
+		}))
+	})
+}
+
+// readMemSink は、登録済みメモリ sink に書き込まれた内容を取り出す。
+func readMemSink(t *testing.T, name string) []byte {
+	t.Helper()
+	v, ok := memSinks.Load(name)
+	require.True(t, ok, "mem sink %q not found", name)
+	return v.(*memSink).Bytes()
+}
 
 // newJSONStacktraceLogger は、JSON エンコード + stacktraceArrayCore ラップ付きの zap ロガーを生成する。
 func newJSONStacktraceLogger(t *testing.T, stacktraceLevel zapcore.Level) (*zap.Logger, *bytes.Buffer) {
@@ -64,6 +112,87 @@ func Test_stacktraceArrayCore_Write(t *testing.T) {
 
 			_, ok := got["stacktrace"]
 			assert.False(t, ok, "stacktrace must not be present below configured level")
+		})
+	})
+}
+
+// 本番ロガー相当の Encoding=json + 非空 StacktraceKey 設定で buildLogger を組み、
+// JSON 出力の stacktrace キーが配列になるエンドツーエンド経路を検証する。
+func Test_buildLogger_jsonStacktraceIsArray(t *testing.T) {
+	t.Parallel()
+
+	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("json設定でErrorログのstacktraceが配列で出力される", func(t *testing.T) {
+			t.Parallel()
+
+			registerMemSink(t)
+			const sinkName = "buildlogger-json"
+			cfg := zap.Config{
+				Level:       zap.NewAtomicLevelAt(zapcore.InfoLevel),
+				Encoding:    "json",
+				OutputPaths: []string{"mem://" + sinkName},
+				EncoderConfig: zapcore.EncoderConfig{
+					MessageKey:    "msg",
+					LevelKey:      "level",
+					StacktraceKey: "stacktrace",
+					EncodeLevel:   zapcore.LowercaseLevelEncoder,
+				},
+			}
+			l, err := buildLogger(cfg, zapcore.ErrorLevel)
+			require.NoError(t, err)
+			l.Error("simulated server error")
+
+			raw := readMemSink(t, sinkName)
+
+			var got map[string]any
+			require.NoError(t, json.Unmarshal(bytes.TrimRight(raw, "\n"), &got))
+
+			st, ok := got["stacktrace"]
+			require.True(t, ok, "stacktrace key must exist")
+			arr, ok := st.([]any)
+			require.True(t, ok, "stacktrace must be JSON array, got %T", st)
+			require.NotEmpty(t, arr)
+		})
+	})
+}
+
+// console エンコーダで wrap が適用されると一行 JSON 化して可読性が破壊されるため、
+// buildLogger は console 設定では wrap を適用せず、zap 標準の改行付きスタックを保つ。
+func Test_buildLogger_consoleStacktraceStaysMultiline(t *testing.T) {
+	t.Parallel()
+
+	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("console設定ではstacktraceが改行付きの単一文字列として出力される", func(t *testing.T) {
+			t.Parallel()
+
+			registerMemSink(t)
+			const sinkName = "buildlogger-console"
+			cfg := zap.Config{
+				Level:       zap.NewAtomicLevelAt(zapcore.DebugLevel),
+				Encoding:    "console",
+				OutputPaths: []string{"mem://" + sinkName},
+				EncoderConfig: zapcore.EncoderConfig{
+					MessageKey:    "msg",
+					LevelKey:      "level",
+					StacktraceKey: "Stack",
+					EncodeLevel:   zapcore.CapitalLevelEncoder,
+				},
+			}
+			l, err := buildLogger(cfg, zapcore.ErrorLevel)
+			require.NoError(t, err)
+			l.Error("simulated server error")
+
+			raw := readMemSink(t, sinkName)
+			out := string(raw)
+			// console エンコーダ標準の改行+インデント形式が保たれる（一行 JSON 配列化していない）。
+			require.Contains(t, out, "\n", "console output must keep newlines")
+			require.NotContains(t, out, `"Stack":[`, "console output must not contain JSON array form of stack")
+			// 少なくとも複数行に渡るスタックが出力されていること。
+			assert.GreaterOrEqual(t, strings.Count(out, "\n"), 2)
 		})
 	})
 }


### PR DESCRIPTION
# 概要

JSON ログに含まれる stack 系フィールドが `\n\t` を含む単一文字列で出力されており、
Grafana の JSON ビュー上でエスケープがそのまま表示されて可読性が低かった問題を解消する。
zap 自動 stacktrace と recovery / errorhandler の手動 stacktrace の両方を、
1 行 = 1 要素の `[]string` に揃えて出力するよう変更する。

closes #24

## 変更内容

- 内部ロジック
  - `internal/logging/field.go`: `Stacktrace` ヘルパを `[]string` 出力に変更。`SplitStackLines` を追加し、行頭タブも除去する。
  - `internal/logging/stacktrace_core.go` (新規): zap が自動付与する `Entry.Stack`（単一文字列）を行配列に変換する `zapcore.Core` ラッパ `stacktraceArrayCore` を追加。
  - `internal/logging/logger_core.go`: `buildLogger` に `zap.WrapCore` で上記ラッパを注入。
  - `internal/controller/httpstack/recovery/recover.go`: panic 復旧時の `internal_stacktrace` を `logging.Strings` + `SplitStackLines` で配列化。
  - `internal/controller/httpstack/errorhandler/http_error_handler.go`: HTTP エラー時の `internal_stacktrace` を `logging.Stacktrace` 経由で配列化。
- テスト
  - `internal/logging/field_test.go`, `internal/logging/stacktrace_core_test.go` (新規): 行分割・タブ除去・Core ラッパの JSON 出力形式を検証。
  - `internal/controller/httpstack/recovery/recover_test.go`, `internal/controller/httpstack/errorhandler/http_error_handler_test.go`: 期待値を `[]string` / `[]any`（observer 経由）に追従。
- ドキュメント
  - `internal/logging/README.md`, `README.ja.md`: `Stacktrace` の型表記を `[]string` に追従。

### 互換性影響

ログのスキーマが `stack: string` → `stack: []string` に変わるため、`internal_stacktrace` / `stacktrace` を文字列前提で参照している Loki クエリや alert があれば追従が必要。

## 動作確認方法

1. `make fix` / `make test` がパスすること（本 PR では確認済み）。
2. production logger + recovery middleware の構成で `/panic` 経路を叩き、JSON ログの `internal_stacktrace` / `stacktrace` が **JSON 配列**で出力されること（手元確認済み）。期待形:
   ```json
   "stacktrace": [
     "go-boilerplate/internal/logging.(*logger).Error",
     "/Users/.../internal/logging/logger.go:61"
   ]
   ```
3. Grafana / Loki 側のクエリで `stack` を文字列前提で参照している箇所があれば配列対応に更新する。