### PR TITLE
コメント方針の lint 強制・レビュー化と depguard 境界ルールの追加

### DIFF
--- a/.claude/agents/adversarial-reviewer.md
+++ b/.claude/agents/adversarial-reviewer.md
@@ -15,7 +15,7 @@ You are **read-only**. Never edit, write, or mutate anything. Use `Bash` only fo
 
 The orchestrator gives you:
 
-- **Lens** — the single review dimension you own (one of: `correctness`, `security`, `architecture`, `runtime-gap`). Stay in your lane; another reviewer owns the other lenses.
+- **Lens** — the single review dimension you own (one of: `correctness`, `security`, `architecture`, `runtime-gap`, `comment-style`). Stay in your lane; another reviewer owns the other lenses.
 - **Scope** — the base ref / changed file list / diff to review.
 - Repo context pointers (`CLAUDE.md`, relevant `README.md`, OpenAPI spec, migrations) as needed.
 
@@ -25,6 +25,7 @@ The orchestrator gives you:
 - **security** — missing `security:` declaration (endpoint reachable without auth), IDOR (acting on a resource id that is not the authenticated subject — e.g. `/users/{id}` vs `/users/me`), authorization bypass, mass-assignment / over-binding (DTO accepts fields it must not), secret / hash / PII leakage in responses or logs, injection, unsafe input trust.
 - **architecture** — Onion / layer violations per `CLAUDE.md`: infra called from handler, business logic in handler, domain depending on infra, usecase returning domain entities, layer bypass, edits to generated files, new patterns introduced without instruction. (For exhaustive layer compliance, `arch-check` is the heavier tool — here you flag the obvious, high-signal violations.)
 - **runtime-gap** — defects that **mocked tests cannot catch**: DI wiring mismatch (`BindHandler` unregistered / mis-provided), shared OpenAPI schema edits that break *sibling* endpoints (a `components/*` referenced by more than one operation), real-DB SQL behavior differing from the mock (filters, null handling, ordering, uniqueness), OpenAPI validation-middleware effects, `allOf` / `additionalProperties: false` ripple. State explicitly what runtime check would expose each one.
+- **comment-style** — doc / code comments that violate the **Comment Rules in `docs/rules.md`** (the authoritative source — read it). Flag comments that narrate **internal processing** instead of **behavior**: implementation means (`// … os.ReadFile を呼び出して …`), design rationale (`// … の登録は di 層が担う` / `// テスト容易性のため …`), step-by-step "how", internal-representation notes (`// 内部表現は [16]byte`), and tautologies (`// User は User です`). Only flag comments on lines in the diff. Do NOT flag: behavior/contract descriptions, or the documented load-bearing-constraint exception (e.g. a magic caller-skip-depth warning). Comment *presence/format* is the linter's job (`revive exported`) — you own the *content*.
 
 ## How to review
 

--- a/.claude/skills/local-review/SKILL.md
+++ b/.claude/skills/local-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: local-review
-description: Local adversarial, low-bias code review of the current change, run by subagents on a DIFFERENT model than the implementer. Mirrors `/code-review`'s finder → verify shape but keeps everything local and adds a runtime (curl + o11y) stage that mocked tests cannot cover. Confirms scope via `AskUserQuestion` (changed files vs branch-vs-base diff vs specific paths), fans out `adversarial-reviewer` subagents — one per lens (correctness / security / architecture / runtime-gap), each on `sonnet` by default so reviewer ≠ an Opus implementer — then verifies each finding with an independent `review-verifier` subagent (CONFIRMED / PLAUSIBLE / REFUTED), optionally runs the runtime curl + o11y check for touched endpoints (orchestrator-driven, per `scaffold-endpoint` Step 3.5), and synthesizes a single Japanese report. Read-only on source: reviewers cannot edit code (no fix is applied), and any destructive runtime curl is confirmed with the user first. By default the surviving CONFIRMED / PLAUSIBLE findings are posted to the branch's PR as inline review comments anchored to each finding's line (opt out with `--no-comment`; falls back to the local report when no open PR exists). Use before commit / PR to get an independent second opinion that the implementer's own model would not surface.
+description: Local adversarial, low-bias code review of the current change, run by subagents on a DIFFERENT model than the implementer. Mirrors `/code-review`'s finder → verify shape but keeps everything local and adds a runtime (curl + o11y) stage that mocked tests cannot cover. Confirms scope via `AskUserQuestion` (changed files vs branch-vs-base diff vs specific paths), fans out `adversarial-reviewer` subagents — one per lens (correctness / security / architecture / runtime-gap / comment-style), each on `sonnet` by default so reviewer ≠ an Opus implementer — then verifies each finding with an independent `review-verifier` subagent (CONFIRMED / PLAUSIBLE / REFUTED), optionally runs the runtime curl + o11y check for touched endpoints (orchestrator-driven, per `scaffold-endpoint` Step 3.5), and synthesizes a single Japanese report. Read-only on source: reviewers cannot edit code (no fix is applied), and any destructive runtime curl is confirmed with the user first. By default the surviving CONFIRMED / PLAUSIBLE findings are posted to the branch's PR as inline review comments anchored to each finding's line (opt out with `--no-comment`; falls back to the local report when no open PR exists). Use before commit / PR to get an independent second opinion that the implementer's own model would not surface.
 ---
 
 # Local Review
@@ -64,8 +64,9 @@ Spawn `adversarial-reviewer` subagents — **one per lens**, concurrently (issue
 | `security` | always (especially when a handler / auth / DTO / `openapi/**` is touched) |
 | `architecture` | always |
 | `runtime-gap` | when a controller / DI / `openapi/**` / `database/**` is touched |
+| `comment-style` | when the diff adds / changes any doc or code comment (almost always) |
 
-Each subagent prompt MUST include: the lens name + its definition, the base ref + changed-file list + the diff, and pointers to `CLAUDE.md` / the relevant `README.md` / OpenAPI spec / migrations. Use `agentType: "adversarial-reviewer"`, `model:` per the rule, and a `label` like `find:security`.
+Each subagent prompt MUST include: the lens name + its definition, the base ref + changed-file list + the diff, and pointers to `CLAUDE.md` / the relevant `README.md` / OpenAPI spec / migrations. Use `agentType: "adversarial-reviewer"`, `model:` per the rule, and a `label` like `find:security`. For the `comment-style` lens, also point the subagent at `docs/rules.md` ("Comment Rules") as the authoritative policy — it flags comments that narrate internal processing instead of behavior (linters cannot detect this; it is the semantic counterpart to `revive exported`'s presence/format check).
 
 ## Step 3 — Adversarial Verify
 
@@ -94,7 +95,7 @@ Produce one Japanese report:
 ```text
 ## ローカルレビュー結果（reviewer: <model> / implementer: <model>）
 
-スコープ: <base>...HEAD（<N> files） / lens: correctness, security, architecture, runtime-gap
+スコープ: <base>...HEAD（<N> files） / lens: correctness, security, architecture, runtime-gap, comment-style
 ランタイム検証: 実施（curl/o11y）/ 対象外（エンドポイント変更なし）
 
 ### CONFIRMED（要対応）

--- a/.golangci-full.yaml
+++ b/.golangci-full.yaml
@@ -134,6 +134,35 @@ linters:
             - pkg: go.opentelemetry.io/otel
               desc: "オブザーバビリティ関連ライブラリの使用は制限されています。
                 可能な限り、オブザーバビリティ関連ライブラリを追加で使用しない実装を心がけてください。"
+        restrict_the_use_of_otel_contrib: # OTel contrib(計装/エクスポータ)の使用を制限します
+          files:
+            - "**/*.go"
+            - "!**/internal/observability/**.go" # otel 初期化(exporter / runtime 計装)で使用を許可します
+            - "!**/internal/controller/httpstack/observability/**.go" # HTTP層の otelecho ミドルウェア統合で使用を許可します
+          list-mode: lax
+          deny:
+            - pkg: go.opentelemetry.io/contrib
+              desc: "OTel contrib ライブラリの使用は observability の初期化 / HTTP otel ミドルウェアに限定されています。
+                可能な限り、オブザーバビリティ関連ライブラリを追加で使用しない実装を心がけてください。"
+        restrict_lifecycle_to_di: # ライフサイクルの登録は di 層の責務に限定します
+          files:
+            - "**/*.go"
+            - "!**/internal/di/**.go" # di 配下(composition root / module / hook)でのみ使用を許可します
+          list-mode: lax
+          deny:
+            - pkg: go-boilerplate/internal/di/lifecycle
+              desc: "lifecycle.Registrar への直接依存は di 層(hook)の責務です。
+                コンポーネントは Close()/Shutdown() 等のハンドルを公開し、その登録は di の hook に委ねてください。"
+        restrict_di_hook_to_di: # di の hook パッケージは di 層の内部実装であり、外部からの参照を禁止します
+          files:
+            - "**/*.go"
+            - "!**/internal/di/**.go" # di 配下(module / composition root)でのみ参照を許可します
+          list-mode: lax
+          deny:
+            - pkg: go-boilerplate/internal/di/server/hook
+              desc: "di の hook パッケージは di 層の内部実装です。コンポーネントから直接参照せず、結線は di 層で行ってください。"
+            - pkg: go-boilerplate/internal/di/job/hook
+              desc: "di の hook パッケージは di 層の内部実装です。コンポーネントから直接参照せず、結線は di 層で行ってください。"
         independent_apperror: # apperrorパッケージが責務の実装層にも依存しないことを保証します
           files:
             - "**/internal/apperror/**.go"

--- a/.golangci-full.yaml
+++ b/.golangci-full.yaml
@@ -389,6 +389,9 @@ linters:
       enable-all: true
     revive:
       rules:
+        - name: exported # exported な宣言にはドキュメントコメントを必須とする
+          arguments:
+            - "disableStutteringCheck" # 命名の stutter 検査は行わない(コメント必須化のみが目的)
         - name: var-naming
           arguments:
             - []
@@ -408,8 +411,6 @@ linters:
       time-month: true         # time.Month の検出
 
   exclusions:
-    presets:
-      - comments
     paths:
       - vendor
     rules:

--- a/.golangci-full.yaml
+++ b/.golangci-full.yaml
@@ -151,7 +151,7 @@ linters:
           list-mode: lax
           deny:
             - pkg: go-boilerplate/internal/di/lifecycle
-              desc: "lifecycle.Registrar への直接依存は di 層(hook)の責務です。
+              desc: "lifecycle.Registrar への直接依存は di 層の責務です。
                 コンポーネントは Close()/Shutdown() 等のハンドルを公開し、その登録は di の hook に委ねてください。"
         restrict_di_hook_to_di: # di の hook パッケージは di 層の内部実装であり、外部からの参照を禁止します
           files:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -231,6 +231,9 @@ linters:
       require-specific: true
     revive:
       rules:
+        - name: exported # exported な宣言にはドキュメントコメントを必須とする
+          arguments:
+            - "disableStutteringCheck" # 命名の stutter 検査は行わない(コメント必須化のみが目的)
         - name: var-naming
           arguments:
             - []
@@ -238,8 +241,6 @@ linters:
             - [{ skipPackageNameChecks: true }] # 変数名の命名規則をチェックしますが、パッケージ名のチェックはスキップします。これにより、パッケージ名が変数名と同じ場合でもエラーにならなくなります。
 
   exclusions:
-    presets:
-      - comments
     paths:
       - vendor
     rules:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -216,6 +216,17 @@ Usecase should **avoid direct dependency on Infrastructure**.
 - Prefer making impossible failures impossible by construction. When a value is already guaranteed valid at a boundary (e.g. an echo-validated path parameter), convert it through a helper that `panic`s on the unreachable error instead of threading a defensive `error` return up the stack. Name such helpers with a `Must`-style / clearly assertive intent, and unit-test the panic path.
 - Rationale: a defensive `if err != nil { return err }` on an unreachable path is dead code — untestable, it drags coverage down and hides intent. A `panic` documents the invariant and fails loudly if the precondition is ever violated.
 
+## Comment Rules
+
+- Comments describe **behavior — the contract**: what a declaration does, and the meaning of its inputs / outputs. They must NOT narrate **internal processing**: the step-by-step "how", the implementation means, or the design rationale. If the behavior is stated, the implementation can be read from the code.
+- OK (behavior): `// ReadFile は name のファイル内容全体を読み込んで返す`
+- NG (internal processing / rationale):
+  - `// ReadFile は os.ReadFile を呼び出して…`（implementation means）
+  - `// 〜の登録は di 層が担う` / `// テスト容易性のため…`（design rationale）
+  - restating the implementation steps; tautologies (`// User は User です`)
+- **Exception**: a *load-bearing* constraint warning that the code itself cannot convey (e.g. a magic `runtime.Caller` skip depth, or "do not extract this helper — it shifts the skip count") may remain even though it is not strictly "behavior". It prevents a real bug.
+- Enforcement split: `revive`'s `exported` rule guarantees only the **presence** and **`Name`-prefixed format** of comments on exported declarations. This **behavior-only content** rule is semantic and cannot be linted — it is enforced by review (`local-review`'s `comment-style` lens).
+
 ## Testing & Definition of Done
 
 - Co-locate tests with each layer's implementation and verify them **per layer** — write that layer's tests and run `make test` (with coverage) before moving on. Do not batch all testing into a final step; deferred tests hide coverage gaps until late.

--- a/internal/apperror/apperror.go
+++ b/internal/apperror/apperror.go
@@ -4,27 +4,27 @@ package apperror
 import "go-boilerplate/pkg/xerrors"
 
 var (
-	// 引数が無効な場合に使用します。
+	// ErrInvalidArgument は引数が無効な場合に使用します。
 	ErrInvalidArgument = xerrors.New("invalid argument")
-	// 認証に失敗した場合に使用します。
+	// ErrUnauthenticated は認証に失敗した場合に使用します。
 	ErrUnauthenticated = xerrors.New("unauthenticated")
-	// 権限がない場合に使用します。
+	// ErrPermissionDenied は権限がない場合に使用します。
 	ErrPermissionDenied = xerrors.New("permission denied")
-	// 対象が見つからない場合に使用します。
+	// ErrNotFound は対象が見つからない場合に使用します。
 	ErrNotFound = xerrors.New("not found")
-	// 競合が発生した場合に使用します。
+	// ErrConflict は競合が発生した場合に使用します。
 	ErrConflict = xerrors.New("conflict")
-	// 検証が失敗した場合に使用します。
+	// ErrValidation は検証が失敗した場合に使用します。
 	ErrValidation = xerrors.New("validation error")
-	// リクエストが多すぎる場合に使用します。
+	// ErrTooManyRequests はリクエストが多すぎる場合に使用します。
 	ErrTooManyRequests = xerrors.New("too many requests")
-	// クライアントがリクエストをキャンセル/切断した場合に使用します。
+	// ErrCanceled はクライアントがリクエストをキャンセル/切断した場合に使用します。
 	ErrCanceled = xerrors.New("request canceled")
-	// サーバ内部で予期しないエラーが発生した場合に使用します。
+	// ErrInternal はサーバ内部で予期しないエラーが発生した場合に使用します。
 	ErrInternal = xerrors.New("internal error")
-	// 実装されていない操作が呼び出された場合に使用します。
+	// ErrUnimplemented は実装されていない操作が呼び出された場合に使用します。
 	ErrUnimplemented = xerrors.New("unimplemented")
-	// 一時的に利用できない状態を示します（リトライで解消される可能性がある場合）。
+	// ErrUnavailable は一時的に利用できない状態を示します（リトライで解消される可能性がある場合）。
 	ErrUnavailable = xerrors.New("service unavailable")
 )
 

--- a/internal/cli/mergedml/merge_dml.go
+++ b/internal/cli/mergedml/merge_dml.go
@@ -46,7 +46,7 @@ type FileSystem interface {
 // osFileSystem は os パッケージを用いた FileSystem の実装です。
 type osFileSystem struct{}
 
-// Generator は、DML ファイルをカテゴリ単位で連結し、sqlc 向けの単一 SQL ファイルを生成するオブジェクトです。
+// Generator は、DML ファイルから sqlc 用の統合 SQL ファイルを生成するオブジェクトです。
 type Generator struct {
 	logger          logging.Logger
 	callerSkipCount int

--- a/internal/cli/mergedml/merge_dml.go
+++ b/internal/cli/mergedml/merge_dml.go
@@ -46,6 +46,7 @@ type FileSystem interface {
 // osFileSystem は os パッケージを用いた FileSystem の実装です。
 type osFileSystem struct{}
 
+// Generator は、DML ファイルをカテゴリ単位で連結し、sqlc 向けの単一 SQL ファイルを生成するオブジェクトです。
 type Generator struct {
 	logger          logging.Logger
 	callerSkipCount int

--- a/internal/config/envspec.go
+++ b/internal/config/envspec.go
@@ -2,8 +2,7 @@ package config
 
 import "time"
 
-// Loader はアプリケーション全体の環境変数をサブ構造体ごとに読み込むルートコンテナ。
-// 各フィールドは envPrefix に対応するプレフィックス付きの環境変数グループにマッピングされる。
+// Loader はアプリケーション全体の設定を環境変数から読み込むルートコンテナ。
 type Loader struct {
 	OS            OperatingSystem `envPrefix:"OS_"`
 	App           Application     `envPrefix:"APP_"`

--- a/internal/config/envspec.go
+++ b/internal/config/envspec.go
@@ -2,6 +2,8 @@ package config
 
 import "time"
 
+// Loader はアプリケーション全体の環境変数をサブ構造体ごとに読み込むルートコンテナ。
+// 各フィールドは envPrefix に対応するプレフィックス付きの環境変数グループにマッピングされる。
 type Loader struct {
 	OS            OperatingSystem `envPrefix:"OS_"`
 	App           Application     `envPrefix:"APP_"`
@@ -15,10 +17,12 @@ type Loader struct {
 	Auth          Auth            `envPrefix:"AUTH_"`
 }
 
+// OperatingSystem はOS レベルの設定を保持する。現時点ではタイムゾーンのみを管理する。
 type OperatingSystem struct {
 	Timezone string `env:"TZ" default:"Asia/Tokyo"`
 }
 
+// Application はアプリケーション識別・動作モードおよびシャットダウン制御に関する設定を保持する。
 type Application struct {
 	Env             string        `env:"ENV,required"`
 	Name            string        `env:"NAME,required"`
@@ -26,6 +30,7 @@ type Application struct {
 	ShutdownTimeout time.Duration `env:"SHUTDOWN_TIMEOUT,required"`
 }
 
+// Server は HTTP サーバーのバインドアドレスおよび各種タイムアウトに関する設定を保持する。
 type Server struct {
 	Host              string        `env:"HOST,required"`
 	Port              int           `env:"PORT,required"`
@@ -35,6 +40,7 @@ type Server struct {
 	IdleTimeout       time.Duration `env:"IDLE_TIMEOUT,required"`
 }
 
+// Metrics はメトリクスエンドポイント（Prometheus 等）への接続情報と認証情報を保持する。
 type Metrics struct {
 	Host     string `env:"HOST,required"`
 	Port     int    `env:"PORT,required"`
@@ -42,12 +48,16 @@ type Metrics struct {
 	Password string `env:"PASSWORD,required"`
 }
 
+// Observability はトレースや計装の有効化フラグ、DBクエリ引数マスク設定、
+// およびトレース対象とする HTTP ステータスコード一覧を保持する。
 type Observability struct {
 	Enabled           bool  `env:"ENABLED,required"`
 	MaskedDBQueryArgs bool  `env:"MASKED_DB_QUERY_ARGS,required"`
 	TargetStatusCodes []int `env:"TARGET_STATUS_CODES,required"  envSeparator:","`
 }
 
+// Database はデータベースへの接続先情報（ドライバ・ホスト・認証情報・SSL）および
+// 接続確認タイムアウトやスロークエリ警告閾値を保持する。
 type Database struct {
 	Driver                 string        `env:"DRIVER,required"`
 	Host                   string        `env:"HOST,required"`
@@ -60,6 +70,7 @@ type Database struct {
 	SlowQueryWarnThreshold time.Duration `env:"SLOW_QUERY_WARN_THRESHOLD,required"`
 }
 
+// DBConnection はコネクションプールの上限・下限数とコネクションの最大生存時間・最大アイドル時間を保持する。
 type DBConnection struct {
 	MaxConns    int32         `env:"MAX_CONNS,required"`
 	MinConns    int32         `env:"MIN_CONNS,required"`
@@ -67,6 +78,8 @@ type DBConnection struct {
 	MaxIdleTime time.Duration `env:"MAX_IDLE_TIME,required"`
 }
 
+// Security は CORS 許可オリジン・CIDR 制限・セキュリティヘッダー（HSTS・X-Frame-Options 等）・
+// Referrer Policy および bcrypt コストパラメータを保持する。
 type Security struct {
 	AllowedOrigins        []string      `env:"ALLOWED_ORIGINS,required"         envSeparator:","`
 	CIDR                  string        `env:"CIDR,required"`
@@ -79,12 +92,14 @@ type Security struct {
 	BcryptCost            int           `env:"BCRYPT_COST,required"`
 }
 
+// SecureCookie はセキュアクッキーの属性（Secure / SameSite / Domain）の上書き設定を保持する。
 type SecureCookie struct {
 	Secure   *bool  `env:"SECURE"`
 	SameSite string `env:"SAME_SITE"`
 	Domain   string `env:"DOMAIN"`
 }
 
+// Auth は認証に使う Cookie 名・ヘッダー名・Bearer 許可の設定を保持する。
 type Auth struct {
 	CookieName          string `env:"COOKIE_NAME,required"`
 	HeaderName          string `env:"HEADER_NAME,required"`

--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// Config は、アプリケーション全体の設定をサブ設定ごとに束ねたルート設定です。
 type Config struct {
 	os            OperatingSystemConfig
 	app           ApplicationConfig
@@ -18,10 +19,12 @@ type Config struct {
 	auth          AuthConfig
 }
 
+// OperatingSystemConfig は、OS レベルの設定（タイムゾーン）を保持します。
 type OperatingSystemConfig struct {
 	timezone string
 }
 
+// ApplicationConfig は、アプリの識別情報・動作モード・シャットダウン制御の設定を保持します。
 type ApplicationConfig struct {
 	env             string
 	name            string
@@ -29,6 +32,7 @@ type ApplicationConfig struct {
 	shutdownTimeout time.Duration
 }
 
+// ServerConfig は、HTTP サーバーの待ち受けアドレスと各種タイムアウトを保持します。
 type ServerConfig struct {
 	host              string
 	port              int
@@ -38,6 +42,7 @@ type ServerConfig struct {
 	idleTimeout       time.Duration
 }
 
+// MetricsConfig は、メトリクスエンドポイントの待ち受け情報と認証情報を保持します。
 type MetricsConfig struct {
 	host     string
 	port     int
@@ -45,12 +50,14 @@ type MetricsConfig struct {
 	password string
 }
 
+// ObservabilityConfig は、可観測モードの有効化と、DB クエリ引数マスク・監視対象ステータスコードの設定を保持します。
 type ObservabilityConfig struct {
 	enabled             bool
 	maskedDBQueryArgs   bool
 	targetStatusCodeSet map[int]bool
 }
 
+// DatabaseConfig は、データベースの接続情報とタイムアウト閾値を保持します。
 type DatabaseConfig struct {
 	driver                 string
 	host                   string
@@ -63,6 +70,7 @@ type DatabaseConfig struct {
 	slowQueryWarnThreshold time.Duration
 }
 
+// DBConnectionConfig は、データベース接続プールのサイズと寿命の設定を保持します。
 type DBConnectionConfig struct {
 	maxConns    int32
 	minConns    int32
@@ -70,6 +78,7 @@ type DBConnectionConfig struct {
 	maxIdleTime time.Duration
 }
 
+// SecurityConfig は、CORS・許可 CIDR・セキュリティヘッダー・bcrypt コスト等のセキュリティ設定を保持します。
 type SecurityConfig struct {
 	allowedOrigins        []string
 	cidr                  *net.IPNet
@@ -82,12 +91,14 @@ type SecurityConfig struct {
 	bcryptCost            int
 }
 
+// SecureCookieConfig は、セキュアクッキーの属性（Secure / SameSite / Domain）の強制設定を保持します。
 type SecureCookieConfig struct {
 	secure   *bool
 	sameSite string
 	domain   string
 }
 
+// AuthConfig は、認証に使う Cookie 名・ヘッダー名・Bearer 許可の設定を保持します。
 type AuthConfig struct {
 	cookieName          string
 	headerName          string

--- a/internal/controller/handler/health/health_handler.go
+++ b/internal/controller/handler/health/health_handler.go
@@ -17,6 +17,7 @@ type server struct {
 	tracer observability.LayerTracer
 }
 
+// BindHandler は、ヘルスチェック（health）ハンドラを Echo に登録します。
 func BindHandler(
 	e *echo.Echo, tf observability.TracerFactory,
 ) {

--- a/internal/controller/handler/healthz/healthz_handler.go
+++ b/internal/controller/handler/healthz/healthz_handler.go
@@ -17,6 +17,7 @@ type server struct {
 	tracer observability.LayerTracer
 }
 
+// BindHandler は、liveness 用の healthz ハンドラを Echo に登録します。
 func BindHandler(
 	e *echo.Echo, tf observability.TracerFactory,
 ) {

--- a/internal/controller/handler/metrics/metrics_handler.go
+++ b/internal/controller/handler/metrics/metrics_handler.go
@@ -8,6 +8,8 @@ import (
 	echomw "github.com/labstack/echo/v4/middleware"
 )
 
+// BindHandler は、Prometheusメトリクスエンドポイント（/metrics）をEchoに登録します。
+// Basic認証バリデータを受け取り、エンドポイントへのアクセスを保護します。
 func BindHandler(e *echo.Echo, bav echomw.BasicAuthValidator) {
 	e.GET("/metrics",
 		echo.WrapHandler(promhttp.Handler()),

--- a/internal/controller/handler/ready/ready_handler.go
+++ b/internal/controller/handler/ready/ready_handler.go
@@ -19,6 +19,7 @@ type server struct {
 	healthUsecase healthcheckuc.Usecase
 }
 
+// BindHandler は、レディネスチェックのハンドラーをEchoに登録します。
 func BindHandler(e *echo.Echo, tf observability.TracerFactory, healthUsecase healthcheckuc.Usecase) {
 	gen.RegisterHandlers(e, gen.NewStrictHandler(&server{
 		tracer:        tf.Controller(),

--- a/internal/controller/handler/testkit/testecho/test_echo.go
+++ b/internal/controller/handler/testkit/testecho/test_echo.go
@@ -24,11 +24,13 @@ var (
 	errModeConflict = errors.New("RequestURL は RoutePattern/PathParams と併用できません")
 )
 
+// EchoTestParam は、テストリクエストに付与するクエリ/パスパラメータの名前と値を表します。
 type EchoTestParam struct {
 	Name  string
 	Value string
 }
 
+// EchoTestClient は、Echo ハンドラをテストから駆動するためのリクエストビルダ兼クライアントです。
 type EchoTestClient struct {
 	t            *testing.T
 	e            *echo.Echo

--- a/internal/controller/handler/v1/users/detail/v1_users_detail_handler.go
+++ b/internal/controller/handler/v1/users/detail/v1_users_detail_handler.go
@@ -27,6 +27,7 @@ type server struct {
 	uc     user.Usecase
 }
 
+// BindHandler は、ユーザー詳細のハンドラを Echo に登録します。
 func BindHandler(e *echo.Echo, tf observability.TracerFactory, uc user.Usecase) {
 	gen.RegisterHandlers(e, gen.NewStrictHandler(&server{
 		tracer: tf.Controller(),

--- a/internal/controller/handler/v1/users/search/v1_users_handler.go
+++ b/internal/controller/handler/v1/users/search/v1_users_handler.go
@@ -21,6 +21,7 @@ type server struct {
 	uc     search.Usecase
 }
 
+// BindHandler は、ユーザー検索エンドポイントのハンドラーをEchoに登録します。
 func BindHandler(e *echo.Echo, tf observability.TracerFactory, us search.Usecase) {
 	gen.RegisterHandlers(e, gen.NewStrictHandler(&server{
 		tracer: tf.Controller(),

--- a/internal/controller/handler/v1/users/v1_users_handler.go
+++ b/internal/controller/handler/v1/users/v1_users_handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/oapi-codegen/runtime/types"
 )
 
+// ErrUnauthenticatedUser は、認証ユーザー情報が取得できない場合のエラーです。
 var ErrUnauthenticatedUser = xerrors.Wrap(apperror.ErrUnauthenticated, "requires authenticated user")
 
 type server struct {
@@ -26,6 +27,7 @@ type server struct {
 	uc     user.Usecase
 }
 
+// BindHandler は、ユーザー一覧のハンドラを Echo に登録します。
 func BindHandler(e *echo.Echo, tf observability.TracerFactory, uc user.Usecase) {
 	gen.RegisterHandlers(e, gen.NewStrictHandler(&server{
 		tracer: tf.Controller(),

--- a/internal/controller/handler/version/version_handler.go
+++ b/internal/controller/handler/version/version_handler.go
@@ -28,6 +28,7 @@ type server struct {
 	tracer    observability.LayerTracer
 }
 
+// BindHandler は、バージョン情報を返すハンドラを Echo に登録します。
 func BindHandler(
 	e *echo.Echo,
 	tf observability.TracerFactory,

--- a/internal/controller/httpstack/ipextractor/ip_extractor.go
+++ b/internal/controller/httpstack/ipextractor/ip_extractor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// New は、アプリケーション設定とセキュリティ設定をもとにIPアドレス抽出器を生成し、Echoインスタンスに設定します。
 func New(e *echo.Echo, appCfg *config.ApplicationConfig, secCfg *config.SecurityConfig) {
 	e.IPExtractor = NewIPExtractor(appCfg, secCfg)
 }

--- a/internal/controller/httpstack/ipextractor/ip_extractor.go
+++ b/internal/controller/httpstack/ipextractor/ip_extractor.go
@@ -7,7 +7,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// New は、アプリケーション設定とセキュリティ設定をもとにIPアドレス抽出器を生成し、Echoインスタンスに設定します。
+// New は、アプリケーション設定とセキュリティ設定をもとに Echo の IP アドレス抽出ポリシーを設定します。
 func New(e *echo.Echo, appCfg *config.ApplicationConfig, secCfg *config.SecurityConfig) {
 	e.IPExtractor = NewIPExtractor(appCfg, secCfg)
 }

--- a/internal/controller/httpstack/logging/constant.go
+++ b/internal/controller/httpstack/logging/constant.go
@@ -1,5 +1,7 @@
+// Package logging は、HTTPリクエストログに関する定数を提供します。
 package logging
 
 const (
+	// MinStatusError は、エラーとして扱うHTTPステータスコードの最小値です。
 	MinStatusError = 500
 )

--- a/internal/di/module/job.go
+++ b/internal/di/module/job.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/fx"
 )
 
+// JobModule は、バックグラウンドジョブ関連の依存関係を提供するfx.Moduleです。
 func JobModule() fx.Option {
 	return fx.Module("job",
 		provideJobs(

--- a/internal/di/server/hook/http_server_hook.go
+++ b/internal/di/server/hook/http_server_hook.go
@@ -1,3 +1,4 @@
+// Package hook は、起動と停止のライフサイクルフックを提供します。
 package hook
 
 import (

--- a/internal/di/shutdowner/shutdowner.go
+++ b/internal/di/shutdowner/shutdowner.go
@@ -7,6 +7,7 @@ package shutdowner
 
 import "go.uber.org/fx"
 
+// Shutdowner は、アプリケーションのシャットダウンを要求するインターフェースです。
 type Shutdowner interface {
 	Shutdown() error
 }

--- a/internal/domain/prefecture/error.go
+++ b/internal/domain/prefecture/error.go
@@ -6,8 +6,11 @@ import (
 )
 
 var (
-	errInvalid     = xerrors.Wrap(apperror.ErrValidation, "invalid prefecture")
-	ErrInvalidID   = xerrors.Wrap(errInvalid, "id failed")
+	errInvalid = xerrors.Wrap(apperror.ErrValidation, "invalid prefecture")
+	// ErrInvalidID は、都道府県 ID の検証に失敗した場合のエラーです。
+	ErrInvalidID = xerrors.Wrap(errInvalid, "id failed")
+	// ErrInvalidName は、都道府県名の検証に失敗した場合のエラーです。
 	ErrInvalidName = xerrors.Wrap(errInvalid, "name failed")
+	// ErrInvalidCode は、都道府県コードの検証に失敗した場合のエラーです。
 	ErrInvalidCode = xerrors.Wrap(errInvalid, "code failed")
 )

--- a/internal/domain/prefecture/prefecture_domain.go
+++ b/internal/domain/prefecture/prefecture_domain.go
@@ -9,8 +9,10 @@ import (
 	"go-boilerplate/pkg/xerrors"
 )
 
+// Prefectures は、Prefecture エンティティのスライス型です。
 type Prefectures []*Prefecture
 
+// Prefecture は、都道府県を表すドメインエンティティです。
 type Prefecture struct {
 	id   uuid.UUID
 	name string

--- a/internal/domain/prefecture/prefecture_repository.go
+++ b/internal/domain/prefecture/prefecture_repository.go
@@ -7,6 +7,7 @@ import (
 	"go-boilerplate/pkg/uuid"
 )
 
+// Repository は、都道府県の永続化操作を定義するドメインリポジトリインターフェースです。
 type Repository interface {
 	// FindByID は、IDから都道府県を取得します。存在しない場合は NotFound を返します。
 	FindByID(ctx context.Context, id uuid.UUID) (*Prefecture, error)

--- a/internal/domain/user/constant.go
+++ b/internal/domain/user/constant.go
@@ -12,6 +12,8 @@ const (
 	maxBuildingLength     = 255
 	maxPostalCodeLength   = 8
 
+	// MaxRawPasswordLength は、平文パスワードの最大文字数です。
 	MaxRawPasswordLength = 64
+	// MinRawPasswordLength は、平文パスワードの最小文字数です。
 	MinRawPasswordLength = 8
 )

--- a/internal/domain/user/error.go
+++ b/internal/domain/user/error.go
@@ -6,20 +6,33 @@ import (
 )
 
 var (
-	errInvalid             = xerrors.Wrap(apperror.ErrValidation, "invalid user")
-	ErrInvalidID           = xerrors.Wrap(errInvalid, "id failed")
-	ErrInvalidFirstName    = xerrors.Wrap(errInvalid, "first name failed")
-	ErrInvalidLastName     = xerrors.Wrap(errInvalid, "last name failed")
+	errInvalid = xerrors.Wrap(apperror.ErrValidation, "invalid user")
+	// ErrInvalidID は、ユーザー ID の検証に失敗した場合のエラーです。
+	ErrInvalidID = xerrors.Wrap(errInvalid, "id failed")
+	// ErrInvalidFirstName は、名の検証に失敗した場合のエラーです。
+	ErrInvalidFirstName = xerrors.Wrap(errInvalid, "first name failed")
+	// ErrInvalidLastName は、姓の検証に失敗した場合のエラーです。
+	ErrInvalidLastName = xerrors.Wrap(errInvalid, "last name failed")
+	// ErrInvalidPasswordHash は、パスワードハッシュの検証に失敗した場合のエラーです。
 	ErrInvalidPasswordHash = xerrors.Wrap(errInvalid, "password hash failed")
-	ErrInvalidEmail        = xerrors.Wrap(errInvalid, "email failed")
-	ErrInvalidPhone        = xerrors.Wrap(errInvalid, "phone failed")
+	// ErrInvalidEmail は、メールアドレスの検証に失敗した場合のエラーです。
+	ErrInvalidEmail = xerrors.Wrap(errInvalid, "email failed")
+	// ErrInvalidPhone は、電話番号の検証に失敗した場合のエラーです。
+	ErrInvalidPhone = xerrors.Wrap(errInvalid, "phone failed")
+	// ErrInvalidPrefectureID は、都道府県 ID の検証に失敗した場合のエラーです。
 	ErrInvalidPrefectureID = xerrors.Wrap(errInvalid, "prefecture id failed")
-	ErrInvalidCity         = xerrors.Wrap(errInvalid, "city failed")
-	ErrInvalidStreet       = xerrors.Wrap(errInvalid, "street failed")
-	ErrInvalidBuilding     = xerrors.Wrap(errInvalid, "building failed")
-	ErrInvalidPostalCode   = xerrors.Wrap(errInvalid, "postal code failed")
-	ErrInvalidUpdatedAt    = xerrors.Wrap(errInvalid, "updated at failed")
-	ErrInvalidDeletedAt    = xerrors.Wrap(errInvalid, "deleted at failed")
+	// ErrInvalidCity は、市区町村の検証に失敗した場合のエラーです。
+	ErrInvalidCity = xerrors.Wrap(errInvalid, "city failed")
+	// ErrInvalidStreet は、番地の検証に失敗した場合のエラーです。
+	ErrInvalidStreet = xerrors.Wrap(errInvalid, "street failed")
+	// ErrInvalidBuilding は、建物名の検証に失敗した場合のエラーです。
+	ErrInvalidBuilding = xerrors.Wrap(errInvalid, "building failed")
+	// ErrInvalidPostalCode は、郵便番号の検証に失敗した場合のエラーです。
+	ErrInvalidPostalCode = xerrors.Wrap(errInvalid, "postal code failed")
+	// ErrInvalidUpdatedAt は、更新日時の検証に失敗した場合のエラーです。
+	ErrInvalidUpdatedAt = xerrors.Wrap(errInvalid, "updated at failed")
+	// ErrInvalidDeletedAt は、削除日時の検証に失敗した場合のエラーです。
+	ErrInvalidDeletedAt = xerrors.Wrap(errInvalid, "deleted at failed")
 
 	// ErrInvalidRawPassword は、RawPassword 値オブジェクト固有の検証エラーです。
 	// User フィールド検証群（errInvalid 系）とは別系統で、errInvalid を経由しません。

--- a/internal/domain/user/raw_password.go
+++ b/internal/domain/user/raw_password.go
@@ -7,6 +7,7 @@ import (
 	"go-boilerplate/pkg/xerrors"
 )
 
+// RawPassword は、検証済みの平文パスワードを保持する値オブジェクトです。
 type RawPassword struct {
 	value string
 }
@@ -22,6 +23,7 @@ func NewRawPassword(v string) (RawPassword, error) {
 	return RawPassword{value: v}, nil
 }
 
+// Value は、保持している平文パスワード文字列を返します。
 func (p RawPassword) Value() string {
 	return p.value
 }

--- a/internal/domain/user/user_domain.go
+++ b/internal/domain/user/user_domain.go
@@ -10,8 +10,10 @@ import (
 	"go-boilerplate/pkg/xerrors"
 )
 
+// Users は、User エンティティのスライス型です。
 type Users []*User
 
+// User は、ユーザーを表すドメインエンティティです。
 type User struct {
 	id           uuid.UUID
 	firstName    string

--- a/internal/domain/user/user_repository.go
+++ b/internal/domain/user/user_repository.go
@@ -7,6 +7,7 @@ import (
 	"go-boilerplate/pkg/uuid"
 )
 
+// Repository は、ユーザーの永続化操作を定義するドメインリポジトリインターフェースです。
 type Repository interface {
 	// FindByActive は、ユーザーの情報を、ページング付きで取得します。
 	// active=nil で全件（削除済み含む）、true でアクティブのみ、false で削除済みのみを対象とします。

--- a/internal/infrastructure/auth/local/auth_local.go
+++ b/internal/infrastructure/auth/local/auth_local.go
@@ -14,6 +14,7 @@ const (
 	localPrefix = "debug:"
 )
 
+// ErrLocalMockAuthenticatorInvalidToken は、ローカルモック認証でトークンが不正な場合のエラーです。
 var ErrLocalMockAuthenticatorInvalidToken = xerrors.Wrap(apperror.ErrUnauthenticated, "local mock authenticator: invalid token")
 
 // authenticator は local 開発用の Authenticator です。

--- a/internal/infrastructure/rdb/driver/driver.go
+++ b/internal/infrastructure/rdb/driver/driver.go
@@ -14,6 +14,8 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// DatabaseDriver は、PostgreSQL 接続プールに対するトランザクション開始・疎通確認・統計取得を含む
+// DB アクセスの最上位インタフェースです。
 type DatabaseDriver interface {
 	DBTX
 

--- a/internal/infrastructure/rdb/driver/loggingdb/provider.go
+++ b/internal/infrastructure/rdb/driver/loggingdb/provider.go
@@ -12,7 +12,7 @@ import (
 	"go-boilerplate/internal/observability"
 )
 
-// DBProvider は、コンテキストを受け取りログ付き DBTX を生成するファクトリインタフェースです。
+// DBProvider は、コンテキストを受け取り DBTX を生成するファクトリインタフェースです。
 type DBProvider interface {
 	NewLoggingDB(ctx context.Context) driver.DBTX
 }

--- a/internal/infrastructure/rdb/driver/loggingdb/provider.go
+++ b/internal/infrastructure/rdb/driver/loggingdb/provider.go
@@ -12,6 +12,7 @@ import (
 	"go-boilerplate/internal/observability"
 )
 
+// DBProvider は、コンテキストを受け取りログ付き DBTX を生成するファクトリインタフェースです。
 type DBProvider interface {
 	NewLoggingDB(ctx context.Context) driver.DBTX
 }

--- a/internal/infrastructure/rdb/metrics/pool_stats_collector.go
+++ b/internal/infrastructure/rdb/metrics/pool_stats_collector.go
@@ -18,6 +18,7 @@ type poolStatsMetric struct {
 	value     func(stats *pgxpool.Stat) float64
 }
 
+// PoolStatsCollector は、DB コネクションプールの統計情報を Prometheus メトリクスとして公開する収集器です。
 type PoolStatsCollector struct {
 	db      driver.DatabaseDriver
 	metrics []poolStatsMetric

--- a/internal/infrastructure/rdb/query_service/user/user_query_service.go
+++ b/internal/infrastructure/rdb/query_service/user/user_query_service.go
@@ -17,6 +17,7 @@ type service struct {
 	tracer observability.LayerTracer
 }
 
+// New は、ユーザー検索クエリサービスの実装を生成して返します。
 func New(
 	db loggingdb.DBProvider,
 	tf observability.TracerFactory,

--- a/internal/infrastructure/rdb/repository/prefecture/prefecture_repository.go
+++ b/internal/infrastructure/rdb/repository/prefecture/prefecture_repository.go
@@ -17,6 +17,7 @@ type repository struct {
 	tracer observability.LayerTracer
 }
 
+// New は、prefecture.Repository の RDB 実装を生成して返します。
 func New(
 	db loggingdb.DBProvider,
 	tf observability.TracerFactory,

--- a/internal/infrastructure/rdb/repository/user/user_repository.go
+++ b/internal/infrastructure/rdb/repository/user/user_repository.go
@@ -17,6 +17,7 @@ type repository struct {
 	tracer observability.LayerTracer
 }
 
+// New は、user.Repository の RDB 実装を生成して返します。
 func New(
 	db loggingdb.DBProvider,
 	tf observability.TracerFactory,

--- a/internal/infrastructure/rdb/sqlc/like.go
+++ b/internal/infrastructure/rdb/sqlc/like.go
@@ -1,4 +1,4 @@
-// Package sqlc は、sqlc で生成されたコードを補助する関数を提供します。
+// Package sqlc は、LIKE/ILIKE クエリのパターン生成とエスケープのユーティリティを提供します。
 package sqlc
 
 import "strings"

--- a/internal/infrastructure/rdb/sqlc/like.go
+++ b/internal/infrastructure/rdb/sqlc/like.go
@@ -3,6 +3,7 @@ package sqlc
 
 import "strings"
 
+// DefaultLikeEscapeChar は、PostgreSQL の LIKE/ILIKE クエリで使用するデフォルトのエスケープ文字です。
 const DefaultLikeEscapeChar = "\\"
 
 // WrapPrefixLikePattern は、前方一致（prefix match）用に pattern を作ります。

--- a/internal/infrastructure/rdb/sqlc/like.go
+++ b/internal/infrastructure/rdb/sqlc/like.go
@@ -1,3 +1,4 @@
+// Package sqlc は、sqlc で生成されたコードを補助する関数を提供します。
 package sqlc
 
 import "strings"

--- a/internal/infrastructure/rdb/system_query/healthcheck/health_check_system_query.go
+++ b/internal/infrastructure/rdb/system_query/healthcheck/health_check_system_query.go
@@ -17,6 +17,7 @@ type systemQuery struct {
 	tracer observability.LayerTracer
 }
 
+// New は、DB ヘルスチェック用のシステムクエリ実装を生成して返します。
 func New(
 	provider loggingdb.DBProvider,
 	tf observability.TracerFactory,

--- a/internal/infrastructure/rdb/testkit/test_kit.go
+++ b/internal/infrastructure/rdb/testkit/test_kit.go
@@ -29,6 +29,7 @@ var (
 	txLock sync.Mutex
 )
 
+// TransactionRunner は、テスト用に関数をトランザクション内で実行するインターフェースです。
 type TransactionRunner interface {
 	WithinTx(fn func(ctx context.Context))
 }

--- a/internal/logging/field_builder.go
+++ b/internal/logging/field_builder.go
@@ -8,6 +8,7 @@ import (
 	"go-boilerplate/internal/config"
 )
 
+// LogFieldBuilder は、各種ログ入力から構造化ログのフィールド列を構築するインターフェースです。
 type LogFieldBuilder interface {
 	BuildHTTPRequestFields(req HTTPRequestLogInput) []*Field
 	BuildHTTPResponseFields(resp HTTPResponseLogInput) []*Field

--- a/internal/observability/helper.go
+++ b/internal/observability/helper.go
@@ -9,8 +9,10 @@ import (
 )
 
 const (
+	// SpanEventStart は、span の開始イベントを表します。
 	SpanEventStart = "start"
-	SpanEventEnd   = "end"
+	// SpanEventEnd は、span の終了イベントを表します。
+	SpanEventEnd = "end"
 )
 
 // TraceContext は、トレースを識別するための情報を保持します。

--- a/internal/observability/layer_tracer.go
+++ b/internal/observability/layer_tracer.go
@@ -28,7 +28,7 @@ const (
 
 type layerName string
 
-// LayerTracer は、レイヤー単位で span を生成・終了し、観測ログを出力するトレーサーです。
+// LayerTracer は、アーキテクチャレイヤー単位のトレース span を提供するトレーサーです。
 type LayerTracer struct {
 	log      logging.Logger
 	lf       logging.LogFieldBuilder

--- a/internal/observability/layer_tracer.go
+++ b/internal/observability/layer_tracer.go
@@ -14,10 +14,13 @@ import (
 )
 
 const (
-	delimiter            = "."
+	delimiter = "."
+	// Controller は、コントローラー層を表すレイヤー名です。
 	Controller layerName = "controller"
-	Usecase    layerName = "usecase"
-	Infra      layerName = "infrastructure"
+	// Usecase は、ユースケース層を表すレイヤー名です。
+	Usecase layerName = "usecase"
+	// Infra は、インフラ層を表すレイヤー名です。
+	Infra layerName = "infrastructure"
 
 	// callSkip は、ロガーのコールスタックのスキップ数を定義します。
 	callSkip = 3
@@ -25,6 +28,7 @@ const (
 
 type layerName string
 
+// LayerTracer は、レイヤー単位で span を生成・終了し、観測ログを出力するトレーサーです。
 type LayerTracer struct {
 	log      logging.Logger
 	lf       logging.LogFieldBuilder

--- a/internal/observability/test_kit.go
+++ b/internal/observability/test_kit.go
@@ -42,6 +42,7 @@ func NewMockUsecaseLayerTracer(t *testing.T) LayerTracer {
 	return tf.Usecase()
 }
 
+// NewMockInfraLayerTracer は、テスト用のインフラレイヤートレーサーを生成します。
 func NewMockInfraLayerTracer(t *testing.T) LayerTracer {
 	t.Helper()
 	tf := NewNoopTracerFactory(t)

--- a/internal/observability/tracer_factory.go
+++ b/internal/observability/tracer_factory.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// TracerFactory は、レイヤー別の LayerTracer を生成するファクトリです。
 type TracerFactory interface {
 	// Controller は、コントローラー層用のトレーサーを返します。
 	Controller() LayerTracer

--- a/internal/usecase/boundary/auth/auth.go
+++ b/internal/usecase/boundary/auth/auth.go
@@ -23,6 +23,7 @@ type Authn struct {
 	claims   map[string]any // 任意（監査・UI制御等）
 }
 
+// New は、認証主体や付随情報から認証結果 Authn を生成して返します。
 func New(
 	subject string,
 	provider string,

--- a/internal/usecase/boundary/auth/credential.go
+++ b/internal/usecase/boundary/auth/credential.go
@@ -8,6 +8,8 @@ type Credential struct {
 	accessToken string // アクセストークン
 }
 
+// NewCredential は、アクセストークンを検証して Credential を生成して返します。
+// トークンが空文字列またはホワイトスペースのみの場合は ErrTokenMissing を返します。
 func NewCredential(
 	accessToken string,
 ) (*Credential, error) {

--- a/internal/usecase/boundary/auth/error.go
+++ b/internal/usecase/boundary/auth/error.go
@@ -6,7 +6,10 @@ import (
 )
 
 var (
+	// ErrUnauthenticatedSubjectMissing は、JWT 等のトークンに subject クレームが存在しない場合に返す認証エラーです。
 	ErrUnauthenticatedSubjectMissing = xerrors.Wrap(apperror.ErrUnauthenticated, "unauthenticated: subject missing")
-	ErrSubjectNotUUID                = xerrors.Wrap(apperror.ErrValidation, "id unavailable: subject is not a uuid")
-	ErrTokenMissing                  = xerrors.Wrap(apperror.ErrInvalidArgument, "token missing")
+	// ErrSubjectNotUUID は、subject を UUID として解釈できない場合に返す検証エラーです。
+	ErrSubjectNotUUID = xerrors.Wrap(apperror.ErrValidation, "id unavailable: subject is not a uuid")
+	// ErrTokenMissing は、トークンが指定されていない場合に返すエラーです。
+	ErrTokenMissing = xerrors.Wrap(apperror.ErrInvalidArgument, "token missing")
 )

--- a/internal/usecase/healthcheck/health_check_usecase.go
+++ b/internal/usecase/healthcheck/health_check_usecase.go
@@ -12,9 +12,13 @@ import (
 	"go-boilerplate/internal/usecase/healthcheck/query"
 )
 
+// ヘルスチェックの総合ステータスを表す値。
 const (
-	Degraded  = "degraded"
-	Ok        = "ok"
+	// Degraded は、一部の依存が不調だが稼働継続できる状態を表します。
+	Degraded = "degraded"
+	// Ok は、すべて正常な状態を表します。
+	Ok = "ok"
+	// Unhealthy は、サービスが正常に応答できない状態を表します。
 	Unhealthy = "unhealthy"
 )
 

--- a/internal/usecase/healthcheck/query/health_check_system_query.go
+++ b/internal/usecase/healthcheck/query/health_check_system_query.go
@@ -8,6 +8,7 @@ import (
 	"time"
 )
 
+// DBSystemQuery は、データベースの健全性を確認するシステムクエリのインターフェースです。
 type DBSystemQuery interface {
 	CheckDBHealth(ctx context.Context) (DBHealth, error)
 }

--- a/internal/usecase/tools/paging/paging.go
+++ b/internal/usecase/tools/paging/paging.go
@@ -21,6 +21,7 @@ const (
 	maxOffset = maxPage * maxPerPage
 )
 
+// Paging は、ページネーションに必要な取得上限（limit）とオフセット（offset）を保持する値オブジェクトです。
 type Paging struct {
 	limit  int
 	offset int

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -22,6 +22,7 @@ type Runner interface {
 // OS は、os/exec を用いた Runner の実装です。
 type OS struct{}
 
+// Output は、dir をカレントとしてコマンドを実行し、標準出力を返します。
 func (OS) Output(ctx context.Context, dir string, env []string, name string, args []string) ([]byte, error) {
 	var stdout bytes.Buffer
 	cmd := osexec.CommandContext(ctx, name, args...) //nolint:gosec // name/args は呼び出し側で固定された信頼値

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -19,14 +19,17 @@ type FS interface {
 // OS は、os / path/filepath を用いた FS の実装です。
 type OS struct{}
 
+// ReadFile は、name のファイル内容全体を読み込んで返します。
 func (OS) ReadFile(name string) ([]byte, error) {
 	return os.ReadFile(name) //nolint:gosec // path は呼び出し側で検証された信頼パス
 }
 
+// WriteFile は、data を name のファイルへ書き込みます。ファイルが存在しない場合は perm で新規作成します。
 func (OS) WriteFile(name string, data []byte, perm os.FileMode) error {
 	return os.WriteFile(name, data, perm)
 }
 
+// Glob は、pattern に一致するファイルパスの一覧を返します。
 func (OS) Glob(pattern string) ([]string, error) {
 	return filepath.Glob(pattern)
 }

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -7,6 +7,8 @@ import (
 	"github.com/google/uuid"
 )
 
+// UUID は、128 ビットの一意識別子を表す値オブジェクトです。
+//
 //nolint:recvcheck // safe: UUID is immutable (value object); pointer receiver is required only for Scan to implement sql.Scanner
 type UUID struct{ b [16]byte }
 


### PR DESCRIPTION
# 概要

「コメント方針の徹底」と「アーキテクチャ境界の lint 化」をまとめて行う。

1. exported 宣言へのコメントを revive で必須化し、既存分を振る舞いベースで一括整備。
2. コメントの中身（振る舞いのみ／内部処理は書かない）は lint 不能なため、`docs/rules.md` に方針を明記し `local-review` に `comment-style` レンズを追加。
3. #407 で確立した責務分離（observability / lifecycle 境界）を守る depguard ルールを追加。

## 変更内容

- Lint（depguard / revive）
  - depguard 3ルール追加: `restrict_lifecycle_to_di` / `restrict_di_hook_to_di` / `restrict_the_use_of_otel_contrib`（いずれも既存違反ゼロ）
  - `revive exported` を有効化（`comments` プリセット除外解除・命名 stutter は `disableStutteringCheck` で無効化）。コメントの存在・形式を CI で担保
- ドキュメント
  - `docs/rules.md` に Comment Rules（振る舞いを書く／内部処理は書かない）を明記＝方針の単一 SoT
  - sqlc / hook パッケージにパッケージコメントを追加
- コメント整備
  - exported 宣言（49ファイル）に振る舞いベースの doc コメントを付与
- レビュー基盤
  - `local-review` に `comment-style` レンズを追加（`docs/rules.md` を権威ソースとして内部処理ナレーションを検出）
- local-review 指摘反映
  - 追加コメントの内部処理ナレーションを振る舞い記述へ修正、depguard desc 文言を修正

## 動作確認方法

1. `make lint`（0 issues。revive exported / depguard 全ルール適用済み）
2. `make test`（全パス）
3. 非 di パッケージから `internal/di/lifecycle` 等を import すると depguard が弾くこと（probe で確認済み）