### PR TITLE
OTLP エクスポート動作確認用の手動 e2e ハーネスを追加

### DIFF
--- a/internal/observability/export_verify_test.go
+++ b/internal/observability/export_verify_test.go
@@ -1,0 +1,64 @@
+//go:build otelverify
+
+package observability
+
+import (
+	"context"
+	"testing"
+
+	"go-boilerplate/internal/config"
+	"go-boilerplate/internal/system"
+
+	"github.com/stretchr/testify/require"
+)
+
+// captureReg は、検証中に登録された Stop フックを保持する簡易 Registrar。
+type captureReg struct {
+	stops []func(context.Context) error
+}
+
+func (r *captureReg) RegisterStart(func(context.Context) error) {}
+
+func (r *captureReg) RegisterStop(f func(context.Context) error) {
+	r.stops = append(r.stops, f)
+}
+
+// TestExportVerify は、実装した provider が OTLP で実際にエクスポートし受信側で取得できるかを確認する
+// 手動 e2e ハーネス。ビルドタグ otelverify で隔離しており、通常の test / lint / カバレッジには含まれない。
+//
+// 実行手順:
+//  1. 受信側 Collector を起動する（debug exporter が受信内容を標準出力にダンプする）:
+//     docker run --rm -p 4317:4317 -p 4318:4318 \
+//       -v "$PWD/internal/observability/testdata/otel-collector.yaml":/cfg.yaml \
+//       otel/opentelemetry-collector-contrib --config=/cfg.yaml
+//  2. 別ターミナルで本テストを実行する:
+//     go test -tags otelverify -run TestExportVerify -count=1 ./internal/observability/
+//  3. Collector のログに、service.name / service.version / deployment.environment.name つきの
+//     span（otel-verify-span）と、go.* のランタイムメトリクスが出力されることを確認する。
+func TestExportVerify(t *testing.T) {
+	t.Setenv("OTEL_TRACES_EXPORTER", "otlp")
+	t.Setenv("OTEL_METRICS_EXPORTER", "otlp")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+
+	appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
+	res, err := NewResource(appCfg, system.NewBuildInfo())
+	require.NoError(t, err)
+
+	reg := &captureReg{}
+
+	tp, err := TracerProvider(reg, res)
+	require.NoError(t, err)
+
+	_, err = MeterProvider(reg, res)
+	require.NoError(t, err)
+
+	tr := tp.Tracer("otel-verify")
+	_, span := tr.Start(context.Background(), "otel-verify-span")
+	span.End()
+
+	// 登録された Stop フック(tp.Shutdown / mp.Shutdown)を実行し、span とメトリクスをフラッシュする。
+	for _, stop := range reg.stops {
+		require.NoError(t, stop(context.Background()))
+	}
+}

--- a/internal/observability/testdata/otel-collector.yaml
+++ b/internal/observability/testdata/otel-collector.yaml
@@ -1,0 +1,26 @@
+# OTLP エクスポート動作確認用の最小 Collector 設定。
+# 受信した traces / metrics / logs を debug exporter で標準出力にダンプするだけ。
+# 使い方は export_verify_test.go のコメントを参照。
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      exporters: [debug]
+  telemetry:
+    logs:
+      level: info


### PR DESCRIPTION
# 概要

実装した OpenTelemetry provider が OTLP で実際に送出し、受信側で取得できるかを確認する手動 e2e ハーネスを追加します。ビルドタグ `otelverify` で隔離しており、通常の `make test` / `make lint` / カバレッジには一切含まれません。

ベースは親ブランチ `feature/otel-provider-plumbing`（PR #403）に積む stacked PR で、差分は検証コードのみです。

## 変更内容

- `internal/observability/export_verify_test.go`（`//go:build otelverify`）
  - `TestExportVerify`: `NewResource` / `TracerProvider` / `MeterProvider` で span・metrics を生成し、標準 OTLP env で Collector へ送出する
  - 簡易 `Registrar` 実装（`captureReg`）で Shutdown フックを実行しフラッシュ
- `internal/observability/testdata/otel-collector.yaml`
  - 受信内容を `debug` exporter で標準出力にダンプする最小 Collector 設定

## 動作確認方法

1. 受信側 Collector を起動:
   ```
   docker run --rm -p 4317:4317 -p 4318:4318 \
     -v "$PWD/internal/observability/testdata/otel-collector.yaml":/cfg.yaml \
     otel/opentelemetry-collector-contrib --config=/cfg.yaml
   ```
2. ハーネス実行:
   ```
   go test -tags otelverify -run TestExportVerify -count=1 ./internal/observability/
   ```
3. Collector ログに `service.name` / `service.version` / `service.revision` / `deployment.environment.name` つきの span（`otel-verify-span`）と `go.*` ランタイムメトリクスが出ることを確認

実機確認済み: span 受信、リソース属性（`service.name=TestApp` / `service.version=dev` / `service.revision=none`）、`go.memory.*` / `go.goroutine.count` 等のメトリクス受信を確認。