### PR TITLE
js-yaml を 4.2.0 へ更新し Trivy FS 警告を解消

### DIFF
--- a/docker/tools/package-lock.json
+++ b/docker/tools/package-lock.json
@@ -7,7 +7,7 @@
       "name": "docs-tools",
       "dependencies": {
         "commander": "15.0.0",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "zod": "4.4.3"
       }
     },
@@ -27,9 +27,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/docker/tools/package.json
+++ b/docker/tools/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "dependencies": {
     "commander": "15.0.0",
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.2.0",
     "zod": "4.4.3"
   }
 }


### PR DESCRIPTION
# 概要

trivy-fs（依存ライブラリ脆弱性スキャン）が検出していた `js-yaml` の脆弱性 CVE-2026-53550 (MEDIUM) を解消するため、`docker/tools` の `js-yaml` を 4.1.1 → 4.2.0 に更新する。

## 変更内容

- **依存関係 (docker/tools)**
  - `package.json`: `js-yaml` を `4.1.1` → `4.2.0` に更新。
  - `package-lock.json`: `npm install --package-lock-only` で再生成し、新 integrity と整合させた（`npm ci` がそのまま通る状態）。

## 動作確認方法

1. `make trivy-fs` を実行し、npm / gomod とも脆弱性 0 件になることを確認。

   ```
   ┌────────────────────────────────┬───────┬─────────────────┐
   │             Target             │ Type  │ Vulnerabilities │
   ├────────────────────────────────┼───────┼─────────────────┤
   │ docker/tools/package-lock.json │  npm  │        0        │
   │ go.mod                         │ gomod │        0        │
   └────────────────────────────────┴───────┴─────────────────┘
   ```

> [!NOTE]
> trivy-fs ワークフローのトリガ paths は現状 `**/*.go` / `go.mod` / `go.sum` のみで lockfile を含まないため、本 PR では trivy-fs の自動コメントは起動しません（週次 schedule で検証されます）。トリガへの lockfile 追加は別途検討。