### PR TITLE
CI: auto-generate-docs を並行化し重複PR作成を抑止

### DIFF
--- a/.github/workflows/auto-generate-docs.yaml
+++ b/.github/workflows/auto-generate-docs.yaml
@@ -125,22 +125,12 @@ jobs:
           # この push に .go 変更が含まれるか（意味のあるカバレッジ更新の判定に使う）。
           go_changed=false
           if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
-            # 前回 tip が取れない（新規ブランチ等）場合は安全側で「変更あり」とみなす。
             go_changed=true
           elif git diff --name-only "$BEFORE_SHA..$AFTER_SHA" -- '*.go' | grep -q .; then
             go_changed=true
           fi
 
-          # 非決定的ノイズ（再生成のたびに揺れる値）を PR コミットから除外する。【根本対応】
-          # これらを残すと、各 auto-docs PR が異なるノイズ値を抱え、1 つが merge される度に
-          # 他の PR が「SchemaSpy 生成日時 / カバレッジ実行回数」だけで衝突してしまう。
-          # ここで戻す 3 ファイルは、従来から差分判定で除外していたノイズ集合と同一。
-          #
-          # SchemaSpy の概要 / メタ情報は生成日時のみが揺れる純ノイズ → 常に元へ戻す
-          # （スキーマ自体の変更は diagrams/ や tables/ 等の別ファイルに反映されるため失われない）。
           git checkout -- docs/db-schema/index.html docs/db-schema/info-html.txt 2>/dev/null || true
-          # coverage はカバレッジ実行回数が揺れる純ノイズ。ただし今回 push に .go 変更があれば
-          # 意味のあるカバレッジ更新があり得るため残す。
           if [ "$go_changed" = "false" ]; then
             git checkout -- docs/coverage/index.html 2>/dev/null || true
           fi

--- a/.github/workflows/auto-generate-docs.yaml
+++ b/.github/workflows/auto-generate-docs.yaml
@@ -158,7 +158,7 @@ jobs:
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           commit-message: "chore(docs): auto update docs [skip ci]"
-          branch: auto/docs-update/${{ github.ref_name }}-${{ github.run_id }}
+          branch: auto/docs-update/${{ github.ref_name }}
           base: ${{ github.ref_name }}
           title: "chore(docs): sync generated artifacts"
           body: |

--- a/.github/workflows/auto-generate-docs.yaml
+++ b/.github/workflows/auto-generate-docs.yaml
@@ -84,20 +84,29 @@ jobs:
       - name: Seed Database
         run: go run ./cmd/ db-seed --database ${{ env.DB }}
 
-      - name: Generate Test Repo Docs
-        run: make gen-test-repo
-
       - name: Generate ER Diagram
         run: make gen-db-schema-ci
 
-      - name: Generate Portal Docs
+      - name: Generate docs (parallel)
         run: |
-          make gen-portal-docs
-          make gen-docs-json
-          make gen-portal-build
+          set -uo pipefail
+          LOG="$RUNNER_TEMP/genlogs"
+          mkdir -p "$LOG"
 
-      - name: Generate godoc
-        run: make gen-godoc
+          ( make gen-test-repo )      > "$LOG/test-repo.log" 2>&1 & pid_test=$!
+          ( make gen-portal-docs && make gen-docs-json && make gen-portal-build ) \
+                                      > "$LOG/portal.log"    2>&1 & pid_portal=$!
+          ( make gen-godoc )          > "$LOG/godoc.log"     2>&1 & pid_godoc=$!
+
+          rc=0
+          for pid in $pid_test $pid_portal $pid_godoc; do
+            wait "$pid" || rc=1
+          done
+
+          for f in test-repo portal godoc; do
+            echo "::group::$f"; cat "$LOG/$f.log"; echo "::endgroup::"
+          done
+          exit $rc
 
       - name: Fix permissions
         run: |


### PR DESCRIPTION
# 概要

`auto-generate-docs` ワークフローの Seed 以降のドキュメント生成を並行化して実行時間を短縮し、併せて auto-docs PR がリリースブランチごとに溜まる問題を解消する。

## 変更内容

- **CI / 並行化**: ER 図(SchemaSpy)は後段の `gen-test-repo` と DB を共有するため前段で単独実行し、出力先が独立した `gen-test-repo` / portal / godoc を 1 ステップ内でバックグラウンド実行して並行化。各ログは作業ツリー外（`$RUNNER_TEMP`）へ退避し、終了コードを個別集約して 1 つでも失敗すればステップを失敗させる。
- **CI / 重複PR抑止**: Create PR の `branch` から `run_id` を除去し `auto/docs-update/<ref>` に固定。`peter-evans/create-pull-request` が既存 PR を in-place 更新するため、リリースブランチごとに常に最新 1 本だけが open になる。
- **Docs**: ノイズ除去ステップ（Strip nondeterministic noise）の冗長な説明コメントを整理。

## 動作確認方法

- `release/**` への push で起動するワークフローのため、ローカルでの完全実行は不可。
- `make actions-lint`（actionlint）と `make pin-actions-check` で静的検証済み。
- マージ後、次回 `release/v1.5.0` への push で生成ステップが並行実行され、auto-docs PR が単一ブランチに集約されることを確認する。