### PR TITLE
Test: テストファイルの規約違反を修正し命名を日本語へ統一

### DIFF
--- a/internal/cli/job/job_test.go
+++ b/internal/cli/job/job_test.go
@@ -137,7 +137,7 @@ func TestRunJobWith(t *testing.T) {
 	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("正常系_provideで取得したstart/stopをrunJobへ渡し結果を返す", func(t *testing.T) {
+		t.Run("provideで取得したstart/stopをrunJobへ渡し結果を返す", func(t *testing.T) {
 			t.Parallel()
 
 			done := make(chan error, 1)

--- a/internal/config/config_testing_setter_test.go
+++ b/internal/config/config_testing_setter_test.go
@@ -12,62 +12,62 @@ func TestConfigTestingSetters(t *testing.T) {
 	t.Run("正常系", func(t *testing.T) {
 		cfg := MockConfigForTest(t)
 
-		t.Run("SetAppMode", func(t *testing.T) {
+		t.Run("アプリケーションモードを設定して取得できる", func(t *testing.T) {
 			expected := "test-mode"
 			cfg.app.SetApplicationMode(t, expected)
 			assert.Equal(t, expected, cfg.app.Mode())
 		})
 
-		t.Run("SetAppEnv", func(t *testing.T) {
+		t.Run("アプリケーション環境を設定して取得できる", func(t *testing.T) {
 			expected := "test-env"
 			cfg.app.SetApplicationEnv(t, expected)
 			assert.Equal(t, expected, cfg.app.Env())
 		})
 
-		t.Run("SetServerPort", func(t *testing.T) {
+		t.Run("サーバーポートを設定して取得できる", func(t *testing.T) {
 			expected := 8081
 			cfg.server.SetServerPort(t, expected)
 			assert.Equal(t, expected, cfg.server.Port())
 		})
 
-		t.Run("SetObservabilityMaskedDBQueryArgs", func(t *testing.T) {
+		t.Run("DBクエリ引数のマスク設定を設定して取得できる", func(t *testing.T) {
 			expected := true
 			cfg.observability.SetObservabilityMaskedDBQueryArgs(t, expected)
 			assert.Equal(t, expected, cfg.observability.MaskedDBQueryArgs())
 		})
 
-		t.Run("SetDatabaseHost", func(t *testing.T) {
+		t.Run("データベースホストを設定して取得できる", func(t *testing.T) {
 			expected := "test-host"
 			cfg.database.SetDatabaseHost(t, expected)
 			assert.Equal(t, expected, cfg.database.Host())
 		})
 
-		t.Run("SetDatabaseName", func(t *testing.T) {
+		t.Run("データベース名を設定して取得できる", func(t *testing.T) {
 			expected := "test-name"
 			cfg.database.SetDatabaseName(t, expected)
 			assert.Equal(t, expected, cfg.database.DBName())
 		})
 
-		t.Run("SetMaxConns", func(t *testing.T) {
+		t.Run("最大コネクション数を設定して取得できる", func(t *testing.T) {
 			expected := int32(20)
 			cfg.dbconnection.SetMaxConns(t, expected)
 			assert.Equal(t, expected, cfg.dbconnection.MaxConns())
 		})
 
-		t.Run("SetCIDR", func(t *testing.T) {
+		t.Run("CIDRを設定して取得できる", func(t *testing.T) {
 			_, testCIDR, err := net.ParseCIDR("192.168.1.0/24")
 			require.NoError(t, err)
 			cfg.security.SetCIDR(t, testCIDR)
 			assert.Equal(t, testCIDR, cfg.security.CIDR())
 		})
 
-		t.Run("SetHeaderName", func(t *testing.T) {
+		t.Run("認証ヘッダー名を設定して取得できる", func(t *testing.T) {
 			expected := "X-TEST-AUTH"
 			cfg.auth.SetHeaderName(t, expected)
 			assert.Equal(t, expected, cfg.auth.HeaderName())
 		})
 
-		t.Run("SetAllowedHeaderBearer", func(t *testing.T) {
+		t.Run("Bearerヘッダー許可を設定して取得できる", func(t *testing.T) {
 			expected := true
 			cfg.auth.SetAllowedHeaderBearer(t, expected)
 			assert.Equal(t, expected, cfg.auth.AllowedHeaderBearer())

--- a/internal/config/model_test.go
+++ b/internal/config/model_test.go
@@ -14,67 +14,61 @@ func TestConstructor(t *testing.T) {
 		t.Parallel()
 		cfg := MockConfigForTest(t)
 
-		t.Run("NewOSConfig", func(t *testing.T) {
+		t.Run("OS設定のコンストラクタが内部フィールドへの参照を返す", func(t *testing.T) {
 			t.Parallel()
 			osCfg := NewOperatingSystemConfig(cfg)
 			assert.Same(t, &cfg.os, osCfg)
 		})
 
-		t.Run("NewServerConfig", func(t *testing.T) {
+		t.Run("サーバー設定のコンストラクタが内部フィールドへの参照を返す", func(t *testing.T) {
 			t.Parallel()
 			serverCfg := NewServerConfig(cfg)
 			assert.Same(t, &cfg.server, serverCfg)
 		})
 
-		t.Run("NewMetricsConfig", func(t *testing.T) {
+		t.Run("メトリクス設定のコンストラクタが内部フィールドへの参照を返す", func(t *testing.T) {
 			t.Parallel()
 			metricsCfg := NewMetricsConfig(cfg)
 			assert.Same(t, &cfg.metrics, metricsCfg)
 		})
 
-		t.Run("NewObservabilityConfig", func(t *testing.T) {
+		t.Run("オブザーバビリティ設定のコンストラクタが内部フィールドへの参照を返す", func(t *testing.T) {
 			t.Parallel()
 			observabilityCfg := NewObservabilityConfig(cfg)
 			assert.Same(t, &cfg.observability, observabilityCfg)
 		})
 
-		t.Run("NewObservabilityConfig", func(t *testing.T) {
-			t.Parallel()
-			observabilityCfg := NewObservabilityConfig(cfg)
-			assert.Same(t, &cfg.observability, observabilityCfg)
-		})
-
-		t.Run("NewApplicationConfig", func(t *testing.T) {
+		t.Run("アプリケーション設定のコンストラクタが内部フィールドへの参照を返す", func(t *testing.T) {
 			t.Parallel()
 			appCfg := NewApplicationConfig(cfg)
 			assert.Same(t, &cfg.app, appCfg)
 		})
 
-		t.Run("NewDatabaseConfig", func(t *testing.T) {
+		t.Run("データベース設定のコンストラクタが内部フィールドへの参照を返す", func(t *testing.T) {
 			t.Parallel()
 			dbCfg := NewDatabaseConfig(cfg)
 			assert.Same(t, &cfg.database, dbCfg)
 		})
 
-		t.Run("NewDBConnectionConfig", func(t *testing.T) {
+		t.Run("DBコネクション設定のコンストラクタが内部フィールドへの参照を返す", func(t *testing.T) {
 			t.Parallel()
 			dbConnCfg := NewDBConnectionConfig(cfg)
 			assert.Same(t, &cfg.dbconnection, dbConnCfg)
 		})
 
-		t.Run("NewSecurityConfig", func(t *testing.T) {
+		t.Run("セキュリティ設定のコンストラクタが内部フィールドへの参照を返す", func(t *testing.T) {
 			t.Parallel()
 			securityCfg := NewSecurityConfig(cfg)
 			assert.Same(t, &cfg.security, securityCfg)
 		})
 
-		t.Run("NewSecureCookieConfig", func(t *testing.T) {
+		t.Run("セキュアCookie設定のコンストラクタが内部フィールドへの参照を返す", func(t *testing.T) {
 			t.Parallel()
 			secureCookieCfg := NewSecureCookieConfig(cfg)
 			assert.Same(t, &cfg.secureCookie, secureCookieCfg)
 		})
 
-		t.Run("NewAuthConfig", func(t *testing.T) {
+		t.Run("認証設定のコンストラクタが内部フィールドへの参照を返す", func(t *testing.T) {
 			t.Parallel()
 			authCfg := NewAuthConfig(cfg)
 			assert.Same(t, &cfg.auth, authCfg)
@@ -89,195 +83,195 @@ func TestGetterMethods(t *testing.T) {
 
 		cfg := MockConfigForTest(t)
 
-		t.Run("OperatingSystem", func(t *testing.T) {
+		t.Run("OS設定", func(t *testing.T) {
 			t.Parallel()
 			os := cfg.os
-			t.Run("TimeZone", func(t *testing.T) {
+			t.Run("タイムゾーンを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedOSTimeZone, os.TimeZone())
 			})
 		})
 
-		t.Run("Server", func(t *testing.T) {
+		t.Run("サーバー設定", func(t *testing.T) {
 			t.Parallel()
 			server := cfg.server
-			t.Run("Host", func(t *testing.T) {
+			t.Run("ホストを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedServerHost, server.Host())
 			})
 
-			t.Run("Port", func(t *testing.T) {
+			t.Run("ポートを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedServerPort, server.Port())
 			})
 
-			t.Run("ReadHeaderTimeout", func(t *testing.T) {
+			t.Run("ヘッダー読み取りタイムアウトを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedServerReadHeaderTimeout, server.ReadHeaderTimeout())
 			})
 
-			t.Run("ReadTimeout", func(t *testing.T) {
+			t.Run("読み取りタイムアウトを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedServerReadTimeout, server.ReadTimeout())
 			})
 
-			t.Run("WriteTimeout", func(t *testing.T) {
+			t.Run("書き込みタイムアウトを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedServerWriteTimeout, server.WriteTimeout())
 			})
 
-			t.Run("IdleTimeout", func(t *testing.T) {
+			t.Run("アイドルタイムアウトを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedServerIdleTimeout, server.IdleTimeout())
 			})
 		})
 
-		t.Run("Metrics", func(t *testing.T) {
+		t.Run("メトリクス設定", func(t *testing.T) {
 			t.Parallel()
 			metrics := cfg.metrics
 
-			t.Run("Host", func(t *testing.T) {
+			t.Run("ホストを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedMetricsHost, metrics.Host())
 			})
 
-			t.Run("Port", func(t *testing.T) {
+			t.Run("ポートを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedMetricsPort, metrics.Port())
 			})
 
-			t.Run("UserName", func(t *testing.T) {
+			t.Run("ユーザー名を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedMetricsUserName, metrics.UserName())
 			})
 
-			t.Run("Password", func(t *testing.T) {
+			t.Run("パスワードを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedMetricsPassword, metrics.Password())
 			})
 		})
 
-		t.Run("Observability", func(t *testing.T) {
+		t.Run("オブザーバビリティ設定", func(t *testing.T) {
 			t.Parallel()
 			observability := cfg.observability
 
-			t.Run("Enabled", func(t *testing.T) {
+			t.Run("有効フラグを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.True(t, observability.Enabled())
 			})
 
-			t.Run("MaskedDBQueryArgs", func(t *testing.T) {
+			t.Run("DBクエリ引数マスク設定を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedObservabilityMaskedDBQueryArgs, observability.MaskedDBQueryArgs())
 			})
 
-			t.Run("TargetStatusCodeSet", func(t *testing.T) {
+			t.Run("対象ステータスコード集合を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedObservabilityTargetStatusCodeSet, observability.TargetStatusCodeSet())
 			})
 		})
 
-		t.Run("Application", func(t *testing.T) {
+		t.Run("アプリケーション設定", func(t *testing.T) {
 			t.Parallel()
 			app := cfg.app
-			t.Run("Env", func(t *testing.T) {
+			t.Run("環境を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedApplicationEnv, app.Env())
 			})
 
-			t.Run("Name", func(t *testing.T) {
+			t.Run("名前を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedApplicationName, app.Name())
 			})
 
-			t.Run("Mode", func(t *testing.T) {
+			t.Run("モードを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedApplicationMode, app.Mode())
 			})
 
-			t.Run("ShutdownTimeout", func(t *testing.T) {
+			t.Run("シャットダウンタイムアウトを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedAppShutdownTimeout, app.ShutdownTimeout())
 			})
 		})
 
-		t.Run("Database", func(t *testing.T) {
+		t.Run("データベース設定", func(t *testing.T) {
 			t.Parallel()
 			database := cfg.database
-			t.Run("Driver", func(t *testing.T) {
+			t.Run("ドライバーを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedDBDriver, database.Driver())
 			})
 
-			t.Run("Host", func(t *testing.T) {
+			t.Run("ホストを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedDBHost, database.Host())
 			})
 
-			t.Run("Port", func(t *testing.T) {
+			t.Run("ポートを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedDBPort, database.Port())
 			})
 
-			t.Run("User", func(t *testing.T) {
+			t.Run("ユーザーを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedDBUser, database.User())
 			})
 
-			t.Run("Password", func(t *testing.T) {
+			t.Run("パスワードを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedDBPassword, database.Password())
 			})
 
-			t.Run("DBName", func(t *testing.T) {
+			t.Run("データベース名を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedDBName, database.DBName())
 			})
 
-			t.Run("SSLMode", func(t *testing.T) {
+			t.Run("SSLモードを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedDBSSLMode, database.SSLMode())
 			})
 
-			t.Run("PingTimeout", func(t *testing.T) {
+			t.Run("Pingタイムアウトを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedDBPingTimeout, database.PingTimeout())
 			})
 
-			t.Run("SlowQueryWarnThreshold", func(t *testing.T) {
+			t.Run("スロークエリ警告閾値を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedDBSlowQueryWarnThreshold, database.SlowQueryWarnThreshold())
 			})
 		})
 
-		t.Run("DBConnection", func(t *testing.T) {
+		t.Run("DBコネクション設定", func(t *testing.T) {
 			t.Parallel()
 			connection := cfg.dbconnection
-			t.Run("MaxConns", func(t *testing.T) {
+			t.Run("最大コネクション数を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedDBMaxConnsInt32, connection.MaxConns())
 			})
 
-			t.Run("MinConns", func(t *testing.T) {
+			t.Run("最小コネクション数を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedDBMinConnsInt32, connection.MinConns())
 			})
 
-			t.Run("MaxLifetime", func(t *testing.T) {
+			t.Run("最大ライフタイムを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedDBMaxLifetime, connection.MaxLifetime())
 			})
 
-			t.Run("MaxIdleTime", func(t *testing.T) {
+			t.Run("最大アイドル時間を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedDBMaxIdleTime, connection.MaxIdleTime())
 			})
 		})
 
-		t.Run("Security", func(t *testing.T) {
+		t.Run("セキュリティ設定", func(t *testing.T) {
 			t.Parallel()
 			security := cfg.security
-			t.Run("AllowedOrigins", func(t *testing.T) {
+			t.Run("許可オリジンを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(
 					t,
@@ -286,82 +280,82 @@ func TestGetterMethods(t *testing.T) {
 				)
 			})
 
-			t.Run("CIDR", func(t *testing.T) {
+			t.Run("CIDRを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedCIDR, security.CIDR())
 			})
 
-			t.Run("ContentTypeNosniff", func(t *testing.T) {
+			t.Run("ContentTypeNosniffを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedContentTypeNosniff, security.ContentTypeNosniff())
 			})
 
-			t.Run("XFrameOptions", func(t *testing.T) {
+			t.Run("XFrameOptionsを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedXFrameOptions, security.XFrameOptions())
 			})
 
-			t.Run("HSTSMaxAge", func(t *testing.T) {
+			t.Run("HSTS最大期間を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedHSTSMaxAge, security.HSTSMaxAge())
 			})
 
-			t.Run("HSTSExcludeSubdomains", func(t *testing.T) {
+			t.Run("HSTSサブドメイン除外設定を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedHSTSExcludeSubdomains, security.HSTSExcludeSubdomains())
 			})
 
-			t.Run("HSTSPreloadEnabled", func(t *testing.T) {
+			t.Run("HSTSプリロード有効設定を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedHSTSPreloadEnabled, security.HSTSPreloadEnabled())
 			})
 
-			t.Run("ReferrerPolicy", func(t *testing.T) {
+			t.Run("リファラーポリシーを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedReferrerPolicy, security.ReferrerPolicy())
 			})
 
-			t.Run("BcryptCost", func(t *testing.T) {
+			t.Run("bcryptコストを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedBcryptCost, security.BcryptCost())
 			})
 		})
 
-		t.Run("SecureCookie", func(t *testing.T) {
+		t.Run("セキュアCookie設定", func(t *testing.T) {
 			t.Parallel()
 			secureCookie := cfg.secureCookie
 
-			t.Run("Secure", func(t *testing.T) {
+			t.Run("Secure属性を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedSecureCookieSecure, secureCookie.Secure())
 			})
 
-			t.Run("SameSite", func(t *testing.T) {
+			t.Run("SameSite属性を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedSecureCookieSameSite, secureCookie.SameSite())
 			})
 
-			t.Run("Domain", func(t *testing.T) {
+			t.Run("ドメインを取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedSecureCookieDomain, secureCookie.Domain())
 			})
 		})
 
-		t.Run("Auth", func(t *testing.T) {
+		t.Run("認証設定", func(t *testing.T) {
 			t.Parallel()
 			auth := cfg.auth
 
-			t.Run("CookieName", func(t *testing.T) {
+			t.Run("Cookie名を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedAuthCookieName, auth.CookieName())
 			})
 
-			t.Run("HeaderName", func(t *testing.T) {
+			t.Run("ヘッダー名を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedAuthHeaderName, auth.HeaderName())
 			})
 
-			t.Run("AllowedHeaderBearer", func(t *testing.T) {
+			t.Run("Bearerヘッダー許可を取得できる", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, expectedAuthAllowedHeaderBearer, auth.AllowedHeaderBearer())
 			})

--- a/internal/controller/ctxhelper/errorhandled_ctx_test.go
+++ b/internal/controller/ctxhelper/errorhandled_ctx_test.go
@@ -28,53 +28,65 @@ func TestSetErrorHandled(t *testing.T) {
 func TestGetErrorHandled(t *testing.T) {
 	t.Parallel()
 
-	t.Run("正常系_標準コンテキストから取得できる", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
-		ctx = SetErrorHandled(ctx, true)
+		t.Run("標準コンテキストから取得できる", func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			ctx = SetErrorHandled(ctx, true)
 
-		val, ok := GetErrorHandled(ctx)
-		assert.True(t, ok)
-		assert.Equal(t, true, val)
+			val, ok := GetErrorHandled(ctx)
+			assert.True(t, ok)
+			assert.Equal(t, true, val)
+		})
 	})
 
-	t.Run("異常系_値が無い場合はfalseを返す", func(t *testing.T) {
+	t.Run("異常系", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
-		val, ok := GetErrorHandled(ctx)
-		assert.False(t, ok)
-		assert.Equal(t, false, val)
+		t.Run("値が無い場合はfalseを返す", func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			val, ok := GetErrorHandled(ctx)
+			assert.False(t, ok)
+			assert.Equal(t, false, val)
+		})
 	})
 }
 
 func TestSetErrorHandledToEcho(t *testing.T) {
 	t.Parallel()
 
-	t.Run("正常系_echoへ設定し取得できる", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
-		e := echo.New()
-		ctx := context.Background()
-		req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
-		rec := httptest.NewRecorder()
-		c := e.NewContext(req, rec)
+		t.Run("echoへ設定し取得できる", func(t *testing.T) {
+			t.Parallel()
+			e := echo.New()
+			ctx := context.Background()
+			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
 
-		SetErrorHandledToEcho(c, true)
-		val, ok := GetErrorHandledFromEcho(c)
+			SetErrorHandledToEcho(c, true)
+			val, ok := GetErrorHandledFromEcho(c)
 
-		assert.True(t, ok)
-		assert.Equal(t, true, val)
+			assert.True(t, ok)
+			assert.Equal(t, true, val)
+		})
 	})
 
-	t.Run("異常系_echoに値が無い場合はfalseを返す", func(t *testing.T) {
+	t.Run("異常系", func(t *testing.T) {
 		t.Parallel()
-		e := echo.New()
-		ctx := context.Background()
-		req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
-		rec := httptest.NewRecorder()
-		c := e.NewContext(req, rec)
+		t.Run("echoに値が無い場合はfalseを返す", func(t *testing.T) {
+			t.Parallel()
+			e := echo.New()
+			ctx := context.Background()
+			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
 
-		val, ok := GetErrorHandledFromEcho(c)
-		assert.False(t, ok)
-		assert.Equal(t, false, val)
+			val, ok := GetErrorHandledFromEcho(c)
+			assert.False(t, ok)
+			assert.Equal(t, false, val)
+		})
 	})
 }

--- a/internal/controller/ctxhelper/recovered_ctx_test.go
+++ b/internal/controller/ctxhelper/recovered_ctx_test.go
@@ -28,53 +28,65 @@ func TestSetRecovered(t *testing.T) {
 func TestGetRecovered(t *testing.T) {
 	t.Parallel()
 
-	t.Run("正常系_標準コンテキストから取得できる", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
-		ctx = SetRecovered(ctx, true)
+		t.Run("標準コンテキストから取得できる", func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			ctx = SetRecovered(ctx, true)
 
-		val, ok := GetRecovered(ctx)
-		assert.True(t, ok)
-		assert.Equal(t, true, val)
+			val, ok := GetRecovered(ctx)
+			assert.True(t, ok)
+			assert.Equal(t, true, val)
+		})
 	})
 
-	t.Run("異常系_値が無い場合はfalseを返す", func(t *testing.T) {
+	t.Run("異常系", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
-		val, ok := GetRecovered(ctx)
-		assert.False(t, ok)
-		assert.Equal(t, false, val)
+		t.Run("値が無い場合はfalseを返す", func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			val, ok := GetRecovered(ctx)
+			assert.False(t, ok)
+			assert.Equal(t, false, val)
+		})
 	})
 }
 
 func TestSetRecoveredToEcho(t *testing.T) {
 	t.Parallel()
 
-	t.Run("正常系_echoへ設定し取得できる", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
-		e := echo.New()
-		ctx := context.Background()
-		req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
-		rec := httptest.NewRecorder()
-		c := e.NewContext(req, rec)
+		t.Run("echoへ設定し取得できる", func(t *testing.T) {
+			t.Parallel()
+			e := echo.New()
+			ctx := context.Background()
+			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
 
-		SetRecoveredToEcho(c, true)
-		val, ok := GetRecoveredFromEcho(c)
+			SetRecoveredToEcho(c, true)
+			val, ok := GetRecoveredFromEcho(c)
 
-		assert.True(t, ok)
-		assert.Equal(t, true, val)
+			assert.True(t, ok)
+			assert.Equal(t, true, val)
+		})
 	})
 
-	t.Run("異常系_echoに値が無い場合はfalseを返す", func(t *testing.T) {
+	t.Run("異常系", func(t *testing.T) {
 		t.Parallel()
-		e := echo.New()
-		ctx := context.Background()
-		req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
-		rec := httptest.NewRecorder()
-		c := e.NewContext(req, rec)
+		t.Run("echoに値が無い場合はfalseを返す", func(t *testing.T) {
+			t.Parallel()
+			e := echo.New()
+			ctx := context.Background()
+			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
 
-		val, ok := GetRecoveredFromEcho(c)
-		assert.False(t, ok)
-		assert.Equal(t, false, val)
+			val, ok := GetRecoveredFromEcho(c)
+			assert.False(t, ok)
+			assert.Equal(t, false, val)
+		})
 	})
 }

--- a/internal/di/job/hook/register_job_hooks_test.go
+++ b/internal/di/job/hook/register_job_hooks_test.go
@@ -135,7 +135,7 @@ func TestRunJobAndShutdown(t *testing.T) {
 			runJobAndShutdown(startCtx, sd, runner, logger, osCfg, state)
 
 			require.NoError(t, <-doneCh)
-			assert.NoError(t, jobCtxErr)
+			require.NoError(t, jobCtxErr)
 		})
 	})
 }

--- a/internal/di/server/extension/extension_test.go
+++ b/internal/di/server/extension/extension_test.go
@@ -17,70 +17,78 @@ import (
 func TestApplyPreMiddlewares(t *testing.T) {
 	t.Parallel()
 
-	t.Run("applies pre middlewares in priority order", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
 
-		e := echo.New()
+		t.Run("優先度順にPreミドルウェアが適用される", func(t *testing.T) {
+			t.Parallel()
 
-		mwA := func(next echo.HandlerFunc) echo.HandlerFunc {
-			return func(c echo.Context) error {
-				c.Response().Header().Add("X-Order", "A")
-				return next(c)
+			e := echo.New()
+
+			mwA := func(next echo.HandlerFunc) echo.HandlerFunc {
+				return func(c echo.Context) error {
+					c.Response().Header().Add("X-Order", "A")
+					return next(c)
+				}
 			}
-		}
-		mwB := func(next echo.HandlerFunc) echo.HandlerFunc {
-			return func(c echo.Context) error {
-				c.Response().Header().Add("X-Order", "B")
-				return next(c)
+			mwB := func(next echo.HandlerFunc) echo.HandlerFunc {
+				return func(c echo.Context) error {
+					c.Response().Header().Add("X-Order", "B")
+					return next(c)
+				}
 			}
-		}
 
-		// Priority はあえてバラバラにして、ソートされることを確認
-		mws := []PreMiddleware{
-			{Name: "B", Priority: 2, Middleware: mwB},
-			{Name: "A", Priority: 1, Middleware: mwA},
-		}
+			// Priority はあえてバラバラにして、ソートされることを確認
+			mws := []PreMiddleware{
+				{Name: "B", Priority: 2, Middleware: mwB},
+				{Name: "A", Priority: 1, Middleware: mwA},
+			}
 
-		err := ApplyPreMiddlewares(e, logging.NewTestLogger(t), mws)
-		require.NoError(t, err)
+			err := ApplyPreMiddlewares(e, logging.NewTestLogger(t), mws)
+			require.NoError(t, err)
 
-		// 適当なハンドラを登録して 1 回リクエスト
-		e.GET("/", func(c echo.Context) error {
-			return c.String(http.StatusOK, "ok")
+			// 適当なハンドラを登録して 1 回リクエスト
+			e.GET("/", func(c echo.Context) error {
+				return c.String(http.StatusOK, "ok")
+			})
+
+			ctx := context.Background()
+			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			// Pre ミドルウェアで積まれたヘッダの順序を確認
+			vals := rec.Header()["X-Order"]
+			assert.Equal(t, []string{"A", "B"}, vals)
 		})
-
-		ctx := context.Background()
-		req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
-		rec := httptest.NewRecorder()
-		e.ServeHTTP(rec, req)
-
-		// Pre ミドルウェアで積まれたヘッダの順序を確認
-		vals := rec.Header()["X-Order"]
-		assert.Equal(t, []string{"A", "B"}, vals)
 	})
 
-	t.Run("returns error when priorities conflict", func(t *testing.T) {
+	t.Run("異常系", func(t *testing.T) {
 		t.Parallel()
 
-		e := echo.New()
+		t.Run("優先度が重複する場合はエラーを返す", func(t *testing.T) {
+			t.Parallel()
 
-		mws := []PreMiddleware{
-			{
-				Name:       "pre1",
-				Priority:   1,
-				Middleware: func(next echo.HandlerFunc) echo.HandlerFunc { return next },
-			},
-			{
-				Name:       "pre2",
-				Priority:   1, // ★ 敢えて同じ Priority
-				Middleware: func(next echo.HandlerFunc) echo.HandlerFunc { return next },
-			},
-		}
+			e := echo.New()
 
-		err := ApplyPreMiddlewares(e, logging.NewTestLogger(t), mws)
-		require.Error(t, err)
-		// エラーメッセージの一部まで見ておきたい場合
-		assert.Contains(t, err.Error(), "priority")
+			mws := []PreMiddleware{
+				{
+					Name:       "pre1",
+					Priority:   1,
+					Middleware: func(next echo.HandlerFunc) echo.HandlerFunc { return next },
+				},
+				{
+					Name:       "pre2",
+					Priority:   1, // ★ 敢えて同じ Priority
+					Middleware: func(next echo.HandlerFunc) echo.HandlerFunc { return next },
+				},
+			}
+
+			err := ApplyPreMiddlewares(e, logging.NewTestLogger(t), mws)
+			require.Error(t, err)
+			// エラーメッセージの一部まで見ておきたい場合
+			assert.Contains(t, err.Error(), "priority")
+		})
 	})
 }
 

--- a/internal/infrastructure/rdb/pgerror/pgerror_test.go
+++ b/internal/infrastructure/rdb/pgerror/pgerror_test.go
@@ -158,7 +158,7 @@ func TestNormalizePgError(t *testing.T) {
 
 func TestIsUnavailable(t *testing.T) {
 	t.Parallel()
-	t.Run("nil", func(t *testing.T) {
+	t.Run("nilの場合は接続不可ではない", func(t *testing.T) {
 		t.Parallel()
 		got := IsUnavailable(nil)
 		assert.False(t, got)

--- a/internal/infrastructure/rdb/repository/user/user_repository_detail_test.go
+++ b/internal/infrastructure/rdb/repository/user/user_repository_detail_test.go
@@ -28,21 +28,27 @@ func Test_repository_FindByID(t *testing.T) {
 	seededID, err := uuid.Parse("eaabee3e-3b7a-4f61-8fa9-030944625e92")
 	require.NoError(t, err)
 
-	t.Run("正常系_存在するIDでユーザーが取得できる", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
-		txm.WithinTx(func(ctx context.Context) {
-			got, err := repo.FindByID(ctx, seededID)
-			require.NoError(t, err)
-			assert.Equal(t, seededID, got.ID())
+		t.Run("存在するIDでユーザーが取得できる", func(t *testing.T) {
+			t.Parallel()
+			txm.WithinTx(func(ctx context.Context) {
+				got, err := repo.FindByID(ctx, seededID)
+				require.NoError(t, err)
+				assert.Equal(t, seededID, got.ID())
+			})
 		})
 	})
 
-	t.Run("異常系_存在しないIDの場合_NotFoundが返る", func(t *testing.T) {
+	t.Run("異常系", func(t *testing.T) {
 		t.Parallel()
-		txm.WithinTx(func(ctx context.Context) {
-			missing := uuid.NewTestFromSalt(t, "missing-user")
-			_, err := repo.FindByID(ctx, missing)
-			require.ErrorIs(t, err, apperror.ErrNotFound)
+		t.Run("存在しないIDの場合_NotFoundが返る", func(t *testing.T) {
+			t.Parallel()
+			txm.WithinTx(func(ctx context.Context) {
+				missing := uuid.NewTestFromSalt(t, "missing-user")
+				_, err := repo.FindByID(ctx, missing)
+				require.ErrorIs(t, err, apperror.ErrNotFound)
+			})
 		})
 	})
 }
@@ -62,69 +68,73 @@ func Test_repository_Update(t *testing.T) {
 	lastID, err := uuid.Parse("550e8400-e29b-41d4-a716-446655440000")
 	require.NoError(t, err)
 
-	// 同一行（firstID）を更新するため、ロック競合回避にサブテストは直列実行する。
-	t.Run("正常系_プロフィール更新が永続化される", func(t *testing.T) {
-		txm.WithinTx(func(ctx context.Context) {
-			u, err := repo.FindByID(ctx, firstID)
-			require.NoError(t, err)
+	// 同一行（firstID）を更新するため、ロック競合回避にサブテストは直列実行する（t.Parallel を付けない）。
+	t.Run("正常系", func(t *testing.T) {
+		t.Run("プロフィール更新が永続化される", func(t *testing.T) {
+			txm.WithinTx(func(ctx context.Context) {
+				u, err := repo.FindByID(ctx, firstID)
+				require.NoError(t, err)
 
-			err = u.UpdateProfile("UpdatedFirst", u.LastName(), u.Email(), u.Phone(),
-				u.PrefectureID(), u.City(), u.Street(), u.Building(), u.PostalCode(), time.Now())
-			require.NoError(t, err)
-			require.NoError(t, repo.Update(ctx, u))
+				err = u.UpdateProfile("UpdatedFirst", u.LastName(), u.Email(), u.Phone(),
+					u.PrefectureID(), u.City(), u.Street(), u.Building(), u.PostalCode(), time.Now())
+				require.NoError(t, err)
+				require.NoError(t, repo.Update(ctx, u))
 
-			got, err := repo.FindByID(ctx, firstID)
-			require.NoError(t, err)
-			assert.Equal(t, "UpdatedFirst", got.FirstName())
+				got, err := repo.FindByID(ctx, firstID)
+				require.NoError(t, err)
+				assert.Equal(t, "UpdatedFirst", got.FirstName())
+			})
+		})
+
+		t.Run("論理削除すると以降FindByIDの対象外になる", func(t *testing.T) {
+			txm.WithinTx(func(ctx context.Context) {
+				u, err := repo.FindByID(ctx, firstID)
+				require.NoError(t, err)
+				require.NoError(t, u.MarkAsDeleted(time.Now()))
+				require.NoError(t, repo.Update(ctx, u))
+
+				// FindByID / Update は deleted_at IS NULL でフィルタするため、削除後は NotFound
+				_, err = repo.FindByID(ctx, firstID)
+				require.ErrorIs(t, err, apperror.ErrNotFound)
+			})
 		})
 	})
 
-	t.Run("正常系_論理削除すると以降FindByIDの対象外になる", func(t *testing.T) {
-		txm.WithinTx(func(ctx context.Context) {
-			u, err := repo.FindByID(ctx, firstID)
-			require.NoError(t, err)
-			require.NoError(t, u.MarkAsDeleted(time.Now()))
-			require.NoError(t, repo.Update(ctx, u))
+	t.Run("異常系", func(t *testing.T) {
+		t.Run("メールアドレス重複でErrConflictが返る", func(t *testing.T) {
+			txm.WithinTx(func(ctx context.Context) {
+				target, err := repo.FindByID(ctx, firstID)
+				require.NoError(t, err)
+				other, err := repo.FindByID(ctx, lastID)
+				require.NoError(t, err)
 
-			// FindByID / Update は deleted_at IS NULL でフィルタするため、削除後は NotFound
-			_, err = repo.FindByID(ctx, firstID)
-			require.ErrorIs(t, err, apperror.ErrNotFound)
+				// 別ユーザーのメールアドレスへ更新 → unique 制約違反
+				err = target.UpdateProfile(target.FirstName(), target.LastName(), other.Email(), target.Phone(),
+					target.PrefectureID(), target.City(), target.Street(), target.Building(), target.PostalCode(), time.Now())
+				require.NoError(t, err)
+
+				err = repo.Update(ctx, target)
+				require.ErrorIs(t, err, apperror.ErrConflict)
+			})
 		})
-	})
 
-	t.Run("異常系_メールアドレス重複でErrConflictが返る", func(t *testing.T) {
-		txm.WithinTx(func(ctx context.Context) {
-			target, err := repo.FindByID(ctx, firstID)
-			require.NoError(t, err)
-			other, err := repo.FindByID(ctx, lastID)
-			require.NoError(t, err)
+		t.Run("存在しないIDのUpdateはErrNotFoundを返す", func(t *testing.T) {
+			txm.WithinTx(func(ctx context.Context) {
+				prefID, err := uuid.Parse("a03aaec4-3bd6-4bfb-8e47-2fbfa026d344") // シード済み都道府県
+				require.NoError(t, err)
+				now := time.Now()
 
-			// 別ユーザーのメールアドレスへ更新 → unique 制約違反
-			err = target.UpdateProfile(target.FirstName(), target.LastName(), other.Email(), target.Phone(),
-				target.PrefectureID(), target.City(), target.Street(), target.Building(), target.PostalCode(), time.Now())
-			require.NoError(t, err)
+				// DB に存在しない ID のエンティティ
+				u, err := user.New(
+					uuid.NewTestFromSalt(t, "missing-update"),
+					"X", "Y", "hashed_password", "missing-update@example.com", "09000000000",
+					prefID, "City", "Street", nil, "100-0001", now, now, nil,
+				)
+				require.NoError(t, err)
 
-			err = repo.Update(ctx, target)
-			require.ErrorIs(t, err, apperror.ErrConflict)
-		})
-	})
-
-	t.Run("異常系_存在しないIDのUpdateはErrNotFoundを返す", func(t *testing.T) {
-		txm.WithinTx(func(ctx context.Context) {
-			prefID, err := uuid.Parse("a03aaec4-3bd6-4bfb-8e47-2fbfa026d344") // シード済み都道府県
-			require.NoError(t, err)
-			now := time.Now()
-
-			// DB に存在しない ID のエンティティ
-			u, err := user.New(
-				uuid.NewTestFromSalt(t, "missing-update"),
-				"X", "Y", "hashed_password", "missing-update@example.com", "09000000000",
-				prefID, "City", "Street", nil, "100-0001", now, now, nil,
-			)
-			require.NoError(t, err)
-
-			err = repo.Update(ctx, u)
-			require.ErrorIs(t, err, apperror.ErrNotFound)
+				err = repo.Update(ctx, u)
+				require.ErrorIs(t, err, apperror.ErrNotFound)
+			})
 		})
 	})
 }

--- a/internal/infrastructure/rdb/sqlc/like_test.go
+++ b/internal/infrastructure/rdb/sqlc/like_test.go
@@ -9,19 +9,19 @@ import (
 func TestWrapLikePatterns(t *testing.T) {
 	t.Parallel()
 
-	t.Run("WrapPrefixLikePattern", func(t *testing.T) {
+	t.Run("前方一致のLIKEパターンに変換する", func(t *testing.T) {
 		t.Parallel()
 		got := WrapPrefixLikePattern("hoge")
 		assert.Equal(t, "hoge%", got)
 	})
 
-	t.Run("WrapSuffixLikePattern", func(t *testing.T) {
+	t.Run("後方一致のLIKEパターンに変換する", func(t *testing.T) {
 		t.Parallel()
 		got := WrapSuffixLikePattern("hoge")
 		assert.Equal(t, "%hoge", got)
 	})
 
-	t.Run("WrapContainsLikePattern", func(t *testing.T) {
+	t.Run("部分一致のLIKEパターンに変換する", func(t *testing.T) {
 		t.Parallel()
 		got := WrapContainsLikePattern("hoge")
 		assert.Equal(t, "%hoge%", got)

--- a/internal/usecase/tools/paging/paging_test.go
+++ b/internal/usecase/tools/paging/paging_test.go
@@ -16,6 +16,7 @@ func TestNewPageFrom1Based(t *testing.T) {
 		t.Parallel()
 
 		t.Run("ページ番号と件数がnilの場合、デフォルト値が使用される", func(t *testing.T) {
+			t.Parallel()
 			actual, err := NewPagingFrom1Based(nil, nil)
 			expected := &Paging{
 				limit:  defaultPerPage,
@@ -27,6 +28,7 @@ func TestNewPageFrom1Based(t *testing.T) {
 		})
 
 		t.Run("ページ番号が1未満の場合、1として扱われる", func(t *testing.T) {
+			t.Parallel()
 			page := -1
 			actual, err := NewPagingFrom1Based(&page, nil)
 			expected := &Paging{
@@ -39,6 +41,7 @@ func TestNewPageFrom1Based(t *testing.T) {
 		})
 
 		t.Run("件数が0以下の場合、デフォルト値が使用される", func(t *testing.T) {
+			t.Parallel()
 			perPage := 0
 			actual, err := NewPagingFrom1Based(nil, &perPage)
 			expected := &Paging{
@@ -51,6 +54,7 @@ func TestNewPageFrom1Based(t *testing.T) {
 		})
 
 		t.Run("件数が最大値を超える場合、最大値が使用される", func(t *testing.T) {
+			t.Parallel()
 			perPage := maxPerPage + 1
 			actual, err := NewPagingFrom1Based(nil, &perPage)
 			expected := &Paging{
@@ -63,6 +67,7 @@ func TestNewPageFrom1Based(t *testing.T) {
 		})
 
 		t.Run("ページ番号が3ページで1ページあたりの件数が50の場合、オフセットは100になる", func(t *testing.T) {
+			t.Parallel()
 			page := 3
 			perPage := 50
 			expectedPageCount := 100
@@ -77,6 +82,7 @@ func TestNewPageFrom1Based(t *testing.T) {
 		})
 
 		t.Run("ページ番号が最大値の場合、正しいオフセットが計算される", func(t *testing.T) {
+			t.Parallel()
 			page := maxPage
 			perPage := 10
 			expectedOffset := (maxPage - 1) * perPage
@@ -91,6 +97,7 @@ func TestNewPageFrom1Based(t *testing.T) {
 		})
 
 		t.Run("件数が最大値の場合、正しいリミットが設定される", func(t *testing.T) {
+			t.Parallel()
 			page := 1
 			perPage := maxPerPage
 			actual, err := NewPagingFrom1Based(&page, &perPage)
@@ -104,6 +111,7 @@ func TestNewPageFrom1Based(t *testing.T) {
 		})
 
 		t.Run("ページ番号が負の値で、件数が負の値の場合、デフォルト値が使用される", func(t *testing.T) {
+			t.Parallel()
 			page := -5
 			perPage := -10
 			actual, err := NewPagingFrom1Based(&page, &perPage)
@@ -121,6 +129,7 @@ func TestNewPageFrom1Based(t *testing.T) {
 		t.Parallel()
 
 		t.Run("ページ番号が最大値を超える場合、エラーが返される", func(t *testing.T) {
+			t.Parallel()
 			page := maxPage + 1
 			actual, err := NewPagingFrom1Based(&page, nil)
 
@@ -134,6 +143,7 @@ func TestPage_Getters(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Limitが正しい値を返す", func(t *testing.T) {
+		t.Parallel()
 		page := &Paging{
 			limit:  100,
 			offset: 200,
@@ -146,6 +156,7 @@ func TestPage_Getters(t *testing.T) {
 	})
 
 	t.Run("Offsetが正しい値を返す", func(t *testing.T) {
+		t.Parallel()
 		page := &Paging{
 			limit:  100,
 			offset: 200,
@@ -158,6 +169,7 @@ func TestPage_Getters(t *testing.T) {
 	})
 
 	t.Run("Limit32が正しい値を返す", func(t *testing.T) {
+		t.Parallel()
 		page := &Paging{
 			limit:  100,
 			offset: 200,
@@ -170,6 +182,7 @@ func TestPage_Getters(t *testing.T) {
 	})
 
 	t.Run("Limit32がmaxPerPageを超える場合はクランプされる", func(t *testing.T) {
+		t.Parallel()
 		page := &Paging{
 			limit:  maxPerPage + 100,
 			offset: 0,
@@ -182,6 +195,7 @@ func TestPage_Getters(t *testing.T) {
 	})
 
 	t.Run("Offset32が正しい値を返す", func(t *testing.T) {
+		t.Parallel()
 		page := &Paging{
 			limit:  100,
 			offset: 200,
@@ -194,6 +208,7 @@ func TestPage_Getters(t *testing.T) {
 	})
 
 	t.Run("Offset32が最大値を超える場合はクランプされる", func(t *testing.T) {
+		t.Parallel()
 		page := &Paging{
 			limit:  0,
 			offset: maxPage*maxPerPage + 1000,

--- a/internal/usecase/user/user_detail_usecase_test.go
+++ b/internal/usecase/user/user_detail_usecase_test.go
@@ -53,65 +53,73 @@ func Test_usecase_GetUser(t *testing.T) {
 	pft, err := prefecture.New(prefID, "Tokyo", 13)
 	require.NoError(t, err)
 
-	t.Run("正常系_ユーザーと都道府県名が取得できる", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
-		ctrl := gomock.NewController(t)
-		u := newActiveUser(t, id, prefID, now)
 
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		pftRepo := mock_prefecture.NewMockRepository(ctrl)
-		pftRepo.EXPECT().FindByID(gomock.Any(), prefID).Return(pft, nil)
+		t.Run("ユーザーと都道府県名が取得できる", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			u := newActiveUser(t, id, prefID, now)
 
-		uc := &usecase{tracer: lt, userRepo: userRepo, pftRepo: pftRepo}
-		got, err := uc.GetUser(ctx, id)
-		require.NoError(t, err)
-		assert.Equal(t, "Tokyo", got.PrefectureName)
-		assert.Equal(t, "john@example.com", got.Email)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			pftRepo := mock_prefecture.NewMockRepository(ctrl)
+			pftRepo.EXPECT().FindByID(gomock.Any(), prefID).Return(pft, nil)
+
+			uc := &usecase{tracer: lt, userRepo: userRepo, pftRepo: pftRepo}
+			got, err := uc.GetUser(ctx, id)
+			require.NoError(t, err)
+			assert.Equal(t, "Tokyo", got.PrefectureName)
+			assert.Equal(t, "john@example.com", got.Email)
+		})
 	})
 
-	t.Run("異常系_ユーザー取得でエラー", func(t *testing.T) {
+	t.Run("異常系", func(t *testing.T) {
 		t.Parallel()
-		ctrl := gomock.NewController(t)
-		expectedErr := xerrors.New("not found")
 
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(nil, expectedErr)
+		t.Run("ユーザー取得でエラー", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			expectedErr := xerrors.New("not found")
 
-		uc := &usecase{tracer: lt, userRepo: userRepo}
-		_, err := uc.GetUser(ctx, id)
-		require.ErrorIs(t, err, expectedErr)
-	})
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(nil, expectedErr)
 
-	t.Run("異常系_都道府県取得でエラー", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		expectedErr := xerrors.New("prefecture not found")
-		u := newActiveUser(t, id, prefID, now)
+			uc := &usecase{tracer: lt, userRepo: userRepo}
+			_, err := uc.GetUser(ctx, id)
+			require.ErrorIs(t, err, expectedErr)
+		})
 
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		pftRepo := mock_prefecture.NewMockRepository(ctrl)
-		pftRepo.EXPECT().FindByID(gomock.Any(), prefID).Return(nil, expectedErr)
+		t.Run("都道府県取得でエラー", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			expectedErr := xerrors.New("prefecture not found")
+			u := newActiveUser(t, id, prefID, now)
 
-		uc := &usecase{tracer: lt, userRepo: userRepo, pftRepo: pftRepo}
-		_, err := uc.GetUser(ctx, id)
-		require.ErrorIs(t, err, expectedErr)
-	})
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			pftRepo := mock_prefecture.NewMockRepository(ctrl)
+			pftRepo.EXPECT().FindByID(gomock.Any(), prefID).Return(nil, expectedErr)
 
-	t.Run("異常系_ユーザーの都道府県が NotFound の場合は参照整合性破れとして ErrInternal", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		u := newActiveUser(t, id, prefID, now)
+			uc := &usecase{tracer: lt, userRepo: userRepo, pftRepo: pftRepo}
+			_, err := uc.GetUser(ctx, id)
+			require.ErrorIs(t, err, expectedErr)
+		})
 
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		pftRepo := mock_prefecture.NewMockRepository(ctrl)
-		pftRepo.EXPECT().FindByID(gomock.Any(), prefID).Return(nil, apperror.ErrNotFound)
+		t.Run("ユーザーの都道府県が NotFound の場合は参照整合性破れとして ErrInternal", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			u := newActiveUser(t, id, prefID, now)
 
-		uc := &usecase{tracer: lt, userRepo: userRepo, pftRepo: pftRepo}
-		_, err := uc.GetUser(ctx, id)
-		require.ErrorIs(t, err, apperror.ErrInternal)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			pftRepo := mock_prefecture.NewMockRepository(ctrl)
+			pftRepo.EXPECT().FindByID(gomock.Any(), prefID).Return(nil, apperror.ErrNotFound)
+
+			uc := &usecase{tracer: lt, userRepo: userRepo, pftRepo: pftRepo}
+			_, err := uc.GetUser(ctx, id)
+			require.ErrorIs(t, err, apperror.ErrInternal)
+		})
 	})
 }
 
@@ -129,92 +137,100 @@ func Test_usecase_UpdateUser(t *testing.T) {
 	pft, err := prefecture.New(prefID, prefName, 13)
 	require.NoError(t, err)
 
-	t.Run("正常系_全更新が成功する", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
-		ctrl := gomock.NewController(t)
-		u := newActiveUser(t, id, prefID, now)
 
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		userRepo.EXPECT().Update(gomock.Any(), gomock.AssignableToTypeOf(u)).Return(nil)
-		pftRepo := mock_prefecture.NewMockRepository(ctrl)
-		pftRepo.EXPECT().FindByName(gomock.Any(), prefName).Return(pft, nil)
+		t.Run("全更新が成功する", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			u := newActiveUser(t, id, prefID, now)
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
-		got, err := uc.UpdateUser(ctx, id, newUpdateDTO(prefName))
-		require.NoError(t, err)
-		assert.Equal(t, "Jane", got.FirstName)
-		assert.Equal(t, prefName, got.PrefectureName)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			userRepo.EXPECT().Update(gomock.Any(), gomock.AssignableToTypeOf(u)).Return(nil)
+			pftRepo := mock_prefecture.NewMockRepository(ctrl)
+			pftRepo.EXPECT().FindByName(gomock.Any(), prefName).Return(pft, nil)
+
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
+			got, err := uc.UpdateUser(ctx, id, newUpdateDTO(prefName))
+			require.NoError(t, err)
+			assert.Equal(t, "Jane", got.FirstName)
+			assert.Equal(t, prefName, got.PrefectureName)
+		})
 	})
 
-	t.Run("異常系_対象ユーザーが存在しない", func(t *testing.T) {
+	t.Run("異常系", func(t *testing.T) {
 		t.Parallel()
-		ctrl := gomock.NewController(t)
-		expectedErr := xerrors.New("not found")
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(nil, expectedErr)
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo}
-		_, err := uc.UpdateUser(ctx, id, newUpdateDTO(prefName))
-		require.ErrorIs(t, err, expectedErr)
-	})
+		t.Run("対象ユーザーが存在しない", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			expectedErr := xerrors.New("not found")
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(nil, expectedErr)
 
-	t.Run("異常系_都道府県解決でエラー", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		expectedErr := xerrors.New("prefecture not found")
-		u := newActiveUser(t, id, prefID, now)
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		pftRepo := mock_prefecture.NewMockRepository(ctrl)
-		pftRepo.EXPECT().FindByName(gomock.Any(), prefName).Return(nil, expectedErr)
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo}
+			_, err := uc.UpdateUser(ctx, id, newUpdateDTO(prefName))
+			require.ErrorIs(t, err, expectedErr)
+		})
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
-		_, err := uc.UpdateUser(ctx, id, newUpdateDTO(prefName))
-		require.ErrorIs(t, err, expectedErr)
-	})
+		t.Run("都道府県解決でエラー", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			expectedErr := xerrors.New("prefecture not found")
+			u := newActiveUser(t, id, prefID, now)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			pftRepo := mock_prefecture.NewMockRepository(ctrl)
+			pftRepo.EXPECT().FindByName(gomock.Any(), prefName).Return(nil, expectedErr)
 
-	t.Run("異常系_プロフィール検証エラー", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		u := newActiveUser(t, id, prefID, now)
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		pftRepo := mock_prefecture.NewMockRepository(ctrl)
-		pftRepo.EXPECT().FindByName(gomock.Any(), prefName).Return(pft, nil)
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
+			_, err := uc.UpdateUser(ctx, id, newUpdateDTO(prefName))
+			require.ErrorIs(t, err, expectedErr)
+		})
 
-		dto := newUpdateDTO(prefName)
-		dto.FirstName = "" // UpdateProfile の検証で失敗させる
+		t.Run("プロフィール検証エラー", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			u := newActiveUser(t, id, prefID, now)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			pftRepo := mock_prefecture.NewMockRepository(ctrl)
+			pftRepo.EXPECT().FindByName(gomock.Any(), prefName).Return(pft, nil)
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
-		_, err := uc.UpdateUser(ctx, id, dto)
-		require.ErrorIs(t, err, user.ErrInvalidFirstName)
-	})
+			dto := newUpdateDTO(prefName)
+			dto.FirstName = "" // UpdateProfile の検証で失敗させる
 
-	t.Run("異常系_永続化エラー", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		expectedErr := xerrors.New("update failed")
-		u := newActiveUser(t, id, prefID, now)
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		userRepo.EXPECT().Update(gomock.Any(), gomock.Any()).Return(expectedErr)
-		pftRepo := mock_prefecture.NewMockRepository(ctrl)
-		pftRepo.EXPECT().FindByName(gomock.Any(), prefName).Return(pft, nil)
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
+			_, err := uc.UpdateUser(ctx, id, dto)
+			require.ErrorIs(t, err, user.ErrInvalidFirstName)
+		})
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
-		_, err := uc.UpdateUser(ctx, id, newUpdateDTO(prefName))
-		require.ErrorIs(t, err, expectedErr)
+		t.Run("永続化エラー", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			expectedErr := xerrors.New("update failed")
+			u := newActiveUser(t, id, prefID, now)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			userRepo.EXPECT().Update(gomock.Any(), gomock.Any()).Return(expectedErr)
+			pftRepo := mock_prefecture.NewMockRepository(ctrl)
+			pftRepo.EXPECT().FindByName(gomock.Any(), prefName).Return(pft, nil)
+
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
+			_, err := uc.UpdateUser(ctx, id, newUpdateDTO(prefName))
+			require.ErrorIs(t, err, expectedErr)
+		})
 	})
 }
 
@@ -234,145 +250,153 @@ func Test_usecase_ChangePassword(t *testing.T) {
 		storedHash      = "hashed_password"    // newActiveUser が設定する passwordHash
 	)
 
-	t.Run("正常系_パスワード変更が成功する", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
-		ctrl := gomock.NewController(t)
-		u := newActiveUser(t, id, prefID, now)
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		encrypter := mock_security.NewMockHasher(ctrl)
-		encrypter.EXPECT().Compare(storedHash, currentPassword).Return(true, nil)
-		encrypter.EXPECT().Hash(newPassword).Return("new_hashed", nil)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		userRepo.EXPECT().Update(gomock.Any(), gomock.AssignableToTypeOf(u)).Return(nil)
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, encrypter: encrypter, userRepo: userRepo}
-		err := uc.ChangePassword(ctx, id, currentPassword, newPassword)
-		require.NoError(t, err)
+		t.Run("パスワード変更が成功する", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			u := newActiveUser(t, id, prefID, now)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			encrypter := mock_security.NewMockHasher(ctrl)
+			encrypter.EXPECT().Compare(storedHash, currentPassword).Return(true, nil)
+			encrypter.EXPECT().Hash(newPassword).Return("new_hashed", nil)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			userRepo.EXPECT().Update(gomock.Any(), gomock.AssignableToTypeOf(u)).Return(nil)
+
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, encrypter: encrypter, userRepo: userRepo}
+			err := uc.ChangePassword(ctx, id, currentPassword, newPassword)
+			require.NoError(t, err)
+		})
 	})
 
-	t.Run("異常系_現パスワードの検証エラー", func(t *testing.T) {
+	t.Run("異常系", func(t *testing.T) {
 		t.Parallel()
-		ctrl := gomock.NewController(t)
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
 
-		uc := &usecase{tracer: lt, clock: clock}
-		err := uc.ChangePassword(ctx, id, "short", newPassword)
-		require.ErrorIs(t, err, user.ErrInvalidRawPassword)
-	})
+		t.Run("現パスワードの検証エラー", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
 
-	t.Run("異常系_新パスワードの検証エラー", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
+			uc := &usecase{tracer: lt, clock: clock}
+			err := uc.ChangePassword(ctx, id, "short", newPassword)
+			require.ErrorIs(t, err, user.ErrInvalidRawPassword)
+		})
 
-		uc := &usecase{tracer: lt, clock: clock}
-		err := uc.ChangePassword(ctx, id, currentPassword, "short")
-		require.ErrorIs(t, err, user.ErrInvalidRawPassword)
-	})
+		t.Run("新パスワードの検証エラー", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
 
-	t.Run("異常系_対象ユーザーが存在しない", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		expectedErr := xerrors.New("not found")
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(nil, expectedErr)
+			uc := &usecase{tracer: lt, clock: clock}
+			err := uc.ChangePassword(ctx, id, currentPassword, "short")
+			require.ErrorIs(t, err, user.ErrInvalidRawPassword)
+		})
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo}
-		err := uc.ChangePassword(ctx, id, currentPassword, newPassword)
-		require.ErrorIs(t, err, expectedErr)
-	})
+		t.Run("対象ユーザーが存在しない", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			expectedErr := xerrors.New("not found")
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(nil, expectedErr)
 
-	t.Run("異常系_現パスワードが一致しない", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		u := newActiveUser(t, id, prefID, now)
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		encrypter := mock_security.NewMockHasher(ctrl)
-		encrypter.EXPECT().Compare(storedHash, currentPassword).Return(false, nil)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo}
+			err := uc.ChangePassword(ctx, id, currentPassword, newPassword)
+			require.ErrorIs(t, err, expectedErr)
+		})
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, encrypter: encrypter, userRepo: userRepo}
-		err := uc.ChangePassword(ctx, id, currentPassword, newPassword)
-		require.ErrorIs(t, err, user.ErrCurrentPasswordMismatch)
-	})
+		t.Run("現パスワードが一致しない", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			u := newActiveUser(t, id, prefID, now)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			encrypter := mock_security.NewMockHasher(ctrl)
+			encrypter.EXPECT().Compare(storedHash, currentPassword).Return(false, nil)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
 
-	t.Run("異常系_パスワード照合でエラー", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		expectedErr := xerrors.New("compare failed")
-		u := newActiveUser(t, id, prefID, now)
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		encrypter := mock_security.NewMockHasher(ctrl)
-		encrypter.EXPECT().Compare(storedHash, currentPassword).Return(false, expectedErr)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, encrypter: encrypter, userRepo: userRepo}
+			err := uc.ChangePassword(ctx, id, currentPassword, newPassword)
+			require.ErrorIs(t, err, user.ErrCurrentPasswordMismatch)
+		})
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, encrypter: encrypter, userRepo: userRepo}
-		err := uc.ChangePassword(ctx, id, currentPassword, newPassword)
-		require.ErrorIs(t, err, expectedErr)
-	})
+		t.Run("パスワード照合でエラー", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			expectedErr := xerrors.New("compare failed")
+			u := newActiveUser(t, id, prefID, now)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			encrypter := mock_security.NewMockHasher(ctrl)
+			encrypter.EXPECT().Compare(storedHash, currentPassword).Return(false, expectedErr)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
 
-	t.Run("異常系_新パスワードのハッシュ化エラー", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		expectedErr := xerrors.New("hash failed")
-		u := newActiveUser(t, id, prefID, now)
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		encrypter := mock_security.NewMockHasher(ctrl)
-		encrypter.EXPECT().Compare(storedHash, currentPassword).Return(true, nil)
-		encrypter.EXPECT().Hash(newPassword).Return("", expectedErr)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, encrypter: encrypter, userRepo: userRepo}
+			err := uc.ChangePassword(ctx, id, currentPassword, newPassword)
+			require.ErrorIs(t, err, expectedErr)
+		})
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, encrypter: encrypter, userRepo: userRepo}
-		err := uc.ChangePassword(ctx, id, currentPassword, newPassword)
-		require.ErrorIs(t, err, expectedErr)
-	})
+		t.Run("新パスワードのハッシュ化エラー", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			expectedErr := xerrors.New("hash failed")
+			u := newActiveUser(t, id, prefID, now)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			encrypter := mock_security.NewMockHasher(ctrl)
+			encrypter.EXPECT().Compare(storedHash, currentPassword).Return(true, nil)
+			encrypter.EXPECT().Hash(newPassword).Return("", expectedErr)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
 
-	t.Run("異常系_ドメインのパスワード変更で検証エラー", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		u := newActiveUser(t, id, prefID, now)
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		encrypter := mock_security.NewMockHasher(ctrl)
-		encrypter.EXPECT().Compare(storedHash, currentPassword).Return(true, nil)
-		encrypter.EXPECT().Hash(newPassword).Return("", nil) // 空ハッシュ → ドメイン ChangePassword で失敗
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, encrypter: encrypter, userRepo: userRepo}
+			err := uc.ChangePassword(ctx, id, currentPassword, newPassword)
+			require.ErrorIs(t, err, expectedErr)
+		})
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, encrypter: encrypter, userRepo: userRepo}
-		err := uc.ChangePassword(ctx, id, currentPassword, newPassword)
-		require.ErrorIs(t, err, user.ErrInvalidPasswordHash)
-	})
+		t.Run("ドメインのパスワード変更で検証エラー", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			u := newActiveUser(t, id, prefID, now)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			encrypter := mock_security.NewMockHasher(ctrl)
+			encrypter.EXPECT().Compare(storedHash, currentPassword).Return(true, nil)
+			encrypter.EXPECT().Hash(newPassword).Return("", nil) // 空ハッシュ → ドメイン ChangePassword で失敗
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
 
-	t.Run("異常系_永続化エラー", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		expectedErr := xerrors.New("update failed")
-		u := newActiveUser(t, id, prefID, now)
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		encrypter := mock_security.NewMockHasher(ctrl)
-		encrypter.EXPECT().Compare(storedHash, currentPassword).Return(true, nil)
-		encrypter.EXPECT().Hash(newPassword).Return("new_hashed", nil)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		userRepo.EXPECT().Update(gomock.Any(), gomock.Any()).Return(expectedErr)
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, encrypter: encrypter, userRepo: userRepo}
+			err := uc.ChangePassword(ctx, id, currentPassword, newPassword)
+			require.ErrorIs(t, err, user.ErrInvalidPasswordHash)
+		})
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, encrypter: encrypter, userRepo: userRepo}
-		err := uc.ChangePassword(ctx, id, currentPassword, newPassword)
-		require.ErrorIs(t, err, expectedErr)
+		t.Run("永続化エラー", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			expectedErr := xerrors.New("update failed")
+			u := newActiveUser(t, id, prefID, now)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			encrypter := mock_security.NewMockHasher(ctrl)
+			encrypter.EXPECT().Compare(storedHash, currentPassword).Return(true, nil)
+			encrypter.EXPECT().Hash(newPassword).Return("new_hashed", nil)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			userRepo.EXPECT().Update(gomock.Any(), gomock.Any()).Return(expectedErr)
+
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, encrypter: encrypter, userRepo: userRepo}
+			err := uc.ChangePassword(ctx, id, currentPassword, newPassword)
+			require.ErrorIs(t, err, expectedErr)
+		})
 	})
 }
 
@@ -389,129 +413,137 @@ func Test_usecase_UpdateUserPartially(t *testing.T) {
 	pft, err := prefecture.New(prefID, "Osaka", 27)
 	require.NoError(t, err)
 
-	t.Run("正常系_都道府県指定ありの部分更新", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
-		ctrl := gomock.NewController(t)
-		u := newActiveUser(t, id, prefID, now)
 
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		userRepo.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
-		pftRepo := mock_prefecture.NewMockRepository(ctrl)
-		pftRepo.EXPECT().FindByName(gomock.Any(), "Osaka").Return(pft, nil)
+		t.Run("都道府県指定ありの部分更新", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			u := newActiveUser(t, id, prefID, now)
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
-		dto := &PatchParamsDTO{FirstName: ptr.To("Patched"), PrefectureName: ptr.To("Osaka"), Building: ptr.To("NewTower")}
-		got, err := uc.UpdateUserPartially(ctx, id, dto)
-		require.NoError(t, err)
-		assert.Equal(t, "Patched", got.FirstName)
-		assert.Equal(t, "Osaka", got.PrefectureName)
-		assert.Equal(t, "NewTower", *got.Building)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			userRepo.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+			pftRepo := mock_prefecture.NewMockRepository(ctrl)
+			pftRepo.EXPECT().FindByName(gomock.Any(), "Osaka").Return(pft, nil)
+
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
+			dto := &PatchParamsDTO{FirstName: ptr.To("Patched"), PrefectureName: ptr.To("Osaka"), Building: ptr.To("NewTower")}
+			got, err := uc.UpdateUserPartially(ctx, id, dto)
+			require.NoError(t, err)
+			assert.Equal(t, "Patched", got.FirstName)
+			assert.Equal(t, "Osaka", got.PrefectureName)
+			assert.Equal(t, "NewTower", *got.Building)
+		})
+
+		t.Run("都道府県指定なしは現在値を据え置く", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			u := newActiveUser(t, id, prefID, now)
+
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			userRepo.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+			pftRepo := mock_prefecture.NewMockRepository(ctrl)
+			pftRepo.EXPECT().FindByID(gomock.Any(), prefID).Return(pft, nil)
+
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
+			dto := &PatchParamsDTO{LastName: ptr.To("OnlyLast")}
+			got, err := uc.UpdateUserPartially(ctx, id, dto)
+			require.NoError(t, err)
+			assert.Equal(t, "OnlyLast", got.LastName)
+		})
 	})
 
-	t.Run("正常系_都道府県指定なしは現在値を据え置く", func(t *testing.T) {
+	t.Run("異常系", func(t *testing.T) {
 		t.Parallel()
-		ctrl := gomock.NewController(t)
-		u := newActiveUser(t, id, prefID, now)
 
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		userRepo.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
-		pftRepo := mock_prefecture.NewMockRepository(ctrl)
-		pftRepo.EXPECT().FindByID(gomock.Any(), prefID).Return(pft, nil)
+		t.Run("対象ユーザーが存在しない", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			expectedErr := xerrors.New("not found")
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(nil, expectedErr)
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
-		dto := &PatchParamsDTO{LastName: ptr.To("OnlyLast")}
-		got, err := uc.UpdateUserPartially(ctx, id, dto)
-		require.NoError(t, err)
-		assert.Equal(t, "OnlyLast", got.LastName)
-	})
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo}
+			_, err := uc.UpdateUserPartially(ctx, id, &PatchParamsDTO{FirstName: ptr.To("X")})
+			require.ErrorIs(t, err, expectedErr)
+		})
 
-	t.Run("異常系_対象ユーザーが存在しない", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		expectedErr := xerrors.New("not found")
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(nil, expectedErr)
+		t.Run("都道府県解決でエラー", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			expectedErr := xerrors.New("prefecture not found")
+			u := newActiveUser(t, id, prefID, now)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			pftRepo := mock_prefecture.NewMockRepository(ctrl)
+			pftRepo.EXPECT().FindByName(gomock.Any(), "Unknown").Return(nil, expectedErr)
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo}
-		_, err := uc.UpdateUserPartially(ctx, id, &PatchParamsDTO{FirstName: ptr.To("X")})
-		require.ErrorIs(t, err, expectedErr)
-	})
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
+			_, err := uc.UpdateUserPartially(ctx, id, &PatchParamsDTO{PrefectureName: ptr.To("Unknown")})
+			require.ErrorIs(t, err, expectedErr)
+		})
 
-	t.Run("異常系_都道府県解決でエラー", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		expectedErr := xerrors.New("prefecture not found")
-		u := newActiveUser(t, id, prefID, now)
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		pftRepo := mock_prefecture.NewMockRepository(ctrl)
-		pftRepo.EXPECT().FindByName(gomock.Any(), "Unknown").Return(nil, expectedErr)
+		t.Run("指定なしで現在の都道府県が NotFound の場合は ErrInternal", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			u := newActiveUser(t, id, prefID, now)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			pftRepo := mock_prefecture.NewMockRepository(ctrl)
+			pftRepo.EXPECT().FindByID(gomock.Any(), prefID).Return(nil, apperror.ErrNotFound)
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
-		_, err := uc.UpdateUserPartially(ctx, id, &PatchParamsDTO{PrefectureName: ptr.To("Unknown")})
-		require.ErrorIs(t, err, expectedErr)
-	})
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
+			_, err := uc.UpdateUserPartially(ctx, id, &PatchParamsDTO{FirstName: ptr.To("X")})
+			require.ErrorIs(t, err, apperror.ErrInternal)
+		})
 
-	t.Run("異常系_指定なしで現在の都道府県が NotFound の場合は ErrInternal", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		u := newActiveUser(t, id, prefID, now)
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		pftRepo := mock_prefecture.NewMockRepository(ctrl)
-		pftRepo.EXPECT().FindByID(gomock.Any(), prefID).Return(nil, apperror.ErrNotFound)
+		t.Run("指定なしで現在の都道府県取得が汎用エラーの場合は伝播", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			expectedErr := xerrors.New("db error")
+			u := newActiveUser(t, id, prefID, now)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			pftRepo := mock_prefecture.NewMockRepository(ctrl)
+			pftRepo.EXPECT().FindByID(gomock.Any(), prefID).Return(nil, expectedErr)
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
-		_, err := uc.UpdateUserPartially(ctx, id, &PatchParamsDTO{FirstName: ptr.To("X")})
-		require.ErrorIs(t, err, apperror.ErrInternal)
-	})
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
+			_, err := uc.UpdateUserPartially(ctx, id, &PatchParamsDTO{FirstName: ptr.To("X")})
+			require.ErrorIs(t, err, expectedErr)
+		})
 
-	t.Run("異常系_指定なしで現在の都道府県取得が汎用エラーの場合は伝播", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		expectedErr := xerrors.New("db error")
-		u := newActiveUser(t, id, prefID, now)
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		pftRepo := mock_prefecture.NewMockRepository(ctrl)
-		pftRepo.EXPECT().FindByID(gomock.Any(), prefID).Return(nil, expectedErr)
+		t.Run("プロフィール検証エラー", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			u := newActiveUser(t, id, prefID, now)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			pftRepo := mock_prefecture.NewMockRepository(ctrl)
+			pftRepo.EXPECT().FindByID(gomock.Any(), prefID).Return(pft, nil)
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
-		_, err := uc.UpdateUserPartially(ctx, id, &PatchParamsDTO{FirstName: ptr.To("X")})
-		require.ErrorIs(t, err, expectedErr)
-	})
+			// 空文字へのマージで UpdateProfile（updateProfileThenSave 内）の検証を失敗させる
+			dto := &PatchParamsDTO{FirstName: ptr.To("")}
 
-	t.Run("異常系_プロフィール検証エラー", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		u := newActiveUser(t, id, prefID, now)
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		pftRepo := mock_prefecture.NewMockRepository(ctrl)
-		pftRepo.EXPECT().FindByID(gomock.Any(), prefID).Return(pft, nil)
-
-		// 空文字へのマージで UpdateProfile（updateProfileThenSave 内）の検証を失敗させる
-		dto := &PatchParamsDTO{FirstName: ptr.To("")}
-
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
-		_, err := uc.UpdateUserPartially(ctx, id, dto)
-		require.ErrorIs(t, err, user.ErrInvalidFirstName)
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo, pftRepo: pftRepo}
+			_, err := uc.UpdateUserPartially(ctx, id, dto)
+			require.ErrorIs(t, err, user.ErrInvalidFirstName)
+		})
 	})
 }
 
@@ -525,53 +557,61 @@ func Test_usecase_DeleteUser(t *testing.T) {
 	id := uuid.NewTestFromSalt(t, "user")
 	prefID := uuid.NewTestFromSalt(t, "prefecture")
 
-	t.Run("正常系_論理削除が成功する", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
-		ctrl := gomock.NewController(t)
-		u := newActiveUser(t, id, prefID, now)
 
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
-		userRepo.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+		t.Run("論理削除が成功する", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			u := newActiveUser(t, id, prefID, now)
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo}
-		err := uc.DeleteUser(ctx, id)
-		require.NoError(t, err)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(u, nil)
+			userRepo.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo}
+			err := uc.DeleteUser(ctx, id)
+			require.NoError(t, err)
+		})
 	})
 
-	t.Run("異常系_対象ユーザーが存在しない", func(t *testing.T) {
+	t.Run("異常系", func(t *testing.T) {
 		t.Parallel()
-		ctrl := gomock.NewController(t)
-		expectedErr := xerrors.New("not found")
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now)
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(nil, expectedErr)
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo}
-		err := uc.DeleteUser(ctx, id)
-		require.ErrorIs(t, err, expectedErr)
-	})
+		t.Run("対象ユーザーが存在しない", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			expectedErr := xerrors.New("not found")
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now)
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(nil, expectedErr)
 
-	t.Run("異常系_既に削除済みの場合_ErrAlreadyDeleted", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		deletedUser, err := user.New(
-			id, "John", "Doe", "hashed_password", "john@example.com", "1234567890",
-			prefID, "Shibuya", "1-2-3", ptr.To("Building A"), "150-0001",
-			now, now, ptr.To(now),
-		)
-		require.NoError(t, err)
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo}
+			err := uc.DeleteUser(ctx, id)
+			require.ErrorIs(t, err, expectedErr)
+		})
 
-		clock := mock_clock.NewMockClock(ctrl)
-		clock.EXPECT().Now().Return(now.Add(time.Hour))
-		userRepo := mock_user.NewMockRepository(ctrl)
-		userRepo.EXPECT().FindByID(gomock.Any(), id).Return(deletedUser, nil)
+		t.Run("既に削除済みの場合_ErrAlreadyDeleted", func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			deletedUser, err := user.New(
+				id, "John", "Doe", "hashed_password", "john@example.com", "1234567890",
+				prefID, "Shibuya", "1-2-3", ptr.To("Building A"), "150-0001",
+				now, now, ptr.To(now),
+			)
+			require.NoError(t, err)
 
-		uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo}
-		err = uc.DeleteUser(ctx, id)
-		require.ErrorIs(t, err, user.ErrAlreadyDeleted)
+			clock := mock_clock.NewMockClock(ctrl)
+			clock.EXPECT().Now().Return(now.Add(time.Hour))
+			userRepo := mock_user.NewMockRepository(ctrl)
+			userRepo.EXPECT().FindByID(gomock.Any(), id).Return(deletedUser, nil)
+
+			uc := &usecase{tracer: lt, txm: txm, clock: clock, userRepo: userRepo}
+			err = uc.DeleteUser(ctx, id)
+			require.ErrorIs(t, err, user.ErrAlreadyDeleted)
+		})
 	})
 }

--- a/pkg/stringkit/generate_error_test.go
+++ b/pkg/stringkit/generate_error_test.go
@@ -25,8 +25,11 @@ func TestValidateInRange(t *testing.T) {
 }
 
 func TestErrorMsgInRange(t *testing.T) {
+	t.Parallel()
 	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが範囲外の場合、適切なエラーメッセージを返す", func(t *testing.T) {
+			t.Parallel()
 			lowerBound := 3
 			upperBound := 5
 			input := "こんにちは"
@@ -39,8 +42,11 @@ func TestErrorMsgInRange(t *testing.T) {
 }
 
 func TestErrorMsgMaxOrLess(t *testing.T) {
+	t.Parallel()
 	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが上限を超えた場合、適切なエラーメッセージを返す", func(t *testing.T) {
+			t.Parallel()
 			upperBound := 4
 			input := "こんにちは"
 			expected := "length must be less than or equal to 4 characters (got 5)"
@@ -52,8 +58,11 @@ func TestErrorMsgMaxOrLess(t *testing.T) {
 }
 
 func TestErrorMsgMinOrMore(t *testing.T) {
+	t.Parallel()
 	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが下限を下回った場合、適切なエラーメッセージを返す", func(t *testing.T) {
+			t.Parallel()
 			lowerBound := 6
 			input := "こんにちは"
 			expected := "length must be greater than or equal to 6 characters (got 5)"
@@ -65,8 +74,11 @@ func TestErrorMsgMinOrMore(t *testing.T) {
 }
 
 func TestErrorMsgStrictInRange(t *testing.T) {
+	t.Parallel()
 	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが厳密な範囲外の場合、適切なエラーメッセージを返す", func(t *testing.T) {
+			t.Parallel()
 			lowerBound := 3
 			upperBound := 5
 			input := "こんにちは"
@@ -79,8 +91,11 @@ func TestErrorMsgStrictInRange(t *testing.T) {
 }
 
 func TestErrorMsgLessThanMax(t *testing.T) {
+	t.Parallel()
 	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが上限以上の場合、適切なエラーメッセージを返す", func(t *testing.T) {
+			t.Parallel()
 			upperBound := 4
 			input := "こんにちは"
 			expected := "length must be less than 4 characters (got 5)"
@@ -92,8 +107,11 @@ func TestErrorMsgLessThanMax(t *testing.T) {
 }
 
 func TestErrorMsgGreaterThanMin(t *testing.T) {
+	t.Parallel()
 	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが下限以下の場合、適切なエラーメッセージを返す", func(t *testing.T) {
+			t.Parallel()
 			lowerBound := 6
 			input := "こんにちは"
 			expected := "length must be greater than 6 characters (got 5)"

--- a/pkg/stringkit/string_length_test.go
+++ b/pkg/stringkit/string_length_test.go
@@ -7,8 +7,11 @@ import (
 )
 
 func TestRuneCount(t *testing.T) {
+	t.Parallel()
 	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列が英字の場合、文字数を正しくカウントする", func(t *testing.T) {
+			t.Parallel()
 			input := "hello"
 			expected := 5
 
@@ -17,6 +20,7 @@ func TestRuneCount(t *testing.T) {
 		})
 
 		t.Run("文字列が日本語の場合、文字数を正しくカウントする", func(t *testing.T) {
+			t.Parallel()
 			input := "こんにちは"
 			expected := 5
 
@@ -25,6 +29,7 @@ func TestRuneCount(t *testing.T) {
 		})
 
 		t.Run("文字列が空の場合、文字数が0になる", func(t *testing.T) {
+			t.Parallel()
 			input := ""
 			expected := 0
 
@@ -33,6 +38,7 @@ func TestRuneCount(t *testing.T) {
 		})
 
 		t.Run("文字列が絵文字の場合、文字数を正しくカウントする", func(t *testing.T) {
+			t.Parallel()
 			input := "👋🌍"
 			expected := 2
 
@@ -43,8 +49,11 @@ func TestRuneCount(t *testing.T) {
 }
 
 func TestInRange(t *testing.T) {
+	t.Parallel()
 	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが範囲内の場合、trueを返す", func(t *testing.T) {
+			t.Parallel()
 			input := "hello"
 			minBound := 1
 			maxBound := 5
@@ -56,7 +65,9 @@ func TestInRange(t *testing.T) {
 	})
 
 	t.Run("異常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが範囲外の場合、falseを返す", func(t *testing.T) {
+			t.Parallel()
 			input := "こんにちは"
 			minBound := 1
 			maxBound := 4
@@ -69,8 +80,11 @@ func TestInRange(t *testing.T) {
 }
 
 func TestMaxOrLess(t *testing.T) {
+	t.Parallel()
 	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが最大値以下の場合、trueを返す", func(t *testing.T) {
+			t.Parallel()
 			input := "hello"
 			maxBound := 5
 			expected := true
@@ -81,7 +95,9 @@ func TestMaxOrLess(t *testing.T) {
 	})
 
 	t.Run("異常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが最大値を超える場合、falseを返す", func(t *testing.T) {
+			t.Parallel()
 			input := "こんにちは"
 			maxBound := 4
 			expected := false
@@ -93,8 +109,11 @@ func TestMaxOrLess(t *testing.T) {
 }
 
 func TestMinOrMore(t *testing.T) {
+	t.Parallel()
 	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが最小値以上の場合、trueを返す", func(t *testing.T) {
+			t.Parallel()
 			input := "hello"
 			minBound := 5
 			expected := true
@@ -105,7 +124,9 @@ func TestMinOrMore(t *testing.T) {
 	})
 
 	t.Run("異常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが最小値未満の場合、falseを返す", func(t *testing.T) {
+			t.Parallel()
 			input := "こんにちは"
 			minBound := 6
 			expected := false
@@ -117,8 +138,11 @@ func TestMinOrMore(t *testing.T) {
 }
 
 func TestStrictInRange(t *testing.T) {
+	t.Parallel()
 	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが範囲内の場合、trueを返す", func(t *testing.T) {
+			t.Parallel()
 			input := "hello"
 			minBound := 1
 			maxBound := 6
@@ -130,7 +154,9 @@ func TestStrictInRange(t *testing.T) {
 	})
 
 	t.Run("異常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが範囲外の場合、falseを返す", func(t *testing.T) {
+			t.Parallel()
 			input := "こんにちは"
 			minBound := 1
 			maxBound := 5
@@ -143,8 +169,11 @@ func TestStrictInRange(t *testing.T) {
 }
 
 func TestLessThanMax(t *testing.T) {
+	t.Parallel()
 	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが最大値未満の場合、trueを返す", func(t *testing.T) {
+			t.Parallel()
 			input := "hello"
 			maxBound := 6
 			expected := true
@@ -155,7 +184,9 @@ func TestLessThanMax(t *testing.T) {
 	})
 
 	t.Run("異常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが最大値以上の場合、falseを返す", func(t *testing.T) {
+			t.Parallel()
 			input := "こんにちは"
 			maxBound := 5
 			expected := false
@@ -167,8 +198,11 @@ func TestLessThanMax(t *testing.T) {
 }
 
 func TestGreaterThanMin(t *testing.T) {
+	t.Parallel()
 	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが最小値より大きい場合、trueを返す", func(t *testing.T) {
+			t.Parallel()
 			input := "hello"
 			minBound := 4
 			expected := true
@@ -179,7 +213,9 @@ func TestGreaterThanMin(t *testing.T) {
 	})
 
 	t.Run("異常系", func(t *testing.T) {
+		t.Parallel()
 		t.Run("文字列の長さが最小値以下の場合、falseを返す", func(t *testing.T) {
+			t.Parallel()
 			input := "こんにちは"
 			minBound := 6
 			expected := false

--- a/scripts/genctxkey/template_test.tpl
+++ b/scripts/genctxkey/template_test.tpl
@@ -32,53 +32,65 @@ func TestSet{{.NameCamel}}(t *testing.T) {
 func TestGet{{.NameCamel}}(t *testing.T) {
 	t.Parallel()
 
-	t.Run("正常系_標準コンテキストから取得できる", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
-		ctx = Set{{.NameCamel}}(ctx, {{.TestSuccessValue}})
+		t.Run("標準コンテキストから取得できる", func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			ctx = Set{{.NameCamel}}(ctx, {{.TestSuccessValue}})
 
-		val, ok := Get{{.NameCamel}}(ctx)
-		assert.True(t, ok)
-		assert.Equal(t, {{.TestSuccessValue}}, val)
+			val, ok := Get{{.NameCamel}}(ctx)
+			assert.True(t, ok)
+			assert.Equal(t, {{.TestSuccessValue}}, val)
+		})
 	})
 
-	t.Run("異常系_値が無い場合はfalseを返す", func(t *testing.T) {
+	t.Run("異常系", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
-		val, ok := Get{{.NameCamel}}(ctx)
-		assert.False(t, ok)
-		assert.Equal(t, {{.TestFailValue}}, val)
+		t.Run("値が無い場合はfalseを返す", func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			val, ok := Get{{.NameCamel}}(ctx)
+			assert.False(t, ok)
+			assert.Equal(t, {{.TestFailValue}}, val)
+		})
 	})
 }
 
 func TestSet{{.NameCamel}}ToEcho(t *testing.T) {
 	t.Parallel()
 
-	t.Run("正常系_echoへ設定し取得できる", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
-		e := echo.New()
-		ctx := context.Background()
-		req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
-		rec := httptest.NewRecorder()
-		c := e.NewContext(req, rec)
+		t.Run("echoへ設定し取得できる", func(t *testing.T) {
+			t.Parallel()
+			e := echo.New()
+			ctx := context.Background()
+			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
 
-		Set{{.NameCamel}}ToEcho(c, {{.TestSuccessValue}})
-		val, ok := Get{{.NameCamel}}FromEcho(c)
+			Set{{.NameCamel}}ToEcho(c, {{.TestSuccessValue}})
+			val, ok := Get{{.NameCamel}}FromEcho(c)
 
-		assert.True(t, ok)
-		assert.Equal(t, {{.TestSuccessValue}}, val)
+			assert.True(t, ok)
+			assert.Equal(t, {{.TestSuccessValue}}, val)
+		})
 	})
 
-	t.Run("異常系_echoに値が無い場合はfalseを返す", func(t *testing.T) {
+	t.Run("異常系", func(t *testing.T) {
 		t.Parallel()
-		e := echo.New()
-		ctx := context.Background()
-		req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
-		rec := httptest.NewRecorder()
-		c := e.NewContext(req, rec)
+		t.Run("echoに値が無い場合はfalseを返す", func(t *testing.T) {
+			t.Parallel()
+			e := echo.New()
+			ctx := context.Background()
+			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
 
-		val, ok := Get{{.NameCamel}}FromEcho(c)
-		assert.False(t, ok)
-		assert.Equal(t, {{.TestFailValue}}, val)
+			val, ok := Get{{.NameCamel}}FromEcho(c)
+			assert.False(t, ok)
+			assert.Equal(t, {{.TestFailValue}}, val)
+		})
 	})
 }


### PR DESCRIPTION
# 概要

test-review に基づきリポジトリ全体のテストファイルを点検し、検出した規約違反を修正しました。本番コードの挙動変更はなく、テストの構造・命名・並列化のみの変更です。

## 変更内容

- 規約準拠: `t.Run` の最外グループをフラットな `正常系_`/`異常系_` プレフィックス形から正規の `正常系`/`異常系` グループ形へ再構成（usecase / repository / cli）
- エラー検証: `assert.NoError` を `require.NoError` へ統一（testifylint require-error）
- 命名: 英語のテストケース名・構造識別子名を日本語へ翻訳（config / sqlc / pgerror / extension）。重複サブテスト（`NewObservabilityConfig`）を削除
- 並列化: 共有状態を持たない純粋関数テストに欠落していた `t.Parallel` を全階層へ補完（`-race` 確認済み）。意図的な直列テスト（env/cwd 変更・実DB・グローバル otel・共有 cfg 等）は据え置き
- 生成テスト: `genctxkey` のテンプレート `template_test.tpl` を `正常系`/`異常系` グループ形へ修正し、`ctxhelper` の2ファイルを再生成（生成物は直接編集せずテンプレート経由で修正）

## 動作確認方法

1. `make lint` （0 issues）
2. `make test` （全パッケージ PASS・変更パッケージのカバレッジ低下なし: ctxhelper 100% / config 98.2% / stringkit 100% ほか）