### PR TITLE
サプライチェーン・セキュリティ初期装備の追加（署名・attestation・Dependabot・SECURITY.md）

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,84 @@
+# Security Policy
+
+このリポジトリは boilerplate テンプレートです。本ファイルはテンプレートとして提供される初期ポリシーであり、
+**継承先は連絡先・対象バージョン等を自環境に合わせて修正**してください（環境依存箇所は `※環境に合わせて修正` と明記）。
+
+## Reporting a Vulnerability（脆弱性の報告）
+
+> [!IMPORTANT]
+> 以下の連絡先はプレースホルダです。継承先で必ず実際の窓口へ差し替えてください。
+
+- 脆弱性は **公開 Issue / Pull Request では報告しないでください**（情報が公開されてしまうため）。
+- 次のいずれかで **非公開** に報告してください。
+  - GitHub の Private Vulnerability Reporting（リポジトリの `Security` → `Advisories` → `Report a vulnerability`）
+  - セキュリティ窓口: `security@example.com` ※環境に合わせて修正
+- 報告には以下を含めてください。
+  - 再現手順 / PoC
+  - 影響範囲（想定される被害・前提条件）
+  - 該当するバージョン or コミット SHA
+- 初回応答の目安: **X 営業日以内** ※運用に合わせて修正
+
+### Supported Versions（サポート対象）
+
+- 最新リリース: ✅ サポート対象
+- それ以前: ❌ サポート対象外 ※運用に合わせて修正
+
+## Verifying release artifacts（成果物の検証）
+
+`.github/workflows/deploy-app.yaml` は GHCR へ push する各イメージ（`runtime` / `migration`）に対し、
+**push 済みイメージの digest を対象に** 次を付与します。
+
+- cosign keyless 署名（OIDC → Fulcio → Rekor）
+- SLSA provenance attestation（`actions/attest-build-provenance`）
+- SBOM(SPDX) attestation（`actions/attest-sbom`）
+
+タグは可変だが digest は不変なので、**検証は必ず digest 基準**で行ってください。
+以下コマンド中の `<owner>` / `<repo>` / `<tag>` / `<digest>` は環境に合わせて置換します
+（GHCR 以外へ移した場合は `ghcr.io/<owner>` 部分も読み替え）。
+
+### 0. 対象 digest の取得
+
+```bash
+# タグから digest を解決する
+docker buildx imagetools inspect ghcr.io/<owner>/app:<tag> --format '{{.Manifest.Digest}}'
+# もしくは
+crane digest ghcr.io/<owner>/app:<tag>
+```
+
+### 1. cosign 署名の検証
+
+keyless 署名は「どのワークフローが署名したか（証明書の identity）」と「OIDC 発行者」で検証します。
+
+```bash
+cosign verify \
+  --certificate-identity-regexp "^https://github.com/<owner>/<repo>/\.github/workflows/deploy-app\.yaml@.*$" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  ghcr.io/<owner>/app@<digest>
+```
+
+### 2. provenance attestation の検証（どこで・何からビルドされたか）
+
+```bash
+gh attestation verify oci://ghcr.io/<owner>/app@<digest> \
+  --repo <owner>/<repo> \
+  --predicate-type https://slsa.dev/provenance/v1
+```
+
+### 3. SBOM(SPDX) attestation の検証（同梱物の証明）
+
+```bash
+gh attestation verify oci://ghcr.io/<owner>/app@<digest> \
+  --repo <owner>/<repo> \
+  --predicate-type https://spdx.dev/Document
+```
+
+> [!NOTE]
+> `gh attestation verify` は GitHub Attestation store を参照するため、レジストリが OCI referrer に
+> 非対応でも検証できます（deploy 側で `push-to-registry: false` にした場合も GitHub 側の記録で検証可能）。
+> 一方 `cosign verify` はレジストリ上の署名（referrer）を参照します。
+
+### 検証のデプロイゲート化（推奨）
+
+> [!IMPORTANT]
+> 検証は **デプロイ前のゲート** として CD パイプライン側に組み込むことを推奨します
+> （署名・provenance・SBOM が確認できないイメージはデプロイしない）。本ファイルは検証手順のみを示します。

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -38,11 +38,15 @@
 
 ### 0. 対象 digest の取得
 
+runtime / migration は同一リポジトリ `app` の別タグ（`<sha>` / `<sha>-migration`）で push される。
+検証はタグではなく digest 基準で行うため、対象イメージのタグから digest を解決する。
+
 ```bash
-# タグから digest を解決する
+# runtime イメージ
 docker buildx imagetools inspect ghcr.io/<owner>/app:<tag> --format '{{.Manifest.Digest}}'
-# もしくは
 crane digest ghcr.io/<owner>/app:<tag>
+# migration イメージ（タグに -migration suffix が付く）
+crane digest ghcr.io/<owner>/app:<tag>-migration
 ```
 
 ### 1. cosign 署名の検証

--- a/.github/actions-pin.toml
+++ b/.github/actions-pin.toml
@@ -1,5 +1,7 @@
 # GitHub Actions の pin 対象 SHA（SSOT）。
 # make pin-actions-resolve で解決・make pin-actions-apply で workflow へ反映する。
+"actions/attest-build-provenance@v3" = "977bb373ede98d70efdf65b84cb5f73e068dcc2a"
+"actions/attest-sbom@v3" = "4651f806c01d8637787e274ac3bdf724ef169f34"
 "actions/checkout@v6" = "df4cb1c069e1874edd31b4311f1884172cec0e10"
 "actions/deploy-pages@v5" = "cd2ce8fcbc39b97be8ca5fce6e763baed58fa128"
 "actions/github-script@v8" = "ed597411d8f924073f98dfc5c65a23a2325f34cd"
@@ -14,3 +16,4 @@
 "jdx/mise-action@v2" = "c37c93293d6b742fc901e1406b8f764f6fb19dac"
 "k1LoW/octocov-action@v1" = "b3b6ee60482a667950f87553abf1df63217235d9"
 "peter-evans/create-pull-request@v6" = "c5a7806660adbe173f04e3e038b0ccdcd758773c"
+"sigstore/cosign-installer@v3" = "398d4b0eeef1380460a10c8013a76f728fb906ac"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,10 @@
 # Dependabot 設定
 #
 # 対象エコシステム: Go modules / Docker / GitHub Actions の3種。
-# cooldown: バージョンが公開されてから一定日数（patch=5 / minor=7 / major=30、
-#           semver 分類外は default-days=5）経過するまで更新 PR を作成せず、初期不良の枯れを待つ。
+# cooldown: バージョン公開から一定日数経過するまで更新 PR を作成せず、初期不良の枯れを待つ。
+#           - gomod: semver 段階別に patch=5 / minor=7 / major=30 日。
+#           - docker / github-actions: semver 段階指定（semver-*-days）は非対応のため
+#             単一の default-days=5 日のみ指定する（GitHub 仕様で段階キーが使えない）。
 # groups : 1 エコシステムあたり 1 PR にまとめ、更新 PR のノイズを抑制する。
 #
 # 注意: セキュリティアップデート（security update）は cooldown を通らず即時 PR が作成される。
@@ -35,11 +37,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # docker は semver 段階を区別しないため cooldown は default-days のみ指定可能。
     cooldown:
       default-days: 5
-      semver-patch-days: 5
-      semver-minor-days: 7
-      semver-major-days: 30
     groups:
       docker:
         patterns:
@@ -52,11 +52,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # github-actions は semver 段階を区別しないため cooldown は default-days のみ指定可能。
     cooldown:
       default-days: 5
-      semver-patch-days: 5
-      semver-minor-days: 7
-      semver-major-days: 30
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 # Dependabot 設定
 #
 # 対象エコシステム: Go modules / Docker / GitHub Actions の3種。
-# cooldown: バージョンが公開されてから一定日数（patch=5 / minor=7 / major=30）経過するまで
-#           更新 PR を作成せず、初期不良の枯れを待つ。
+# cooldown: バージョンが公開されてから一定日数（patch=5 / minor=7 / major=30、
+#           semver 分類外は default-days=5）経過するまで更新 PR を作成せず、初期不良の枯れを待つ。
 # groups : 1 エコシステムあたり 1 PR にまとめ、更新 PR のノイズを抑制する。
 #
 # 注意: セキュリティアップデート（security update）は cooldown を通らず即時 PR が作成される。

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+# Dependabot 設定
+#
+# 対象エコシステム: Go modules / Docker / GitHub Actions の3種。
+# cooldown: バージョンが公開されてから一定日数（patch=5 / minor=7 / major=30）経過するまで
+#           更新 PR を作成せず、初期不良の枯れを待つ。
+# groups : 1 エコシステムあたり 1 PR にまとめ、更新 PR のノイズを抑制する。
+#
+# 注意: セキュリティアップデート（security update）は cooldown を通らず即時 PR が作成される。
+#       これは脆弱性対応を遅延させないための Dependabot 仕様であり、承知の上で運用する。
+version: 2
+updates:
+  # ---- Go modules ----
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 5
+      semver-patch-days: 5
+      semver-minor-days: 7
+      semver-major-days: 30
+    groups:
+      gomod:
+        patterns:
+          - "*"
+
+  # ---- Docker ----
+  # Dockerfile は docker/ 配下の3イメージに分かれているため directories で個別指定する。
+  - package-ecosystem: "docker"
+    directories:
+      - "/docker/tools"
+      - "/docker/server"
+      - "/docker/document"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 5
+      semver-patch-days: 5
+      semver-minor-days: 7
+      semver-major-days: 30
+    groups:
+      docker:
+        patterns:
+          - "*"
+
+  # ---- GitHub Actions ----
+  # directory "/" でワークフロー（.github/workflows）と複合アクション（.github/actions）の双方を走査する。
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 5
+      semver-patch-days: 5
+      semver-minor-days: 7
+      semver-major-days: 30
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build:
@@ -97,9 +96,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
-      # WARN: 現状は GHCR 向けログインのみ。後段の build-push / cosign sign / SBOM 取得 / attest は
-      #       すべてここで確立した認証情報を使う。他レジストリではこのステップを差し替える
+      # WARN: 他レジストリへ移行する場合はこのステップを差し替えること
       #       （ECR: aws ecr get-login-password / GCP: gcloud auth / ACR: az acr login 等）。
+      #       後段のビルド/署名/attestation はここで確立した認証セッションに依存する。
       - name: Login to registry
         run: |
           echo "Login to container registry here (ECR/GCR/ACR/GHCR)"
@@ -153,6 +152,9 @@ jobs:
         run: |
           cosign sign --yes "${IMAGE_DIGEST_REF}"
 
+      # NOTE: image-scan.yaml の SBOM とは目的が異なる意図的な重複。
+      #       image-scan.yaml は PR ゲートとしてローカルビルド(push:false)を対象にスキャン/レポートする。
+      #       こちらは push 済み digest を対象に attestation へ添付する。どちらか一方を消さないこと。
       - name: Generate SBOM (SPDX) for pushed image
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:

--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -19,6 +19,7 @@ jobs:
       deployments: write
       packages: write
       id-token: write
+      attestations: write
     concurrency:
       group: ${{ github.workflow }}-build-${{ github.ref }}-${{ matrix.target }}
       cancel-in-progress: true
@@ -64,6 +65,9 @@ jobs:
             echo "app_env=dev" >> $GITHUB_OUTPUT
           fi
 
+      # WARN: 署名 / attestation は後段すべてこの meta_registry を参照する（ghcr.io はハードコードしていない）。
+      #       他レジストリ（ECR / Artifact Registry / ACR 等）へ移す場合は、この registry 値と
+      #       下の Login to registry を差し替えるだけで署名はそのまま対象レジストリへ付く。
       - name: Define registry
         id: meta_registry
         run: |
@@ -93,6 +97,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
+      # WARN: 現状は GHCR 向けログインのみ。後段の build-push / cosign sign / SBOM 取得 / attest は
+      #       すべてここで確立した認証情報を使う。他レジストリではこのステップを差し替える
+      #       （ECR: aws ecr get-login-password / GCP: gcloud auth / ACR: az acr login 等）。
       - name: Login to registry
         run: |
           echo "Login to container registry here (ECR/GCR/ACR/GHCR)"
@@ -104,6 +111,7 @@ jobs:
           go mod vendor
 
       - name: Build and push image (${{ matrix.target }})
+        id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
@@ -124,6 +132,43 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.target }}
           cache-to: type=gha,mode=max,scope=${{ matrix.target }}
           provenance: false
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-name: ${{ steps.meta_registry.outputs.registry }}/app
+          subject-digest: ${{ steps.build.outputs.digest }}
+          # WARN: push-to-registry は attestation を OCI 1.1 referrer としてレジストリへ添付する。
+          #       GitHub Attestation store への記録はレジストリ非依存で常に行われるが、この referrer 添付は
+          #       対象レジストリが OCI referrer 対応の場合のみ成功する。非対応レジストリでは false にし、
+          #       GitHub 側の記録（+ cosign 署名）のみで検証する構成にフォールバックすること。
+          push-to-registry: true
+
+      - name: Sign image (cosign keyless)
+        env:
+          IMAGE_DIGEST_REF: ${{ steps.meta_registry.outputs.registry }}/app@${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes "${IMAGE_DIGEST_REF}"
+
+      - name: Generate SBOM (SPDX) for pushed image
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          image: ${{ steps.meta_registry.outputs.registry }}/app@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-${{ matrix.target }}.spdx.json
+          upload-artifact: false
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34 # v3
+        with:
+          subject-name: ${{ steps.meta_registry.outputs.registry }}/app
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom-${{ matrix.target }}.spdx.json
+          # WARN: 上記 Attest build provenance と同じく OCI referrer 添付。非対応レジストリでは false にする。
+          push-to-registry: true
 
   deploy:
     needs: build


### PR DESCRIPTION
# 概要

継承先が「検証可能なイメージ」を出すための初期装備を追加する。GHCR push 後の
cosign 署名 + SLSA provenance / SBOM(SPDX) attestation、cooldown 付き Dependabot、
検証手順を含む SECURITY.md を整備した。

## 変更内容

- **CI / 署名（`deploy-app.yaml`, `actions-pin.toml`）**
  - GHCR push 済みイメージの digest を対象に cosign keyless 署名・provenance
    attestation・SBOM(SPDX) attestation を付与
  - 署名対象は `meta_registry` 参照で GHCR ハードコードを回避（他レジストリは
    差し替え点のみで適用可能。WARN コメントで明示）
  - `attestations: write` 権限と build ステップ `id` を追加、新規3アクション
    （cosign-installer / attest-build-provenance / attest-sbom）を SHA pin
- **CI / Dependabot（`dependabot.yml`）**
  - gomod / docker / github-actions の3エコシステム
  - cooldown（patch=5・minor=7・major=30日）で初期不良の枯れを待つ。groups で
    PR ノイズ抑制。security update は cooldown を通らない点をコメントに明記
- **ドキュメント（`SECURITY.md`）**
  - 脆弱性の非公開報告ポリシー（連絡先等はプレースホルダ）
  - cosign verify / gh attestation verify による署名・provenance・SBOM の検証手順

## 動作確認方法

- ローカル検証（実施済み）: `make actions-lint` / `make pin-actions-check` /
  `make md-lint` がいずれも OK
- CI 上の実挙動（マージ後 production/staging/develop への push 時に確認）:
  1. deploy-app 実行で GHCR に署名・provenance・SBOM attestation が付与される
  2. `gh attestation verify oci://ghcr.io/<owner>/app@<digest> --repo <owner>/<repo>` で検証できる