### PR TITLE
Docs: v1.4.0 リリースノートを追加 + md-lint をリポジトリ全体でクリーン化

### DIFF
--- a/.claude/skills/full-apply/SKILL.md
+++ b/.claude/skills/full-apply/SKILL.md
@@ -43,7 +43,7 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash, AskUserQuestion
 ## 引数（既定値あり）
 
 | 引数 | 既定 | 意味 |
-|------|------|------|
+| --- | --- | --- |
 | `--reviews-dir` | `tmp/reviews` | 指摘 md 群のあるディレクトリ（full-verify の `--out` と対応。例 `tmp/reviews-config`） |
 | `--severity` | `low` | この重大度まで処理する（`critical` だけ / `high` まで / … / `low` まで全件） |
 | `--scope` | （確認） | 対象ディレクトリの csv。未指定なら起動時に AskUserQuestion で確認 |

--- a/.claude/skills/full-verify/README.md
+++ b/.claude/skills/full-verify/README.md
@@ -74,7 +74,7 @@ tmux attach -t full-verify   # 進捗確認
 ### 引数（既定値あり）
 
 | 引数 | 既定 | 意味 |
-|------|------|------|
+| --- | --- | --- |
 | `--granularity module\|file` | `module` | `module`=サブシステム/ディレクトリ単位、`file`=リーフ（.go 等）1ファイル単位 |
 | `--module-depth N` | `1` | `module` 粒度時のモジュール列挙の深さ |
 | `--include-tests` | off | `file` 粒度時に `*_test.go` 等のテストも対象に含める（実装→テストの順） |

--- a/.claude/skills/full-verify/SKILL.md
+++ b/.claude/skills/full-verify/SKILL.md
@@ -59,7 +59,7 @@ allowed-tools: Read, Grep, Glob, Bash
 `$ARGUMENTS` をそのまま `run.sh` に渡す。各パラメータの既定値:
 
 | 引数 | 既定 | 意味 |
-|------|------|------|
+| --- | --- | --- |
 | `--granularity` | `module` | `module`（サブシステム/ディレクトリ単位）か `file`（リーフ .go 等 1ファイル単位） |
 | `--module-depth` | `1` | `module` 粒度時のモジュール列挙の深さ |
 | `--include-tests` | off | `file` 粒度時に `*_test.go` 等のテストも対象に含める（実装→テストの順で列挙） |

--- a/.github/release/v1.4.0.md
+++ b/.github/release/v1.4.0.md
@@ -1,0 +1,121 @@
+<!-- markdownlint-disable MD041 -->
+## 概要
+
+`v1.3.0` を起点としたマイナーリリースです。
+ドキュメントポータルの構造刷新と AI エージェント基盤の並列化を中心に、CI セキュリティ層 (gitleaks / hadolint / actionlint + GitHub Actions SHA 固定) の追加、godoc 静的 HTML 生成の導入、観測性の改善 (stack trace 行配列化) を含みます。User 機能をゼロから構築するチュートリアルも追加し、新規参加者の学習動線を整えました。
+
+変更規模は以下です。
+
+- `128` コミット
+- `1,005` ファイル変更
+- `+149,335 / -7,751`
+
+## 変更内容
+
+### 新機能・改善
+
+#### ドキュメントポータルの多階層構造化
+
+- `docs/portal/` のビューアーを「manifest = 構造定義 / JS = 構築」の単一契約で動くよう全面再設計。旧 48 フラットセクションを 7 グループ + 26 セクション + 4 リファレンスリンクの 2–3 階層構造に整理し、左サイドバー + ハッシュルーティング (`#/<group-slug>`) の SPA レイアウトに刷新しました (`4a772762`)。
+- `manifest.yaml` に `meta.groups` / `meta.subgroups` / `meta.section_titles` / `meta.reference_links` を導入し、Controller / Infrastructure / DI / Database は役割サブグループ (Layer Top / HTTP Stack / RDB / ...) で細分化。godoc / db-schema / coverage / openapi の生成 HTML はサイドバー下部の常設 Reference ブロックに集約しました。
+- ポータル契約を後続メンテナンス向けに明文化する `docs/maintenance/portal-manifest.md` (+ JA) を新規追加し、`meta.*` スキーマ / FS auto-discovery 規則 / 変更パターン 6 通り / ビルドコマンド / アンチパターンを網羅しました (`26999bfc`)。
+- ポータル再設計のコードレビュー指摘 (検索時の無限再レンダー / hash 履歴汚染 / 言語フィルタの subgroup 混在 / mermaid・hljs の全文書スキャン / gen-docs-json の重複検知漏れ等) を一括修正しました (`3659ffc0`)。
+
+#### チュートリアル追加と Get Started 動線整備
+
+- User 機能をゼロから構築するチュートリアル (`docs/tutorial/build-user-feature.md` + JA) を新規追加。アーキテクチャ参照ドキュメントの「実践例」として、依存方向どおりに 1 機能を threading する手順書になっています (`e5a8b2d3`)。
+- `setup-repository.md` を Maintenance から `docs/get-started/` 配下へ移動し、Get Started グループに「Overview → Setup Repository → Make Commands → Environment Variables → Tutorial」という線形の学習動線を整えました (`cf2e1ea9`、`1bce2f74`)。
+
+#### AI エージェント基盤の並列化と統合
+
+- per-layer 化で冗長化していたスキル 12 個を削除し、統合スキルに集約しました (`b3c3fbba`)。
+- `full-verify` / `arch-check` / `back-prop` / `verify-spec` を並列サブエージェント化し、リポジトリ全体検証の壁時計を圧縮しました (`4a97d88c`、`810281cf`、`fa342047`、`91a851cb`)。
+- 全リポジトリ対象の品質レビュー駆動スキル `full-verify` / `full-apply` を恒常スキルとして追加しました (`96fdda55`)。
+- ローカルレビュースキル `local-review` に PR インラインコメント投稿機能を追加し、運用 runbook スキル `repo-ops` を新設しました (`22eb8945`、`1d8ffd39`)。
+- 生成モックのファイル命名を `.gen.go` に統一しました (`7d2965b3`)。
+
+#### CI セキュリティ層の追加とサプライチェーン硬化
+
+- `gitleaks` / `hadolint` / `actionlint` を CI ワークフローと lefthook に組み込み、シークレット混入 / Dockerfile 規約 / GitHub Actions 構文を各 PR で自動検査するようにしました (`5b3ae033`、`2a99ad56`、`20a522ba`、`ca5975d4`、`d2de7370`、`eb58494e`)。
+- 全 GitHub Actions を commit SHA に固定し、CI と lefthook で pin 状態を enforce。pin 違反は PR で fail させます (`57f032ee`、`64d1cff3`)。
+- `pin-actions` ツールに supply-chain quarantine (`--min-age-days`) を追加し、公開直後の悪性リリース取り込みを防ぐタイムウィンドウを設けました (`a57076a5`)。
+- `secret-scan` を pre-commit から pre-push に移動し、`pre-push` の lefthook コマンドを `parallel: true` で並列化しました (`e6369703`、`2a45d33c`)。
+- カバレッジゲートを新設 (総カバレッジ 90% 未満で fail) しました (`86764d4e`)。
+- PR コメント投稿を `upsert-pr-comment` 共有アクションに統一しました (`add01d0e`)。
+
+#### godoc 静的 HTML 生成
+
+- godoc を静的 HTML として生成するツールと Make ターゲットを追加し、`auto-generate-docs` ワークフローに統合しました (`a528ae13`、`c111c0db`)。
+- 生成を deterministic 化し PR ノイズを抑制 (`1b8000aa`)、生成物 `docs/godoc/` を `.gitignore` から除外してポータルから閲覧できるようにしました (`db874fd4`、`b6ede29d`)。
+
+#### 観測性とドメインの改善
+
+- 例外時の stack trace を 1 本の改行入り文字列ではなく行配列で出力するよう変更し、Grafana 上での可読性を向上させました (`4fb86b3b`、`0f070317`)。
+- `echo.Context` sentinel を `ctxhelper` 経由に統一し、テストの密閉性と参照箇所の検索性を改善しました (`819b9a81`、`0e5ee665`)。
+- prefecture の境界値定数を `constant.go` に分離しました (`2f38f0a4`)。
+
+#### サンプル API 削除ツール
+
+- 新規リポジトリでサンプル User / Product / Order API を一括削除するスクリプトとマーカーを追加し、Make ターゲットでラップしました (`a84f59ce`、`272f3687`)。
+- DRY_RUN 挙動 / DB 前提を README に明記し、削除手順を整理しました (`fcdd155b`、`ec49d946`、`b977674b`)。
+
+#### テスト品質の引き上げ
+
+- 英語のテストケース名を日本語へ翻訳し、重複サブテストを削除しました (`f147ac16`)。
+- 正常系 / 異常系の規約違反 (testifylint `require-error` / 並列実行漏れ等) を全面修正しました (`4bfb5b69`、`e273df2e`、`dbc68645`)。
+- `genctxkey` の Set テストが Set 関数本体を経由するよう改修しました (`9111afe2`)。
+
+#### ドキュメント整備 (ドリフト解消・規約明文化)
+
+- `back-prop` によりドキュメントドリフトを一括解消しました (`d59b366b`)。
+- `commit` / `submit-pr` スキルにリポジトリ衛生規約 (`--no-verify` の意図 / 検証ゲートの後段集約 / push 前確認の wording) を明記しました (`2e411fbb`)。
+- `scaffold-test` にミューテーション検証を必須化し、scaffold / test 各スキルにコメント最小方針を明文化しました (`2aded38e`、`4c276c4d`)。
+
+## 動作確認手順
+
+1. `make gen-portal-docs && make gen-docs-json` を実行し、`docs/portal/docs.json` の再生成が成功すること。
+2. 静的サーバーで `docs/` を配信し (例: `python3 -m http.server 8082 -d docs`)、`http://localhost:8082/portal/` を開く。
+3. 左サイドバーで 7 グループ (Get Started / Architecture / Application Layers / Wiring & Helpers / Cross-Cutting / Build / Operations / API Contracts) を順に開き、URL が `#/<group-slug>` に同期すること。
+4. Application Layers → Controller / Infrastructure / DI、Build / Operations → Database で役割サブグループの見出しごとにカードが分かれて表示されること。
+5. サイドバー下部の Reference ブロック (OpenAPI Reference / Godoc / DB Schema / Coverage Report) をクリックし、新タブで HTML が開くこと。
+6. 検索ボックスに `controller` 等を入力し、フラットなヒット一覧が表示されること。0 件入力時には `No results matched your query.` が表示されること。
+7. Get Started → Tutorial のカードを開き、User 機能チュートリアルが読めること。
+8. `make gen-godoc` で `docs/godoc/index.html` が再生成されること。
+9. `make lint` / `make test` / `make test-cached` が成功すること。
+10. CI 上で gitleaks / hadolint / actionlint / pin-actions / coverage gate が新規ジョブとして実行されること。
+11. パニック発生時に Grafana 上で stacktrace が行配列で展開されて表示されること。
+
+## 影響（想定されるメリット／注意点）
+
+- ✅ ドキュメントポータルが多階層化されたことで、新規参加者・AI エージェントとも特定セクション (`#/<group-slug>`) に直接到達できるようになりました。
+- ✅ ポータル構造は manifest 一箇所で完結するようになり、README 追加時に JS への波及が不要になりました。
+- ✅ チュートリアルと setup-repository の Get Started 配下集約により、新規参加者の onboarding 動線が線形になりました。
+- ✅ AI エージェント検証スキルの並列化により、`full-verify` / `arch-check` / `back-prop` / `verify-spec` の壁時計が圧縮され、レビュー反復が高速化されました。
+- ✅ CI に gitleaks / hadolint / actionlint / pin-actions / coverage gate が追加され、シークレット混入 / Dockerfile 規約 / Actions 構文 / SHA pin 違反 / カバレッジ低下を PR 単位で機械的に検出できるようになりました。
+- ✅ stack trace の行配列化で Grafana ログの可読性が大幅に改善しました。
+- ⚠️ GitHub Actions の SHA pin enforce が有効化されたため、新規ワークフロー追加時は `make pin-actions` で SHA を確定させる必要があります。
+- ⚠️ `pre-push` フックに `gitleaks` / 各種 lint が組み込まれたため、初回 push で実行時間が伸びる可能性があります (並列化済み)。
+- ⚠️ カバレッジゲート (総 90%) が新設されたため、新規パッケージは 90% 以上のカバレッジが必要です。
+- ⚠️ ポータル多階層化により旧 `docs/portal/docs.json` の `sections[]` フォーマットから `groups[]` / `referenceLinks[]` のネスト構造に変わっています。docs.json を直接読む外部ツールがあれば追従が必要です。
+- ⚠️ 生成モック命名は `*_mock.go` から `*.gen.go` 化されています。直接参照しているテスト・lint 除外設定があれば追従が必要です。
+
+## 追加ライブラリ
+
+- Go 依存の追加はありません。
+- node / Go ツールチェーン側で `gitleaks` / `hadolint` / `actionlint` を `go_tool_runner` 経由で実行 (バイナリ取得のみ、`go.mod` / `package.json` 追加なし)。
+
+## 不具合修正
+
+- `bcrypt` エラーを `apperror.ErrInternal` に変換するよう是正しました (`3f6ee428`)。
+- godoc 生成対象から `scripts/` を除外し、モジュール名依存を解消しました (`526aef3e`)。
+- サンプル API 削除ツールの境界条件 (シェル escape / 中途失敗時のロールバック / DRY_RUN 出力) を堅牢化しました (`2c4950da`)。
+- `full-verify` の冗長コメント観点をコメント方針に整合させました (`4feec5e6`)。
+- ローカルレビュー指摘を反映して stacktrace 配列化の品質を高めました (`0f070317`)。
+- ポータル再設計のコードレビューで検出した検索無限ループ / hash 履歴汚染 / 言語フィルタ subgroup 混在 / mermaid・hljs 全文書スキャン / gen-docs-json の重複検知漏れ等を一括修正しました (`3659ffc0`)。
+
+## 補足・備考
+
+- OpenAPI の破壊的変更はありません。
+- ドキュメントポータル (`docs/portal/`) の見た目とナビゲーションが大きく変わっています。リリース後は `make gen-portal-docs && make gen-docs-json` を実行し、配信側でキャッシュ無効化することを推奨します。
+- このリリースは `release/v1.4.0` ブランチを起点として作成されました。
+- ポータル構造への変更を加える場合は `docs/maintenance/portal-manifest.md` を参照してください。`meta.groups` / `meta.subgroups` / `meta.section_titles` / `meta.reference_links` の編集だけで、ほぼ全ての構造変更が manifest 内で完結します。

--- a/.makefiles/markdown/lint.mk
+++ b/.makefiles/markdown/lint.mk
@@ -15,7 +15,7 @@ md-fix:
 
 # -----CI内で実行するコマンド群-----
 # markdownlint-cli2 の ignore 記法は "#glob"。Make 変数代入では # がコメント開始になるため \# でエスケープする。
-MD_GLOBS := "**/*.md" "\#vendor/**" "\#node_modules/**" "\#.git/**" "\#docs/portal/guides/**" "\#docs/coverage/**" "\#docs/db-schema/**" "\#AGENTS.md"
+MD_GLOBS := "**/*.md" "\#vendor/**" "\#**/node_modules/**" "\#.git/**" "\#docs/portal/guides/**" "\#docs/coverage/**" "\#docs/db-schema/**" "\#AGENTS.md"
 
 md-lint-ci:
 	markdownlint-cli2 $(MD_GLOBS)


### PR DESCRIPTION
# 概要

v1.4.0 のリリースノートを `.github/release/v1.4.0.md` に追加しました。あわせて release-notes スキルの md-lint 検証ステップで顕在化した既存の md-lint glob 設定バグ (nested `node_modules` を除外できていない) を修正し、glob 修正で表面化した `.claude/` 配下の MD060 違反 (テーブル区切りの compact style) も整え、リポジトリ全体で `make md-lint` がクリーンに通る状態に回復させています。

## 変更内容

- **リリースノート**: `.github/release/v1.4.0.md` を新規作成。`v1.3.0..HEAD` の 128 コミットをカテゴリ別に整理 (ドキュメントポータル多階層化 / チュートリアル追加 / AI エージェント基盤の並列化と統合 / CI セキュリティ層 / godoc 静的 HTML / 観測性改善など)。
- **lint 設定**: `.makefiles/markdown/lint.mk` の `MD_GLOBS` の ignore パターンを `node_modules/**` → `**/node_modules/**` に修正し、`scripts/node_modules` 配下の vendor 依存 README が lint 対象に拾われないように。
- **既存 MD060 違反の整形**: 上記 glob 修正で表面化した既存違反 (compact style のテーブル区切り `|------|...|`) を `| --- | --- | --- |` 形式へ修正。
  - `.claude/skills/full-verify/SKILL.md:62`
  - `.claude/skills/full-verify/README.md:77`
  - `.claude/skills/full-apply/SKILL.md:46`

## 動作確認方法

1. `make md-lint` を実行し、`Linting: 421 file(s)` / `Summary: 0 error(s)` で完走すること。
2. `.github/release/v1.4.0.md` をエディタで開き、構成 (概要 / 変更内容 / 動作確認手順 / 影響 / 追加ライブラリ / 不具合修正 / 補足) が canonical な v1.1.0 / v1.3.0 と整合していること。
3. `scripts/node_modules/` 配下の vendor README が md-lint の対象から除外されていること (glob 修正前は MD040 等で fail していた)。