### PR TITLE
Markdown の mermaid 構文 lint を md-lint に統合し、outbox 設計ドキュメントを追加

### DIFF
--- a/.makefiles/README.ja.md
+++ b/.makefiles/README.ja.md
@@ -199,9 +199,11 @@ Markdown ファイルに対する Lint と自動修正を扱うターゲット�
 
 | コマンド | 説明 | 補足 |
 | --- | --- | --- |
-| `make md-lint` | Markdown ファイルの Lint を実行します。 | `node_tool_runner` コンテナ内で `make md-lint-ci` を呼び出します。 |
+| `make md-lint` | Markdown の Lint を実行します（markdownlint + mermaid 構文）。 | `node_tool_runner` コンテナ内で `make md-lint-ci` を呼び出します。 |
 | `make md-fix` | Markdown ファイルの Lint 自動修正を実行します。 | `node_tool_runner` コンテナ内で `make md-fix-ci` を呼び出します。 |
-| `make md-lint-ci` | `markdownlint-cli2` で `**/*.md` を直接 Lint します。 | CI 用ターゲットです。`vendor/`、`node_modules/`、`.git/` を除外します。 |
+| `make md-mermaid-lint` | ` ```mermaid ` フェンスのみを構文検証します。 | `node_tool_runner` コンテナ内で `make md-mermaid-lint-ci` を呼び出します。 |
+| `make md-lint-ci` | `markdownlint-cli2` を実行後、mermaid 構文 Lint を実行します。 | CI 用ターゲットです。`vendor/`、`node_modules/`、`.git/` を除外します。 |
+| `make md-mermaid-lint-ci` | `scripts/mermaid-lint.mjs`（実 `mermaid.parse`）で ` ```mermaid ` フェンスを検証します。 | CI 用ターゲット。markdownlint は図の文法を見ません。 |
 | `make md-fix-ci` | `markdownlint-cli2 --fix` で `**/*.md` を直接修正します。 | CI 用ターゲットです。`vendor/`、`node_modules/`、`.git/` を除外します。 |
 
 ## `.makefiles/security` 系

--- a/.makefiles/README.md
+++ b/.makefiles/README.md
@@ -199,9 +199,11 @@ This group handles linting and auto-fixing of Markdown files.
 
 | Command | Description | Notes |
 | --- | --- | --- |
-| `make md-lint` | Lints Markdown files. | Invokes `make md-lint-ci` inside the `node_tool_runner` container. |
+| `make md-lint` | Lints Markdown (markdownlint + mermaid syntax). | Invokes `make md-lint-ci` inside the `node_tool_runner` container. |
 | `make md-fix` | Auto-fixes Markdown files. | Invokes `make md-fix-ci` inside the `node_tool_runner` container. |
-| `make md-lint-ci` | Lints `**/*.md` directly with `markdownlint-cli2`. | CI target. Excludes `vendor/`, `node_modules/`, `.git/`. |
+| `make md-mermaid-lint` | Validates only the ` ```mermaid ` fences. | Invokes `make md-mermaid-lint-ci` inside the `node_tool_runner` container. |
+| `make md-lint-ci` | Runs `markdownlint-cli2` then the mermaid syntax lint. | CI target. Excludes `vendor/`, `node_modules/`, `.git/`. |
+| `make md-mermaid-lint-ci` | Validates ` ```mermaid ` fences with `scripts/mermaid-lint.mjs` (real `mermaid.parse`). | CI target. markdownlint never checks diagram grammar. |
 | `make md-fix-ci` | Fixes `**/*.md` directly with `markdownlint-cli2 --fix`. | CI target. Excludes `vendor/`, `node_modules/`, `.git/`. |
 
 ## `.makefiles/security` group

--- a/.makefiles/markdown/lint.mk
+++ b/.makefiles/markdown/lint.mk
@@ -6,7 +6,7 @@
 # -----CI内で実行するコマンド群-----
 .PHONY: md-lint-ci ## MarkdownのLintを実行(CI用)
 .PHONY: md-fix-ci ## MarkdownのLint自動修正を実行(CI用)
-.PHONY: md-markdownlint-ci
+.PHONY: md-markdownlint-ci ## markdownlint-cli2 で Markdown 体裁を Lint(CI用)
 .PHONY: md-mermaid-lint-ci ## Mermaid 図の構文Lintを実行(CI用)
 
 # -----Dockerコンテナ内で実行するコマンド群-----
@@ -23,7 +23,7 @@ md-mermaid-lint:
 # markdownlint-cli2 の ignore 記法は "#glob"。Make 変数代入では # がコメント開始になるため \# でエスケープする。
 MD_GLOBS := "**/*.md" "\#vendor/**" "\#**/node_modules/**" "\#.git/**" "\#docs/portal/guides/**" "\#docs/coverage/**" "\#docs/db-schema/**" "\#AGENTS.md"
 
-# markdownlint（体裁）と mermaid（図の構文）の両方を通す。どちらかが落ちれば md-lint-ci も落ちる。
+# markdownlint（体裁）と mermaid（図の構文）の両方を通す。
 md-lint-ci: md-markdownlint-ci md-mermaid-lint-ci
 
 md-markdownlint-ci:

--- a/.makefiles/markdown/lint.mk
+++ b/.makefiles/markdown/lint.mk
@@ -1,10 +1,13 @@
 ## Markdownに対するLint/Fixコマンド群
 # -----Dockerコンテナ内で実行するコマンド群-----
-.PHONY: md-lint ## MarkdownのLintを実行
+.PHONY: md-lint ## MarkdownのLintを実行（markdownlint + mermaid 構文検証）
 .PHONY: md-fix ## MarkdownのLint自動修正を実行
+.PHONY: md-mermaid-lint ## Mermaid 図の構文Lintのみを実行
 # -----CI内で実行するコマンド群-----
 .PHONY: md-lint-ci ## MarkdownのLintを実行(CI用)
 .PHONY: md-fix-ci ## MarkdownのLint自動修正を実行(CI用)
+.PHONY: md-markdownlint-ci
+.PHONY: md-mermaid-lint-ci ## Mermaid 図の構文Lintを実行(CI用)
 
 # -----Dockerコンテナ内で実行するコマンド群-----
 md-lint:
@@ -13,12 +16,22 @@ md-lint:
 md-fix:
 	@docker compose run --rm node_tool_runner make md-fix-ci
 
+md-mermaid-lint:
+	@docker compose run --rm node_tool_runner make md-mermaid-lint-ci
+
 # -----CI内で実行するコマンド群-----
 # markdownlint-cli2 の ignore 記法は "#glob"。Make 変数代入では # がコメント開始になるため \# でエスケープする。
 MD_GLOBS := "**/*.md" "\#vendor/**" "\#**/node_modules/**" "\#.git/**" "\#docs/portal/guides/**" "\#docs/coverage/**" "\#docs/db-schema/**" "\#AGENTS.md"
 
-md-lint-ci:
+# markdownlint（体裁）と mermaid（図の構文）の両方を通す。どちらかが落ちれば md-lint-ci も落ちる。
+md-lint-ci: md-markdownlint-ci md-mermaid-lint-ci
+
+md-markdownlint-ci:
 	markdownlint-cli2 $(MD_GLOBS)
+
+# Markdown 内の ```mermaid フェンスを実 mermaid パーサで構文検証する（markdownlint は図の中身を見ない）。
+md-mermaid-lint-ci:
+	node scripts/mermaid-lint.mjs
 
 md-fix-ci:
 	markdownlint-cli2 --fix $(MD_GLOBS)

--- a/docker/tools/README.ja.md
+++ b/docker/tools/README.ja.md
@@ -36,7 +36,8 @@ OpenAPI ドキュメント処理とポータルフロントエンドのバンド
 |`redocly-cli`|OpenAPI YAML のバンドル（`$ref` 解決）と HTML ドキュメント生成|
 |`js-yaml`|ポータルドキュメント生成スクリプト用の YAML 処理|
 |`esbuild`|ポータルフロントエンド（`docs/portal/src/main.jsx`）を `docs/portal/dist/` へバンドル（`make gen-portal-build`）|
-|`react` / `react-dom` / `marked` / `fuse.js` / `mermaid` / `highlight.js`|esbuild がバンドルするポータルフロントエンドの実行時ライブラリ（従来の CDN + ブラウザ内 Babel 構成を置き換え）|
+|`react` / `react-dom` / `marked` / `fuse.js` / `mermaid` / `highlight.js`|esbuild がバンドルするポータルフロントエンドの実行時ライブラリ（従来の CDN + ブラウザ内 Babel 構成を置き換え）。`mermaid` は `scripts/mermaid-lint.mjs` でも再利用し ` ```mermaid ` フェンスを構文検証する（`make md-lint`）。|
+|`linkedom`|`mermaid.parse` を Node で動かすためのヘッドレス DOM。Markdown 内 mermaid の構文 Lint（`scripts/mermaid-lint.mjs`）で使用|
 
 ## python_tools
 

--- a/docker/tools/README.md
+++ b/docker/tools/README.md
@@ -36,7 +36,8 @@ Tools for OpenAPI document processing and portal frontend bundling:
 |`redocly-cli`|Bundle OpenAPI YAML (`$ref` resolution) and generate HTML docs|
 |`js-yaml`|YAML processing for portal doc generation scripts|
 |`esbuild`|Bundle the portal frontend (`docs/portal/src/main.jsx`) into `docs/portal/dist/` (`make gen-portal-build`)|
-|`react` / `react-dom` / `marked` / `fuse.js` / `mermaid` / `highlight.js`|Portal frontend runtime libraries bundled by esbuild (replacing the former CDN + in-browser Babel setup)|
+|`react` / `react-dom` / `marked` / `fuse.js` / `mermaid` / `highlight.js`|Portal frontend runtime libraries bundled by esbuild (replacing the former CDN + in-browser Babel setup). `mermaid` is also reused by `scripts/mermaid-lint.mjs` to validate ` ```mermaid ` fences (`make md-lint`).|
+|`linkedom`|Headless DOM that lets `mermaid.parse` run in Node for the Markdown mermaid syntax lint (`scripts/mermaid-lint.mjs`)|
 
 ## python_tools
 

--- a/docker/tools/package-lock.json
+++ b/docker/tools/package-lock.json
@@ -11,6 +11,7 @@
         "fuse.js": "6.6.2",
         "highlight.js": "11.9.0",
         "js-yaml": "4.2.0",
+        "linkedom": "0.18.5",
         "marked": "15.0.12",
         "mermaid": "10.9.6",
         "react": "18.3.1",
@@ -504,6 +505,12 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -531,6 +538,40 @@
       "dependencies": {
         "layout-base": "^1.0.0"
       }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "license": "MIT"
     },
     "node_modules/cytoscape": {
       "version": "3.34.0",
@@ -1076,6 +1117,47 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.4.11",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
@@ -1085,11 +1167,37 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/elkjs": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
       "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
       "license": "EPL-2.0"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -1148,6 +1256,31 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -1243,6 +1376,19 @@
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
       "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
       "license": "MIT"
+    },
+    "node_modules/linkedom": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.5.tgz",
+      "integrity": "sha512-JGLaGGtqtu+eOhYrC1wkWYTBcpVWL4AsnwAtMtgO1Q0gI0PuPJKI0zBBE+a/1BrhOE3Uw8JI/ycByAv5cLrAuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^9.1.0",
+        "uhyphen": "^0.2.0"
+      }
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -1802,6 +1948,18 @@
       "integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==",
       "license": "MIT"
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1880,6 +2038,12 @@
       "engines": {
         "node": ">=6.10"
       }
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "license": "ISC"
     },
     "node_modules/unist-util-stringify-position": {
       "version": "3.0.3",

--- a/docker/tools/package.json
+++ b/docker/tools/package.json
@@ -7,6 +7,7 @@
     "fuse.js": "6.6.2",
     "highlight.js": "11.9.0",
     "js-yaml": "4.2.0",
+    "linkedom": "0.18.5",
     "marked": "15.0.12",
     "mermaid": "10.9.6",
     "react": "18.3.1",

--- a/docs/design/job.md
+++ b/docs/design/job.md
@@ -165,7 +165,7 @@ sequenceDiagram
     Run->>J: Execute(ctx, args)  // span started, usecase called
     J-->>Run: nil / error
     Run-->>Hook: result
-    Hook->>Hook: done <- result; close(done); sd.Shutdown()
+    Hook->>Hook: done <- result, close(done), sd.Shutdown()
     CLI->>CLI: err := <-done (or waitCtx.Done() on timeout)
     CLI->>DI: gracefulStop → stop(ctx) = app.Stop (≤30s)
     CLI-->>Cobra: return err (exit code)

--- a/docs/design/outbox.md
+++ b/docs/design/outbox.md
@@ -1,0 +1,268 @@
+# Outbox Subsystem Design Reference
+
+[Outbox Store README](../../internal/usecase/boundary/outbox/README.md) | 日本語: [outbox.ja.md](../ja/design/outbox.ja.md)
+
+This document consolidates the transactional outbox subsystem's **role theory, state transitions, implementation locations, what an integrator must implement, and glossary** into a single reference, derived from a close reading of the implementation. For per-package overviews see the READMEs; for the adoption rationale see the ADR in `docs/decisions.md`.
+
+---
+
+## 1. Role theory (what, and what for)
+
+The transactional outbox exists to **eliminate the dual-write anomaly**: when a request both changes domain state *and* must notify the outside world, writing to the DB and publishing to an external endpoint are two separate failures-points. If publish happens after commit it can be lost; if it happens before commit it can be a phantom. The outbox folds the "intent to publish" into **the same DB transaction as the domain change** (one outbox row INSERT), then a separate **relay** asynchronously delivers those rows with **at-least-once** semantics.
+
+So the subsystem splits into two halves that never run in the same breath:
+
+- **emit** — synchronous, inside the caller's business transaction. Records the event as a row.
+- **relay / gc / replay** — asynchronous, in a dedicated long-running process. Drains, prunes, and recovers rows.
+
+Responsibility split (who owns what):
+
+| Component | Layer | Responsibility | Does NOT hold |
+| --- | --- | --- | --- |
+| **EmitUsecase** (`emit.go`) | usecase | INSERT one row in the caller's tx; capture `traceparent` into headers | transaction control (caller owns it), delivery |
+| **RelayUsecase** (`relay.go`) | usecase | per-batch claim → publish → mark (`published` / attempts++ / `dead`) in one tx; record lag | loop cadence, broker specifics |
+| **GCUsecase** / **ReplayUsecase** (`gc.go` / `replay.go`) | usecase | prune old `published` rows / return `dead` rows to `pending` | scheduling, CLI parsing |
+| **Store** / **Publisher** / **tx.Manager** | usecase/boundary | the seam: persistence port / send port / transaction port | implementations |
+| **Engine** (`controller/outbox/relay.go`) | controller | poll-loop orchestration: cadence, sleep/backoff, drain on ctx done, span | claim/publish/mark business (delegated to usecase) |
+| **outbox-gc job** (`controller/job/outboxgc`) | controller | one-shot GC entry point for an external scheduler | the loop (it is a cron, not a daemon) |
+| **httpPublisher** (`infrastructure/publisher`) | infrastructure | `Publisher` HTTP impl: POST + `Idempotency-Key` + non-standard client profile | retry (the poll loop is the retry) |
+| **outbox store** (`infrastructure/rdb/system_query/outbox`) | infrastructure | `Store` impl over sqlc gen + `pgerror.NormalizeError` | business decisions |
+| **DI / cli / cmd** | di / cli / cmd(main) | relay-process composition / subcommands / lifecycle | business logic |
+| **OutboxConfig** | config | relay tuning (`OUTBOX_*`) | broker/endpoint internals |
+
+Design invariants:
+
+- **Dual-write avoidance**: `Emit` is called *inside* the same `tx.Manager.Do` as the domain change, so a rolled-back business tx discards its outbox row too — no lost and no phantom events.
+- **At-least-once, retry-by-poll**: a failed publish is **not** rolled back; the row stays `pending` with `attempts++`, and the *next poll is the retry*. Transport-level retry is therefore disabled (`MaxAttempts=1`, D10) to avoid double-retry.
+- **Multi-instance safety**: `ClaimPending` uses `FOR UPDATE SKIP LOCKED` and the whole claim→publish→mark runs in one tx, so a row's lock is held until delivery settles — two relay instances never publish the same row.
+- **Receiver idempotency**: each row carries a stable `message_id` (assigned at INSERT), propagated as the HTTP `Idempotency-Key`; at-least-once on the send side is made exactly-once-effect by the receiver deduping on it.
+- **Trace continuity**: `Emit` captures the current span's `traceparent` into `headers`; the publisher replays it so the receiver joins the originating trace.
+
+---
+
+## 2. State transitions
+
+### 2.1 Outbox row lifecycle (`status` column: `pending` / `published` / `dead`)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending: Emit INSERT (in business tx)<br/>status=pending, attempts=0
+    Pending --> Published: publish OK → MarkPublished<br/>published_at=NOW (idempotent on status=pending)
+    Pending --> Pending: publish fails → MarkFailed<br/>attempts++, last_error set (stays pending, retried next poll)
+    Pending --> Dead: MarkFailed returns attempts ≥ MaxAttempts(10) → MarkDead<br/>(IncDead metric + warn log)
+    Dead --> Pending: ReplayDead (operator) → attempts=0, last_error=NULL
+    Published --> [*]: GC deletes rows older than now-Retention(7d)
+
+    note right of Pending
+      failed is NOT a status value. It is a pending row
+      whose attempts / last_error advanced. Only 3 statuses exist
+      (CHECK constraint = pending / published / dead).
+    end note
+    note right of Dead
+      Terminal until a human replays. Surfaced by the
+      outbox.dead counter, recovered via the CLI replay subcommand.
+    end note
+```
+
+### 2.2 Relay poll loop (`Engine.Run` + `RelayUsecase.RelayBatch`)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Polling: Engine.Run(ctx)
+    Polling --> Batch: RelayBatch(BatchSize) in 1 tx<br/>ClaimPending → deliver each → mark
+    Batch --> RecordLag: success → observeLag (best-effort, loop continues on failure)
+    RecordLag --> Continue: Claimed equals BatchSize and Published over 0
+    RecordLag --> WaitPoll: empty / partial / full batch with 0 published
+    Batch --> WaitBackoff: RelayBatch error (DB-level only) → log
+    Continue --> Polling: no sleep (drain aggressively while work remains)
+    WaitPoll --> Polling: Sleeper.Sleep(PollInterval = 1s)
+    WaitBackoff --> Polling: Sleeper.Sleep(ErrorBackoff = 5s)
+    Polling --> [*]: ctx done → return nil (graceful)
+
+    note right of WaitPoll
+      A full batch that published nothing is forced to wait,
+      otherwise a downstream outage hot-loops and dead-letters
+      the whole batch instantly.
+    end note
+    note right of Batch
+      A publish failure does NOT roll back the tx (row kept for
+      next poll). Only a DB or mark failure rolls back and is
+      returned as a loop error.
+    end note
+```
+
+---
+
+## 3. Implementation locations (where in the architecture it lives and acts)
+
+### 3.1 Package placement and dependency direction
+
+```mermaid
+flowchart TD
+    subgraph cmdL["cmd (main)"]
+        CMD["cmd/outbox_relay.go<br/>outbox-relay + replay subcommand / SIGTERM"]
+        CMDJOB["cmd/job.go → job outbox-gc"]
+    end
+    subgraph cliL["internal/cli/outbox"]
+        CLIR["relay.go: RunRelay (start → wait ctx → stop w/ grace)"]
+        CLIP["replay.go: RunReplayWith (parse UUID → di.RunOutboxReplay)"]
+    end
+    subgraph diL["internal/di"]
+        DIM["module/outboxrelay.go: OutboxRelayModule (relay-only process)"]
+        DIP["module/outboxpublisher.go: outboxPublisherModule (non-standard profile)"]
+        DIPER["module/persistence.go: outbox Store (shared)"]
+        DIJOB["module/job.go: outbox-gc job (shared, main server)"]
+        DIH["outboxrelay/hook: RegisterRelayHooks → SupervisedRunner"]
+        DIREP["outboxrelay.go: RunOutboxReplay (temp app, no relay loop)"]
+    end
+    subgraph ctrlL["internal/controller"]
+        ENG["outbox/relay.go: Engine (poll loop, sleep/backoff, span)"]
+        GCJ["job/outboxgc: GC job (one-shot)"]
+    end
+    subgraph ucL["internal/usecase/outbox"]
+        EMIT["emit.go: EmitUsecase"]
+        REL["relay.go: RelayUsecase + deliver"]
+        GC["gc.go: GCUsecase"]
+        RPL["replay.go: ReplayUsecase"]
+    end
+    subgraph seamL["internal/usecase/boundary"]
+        STORE["outbox.Store (Insert/Claim/Mark*/Replay/Delete/Oldest)"]
+        PUB["publisher.Publisher (Publish)"]
+        TXM["tx.Manager (Do / DoWithResult)"]
+        CLK["clock.Clock / Sleeper"]
+    end
+    subgraph infraL["internal/infrastructure"]
+        SQ["rdb/system_query/outbox: Store impl (sqlc gen + pgerror)"]
+        HTTP["publisher/http_publisher.go: httpPublisher (POST, Idempotency-Key)"]
+    end
+    subgraph crossL["cross-cutting"]
+        OBS["observability: OutboxMetrics (outbox.lag_seconds / outbox.dead)"]
+        CFG["config: OutboxConfig (OUTBOX_*)"]
+        HC["infrastructure/httpclient (downstream=outbox)"]
+    end
+
+    CMD --> CLIR
+    CMD --> CLIP
+    CMDJOB --> GCJ
+    CLIR --> DIM
+    CLIP --> DIREP
+    DIM --> DIP
+    DIM --> ENG
+    DIM --> DIH
+    DIH --> ENG
+    DIPER --> SQ
+    DIJOB --> GCJ
+    ENG --> REL
+    GCJ --> GC
+    DIREP --> RPL
+    EMIT --> STORE
+    REL --> STORE
+    REL --> PUB
+    REL --> TXM
+    REL --> OBS
+    GC --> STORE
+    RPL --> STORE
+    SQ -- implements --> STORE
+    HTTP -- implements --> PUB
+    HTTP --> HC
+    DIP --> HTTP
+    ENG --> CLK
+    DIM --> CFG
+
+    classDef done fill:#e6ffed,stroke:#2da44e;
+    class CMD,CMDJOB,CLIR,CLIP,DIM,DIP,DIPER,DIJOB,DIH,DIREP,ENG,GCJ,EMIT,REL,GC,RPL,STORE,PUB,TXM,CLK,SQ,HTTP,OBS,CFG,HC done;
+```
+
+> Green = provided by the subsystem. Dependencies point inward: `controller`/`infrastructure` → `usecase`/`boundary`, never the reverse. The relay's non-standard HTTP profile (`MaxAttempts=1`, `PropagateTrace=false`, `AllowPrivateNetwork=false`) is contributed by `outboxPublisherModule`, which is **nested inside `OutboxRelayModule`** so it cannot leak into other processes.
+
+### 3.2 Per-batch action sequence (relay process)
+
+```mermaid
+sequenceDiagram
+    participant E as Engine (controller)
+    participant U as RelayUsecase
+    participant T as tx.Manager
+    participant S as Store (infra/rdb)
+    participant P as httpPublisher (infra)
+    participant R as Receiver (external)
+    E->>U: RelayBatch(BatchSize)
+    U->>T: DoWithResult(fn)  // one tx around the whole batch
+    T->>S: ClaimPending(limit)  // FOR UPDATE SKIP LOCKED
+    S-->>T: []PendingMessage
+    loop each row
+        U->>P: Publish(Message{MessageID, EventType, Payload, Headers})
+        P->>R: POST endpoint (Content-Type json, Idempotency-Key=message_id, traceparent)
+        alt 2xx
+            R-->>P: ok
+            U->>S: MarkPublished(id)
+        else non-2xx / transport error
+            R-->>P: error (apperror)
+            U->>S: MarkFailed(id, err) → attempts
+            opt attempts ≥ MaxAttempts(10)
+                U->>S: MarkDead(id) + IncDead + warn
+            end
+        end
+    end
+    T-->>U: RelayResult{Claimed, Published}
+    U-->>E: result
+    E->>U: RecordLag()  // best-effort SLI
+    E->>E: sleep decision (continue / PollInterval / ErrorBackoff)
+```
+
+---
+
+## 4. What an integrator implements (the parts the subsystem does not provide)
+
+The subsystem ships the **full machinery**: emit/relay/gc/replay usecases, the RDB `Store`, the HTTP `Publisher`, the relay `Engine`, the GC job, DI wiring, and the `outbox-relay` / `replay` / `job outbox-gc` entry points. No event flows by default — the integrator wires the two open ends (the producing call and the consuming endpoint) and operates the processes.
+
+```mermaid
+flowchart LR
+    EM["① call Emit in the business tx<br/>(alongside the domain change)"]:::need
+    PL["② define payload + event_type<br/>(snapshot + version, self-contained)"]:::need
+    RC["③ build the receiver endpoint<br/>(idempotent on Idempotency-Key)"]:::need
+    CF["④ set OUTBOX_ENDPOINT (+ tuning)"]:::need
+    DP["⑤ deploy the relay process<br/>(cmd outbox-relay, resident)"]:::need
+    GC["⑥ schedule GC<br/>(cron → cmd job outbox-gc)"]:::need
+    OP["⑦ operate dead rows<br/>(monitor outbox.dead → replay)"]:::need
+    EM --> PL --> RC --> CF --> DP --> GC --> OP
+    classDef need fill:#fff8c5,stroke:#bf8700;
+```
+
+| # | Required implementation | Location / how | Reference |
+| --- | --- | --- | --- |
+| ① | call `EmitUsecase.Emit` inside the same `tx.Manager.Do` as the domain write | the usecase that mutates the aggregate | `emit.go` `EmitInput` |
+| ② | choose `EventType` (`+version`) and marshal a **self-contained snapshot** payload; do NOT put `Authorization`/`Cookie` in `Headers` (they are sent verbatim) | caller of `Emit` | `EmitInput.Payload` / `.Headers` doc |
+| ③ | a receiving endpoint that **dedupes on `Idempotency-Key`** (= `message_id`) and returns 2xx only on durable accept | external service | `httpPublisher.Publish` |
+| ④ | `OUTBOX_ENDPOINT` (required; empty/invalid URL = relay refuses to start) + optional `OUTBOX_POLL_INTERVAL` / `OUTBOX_ERROR_BACKOFF` / `OUTBOX_BATCH_SIZE` | `env/` & IaC | `OutboxConfig` defaults |
+| ⑤ | run `cmd outbox-relay` as a resident process (it stays up until SIGTERM, drains on stop) | deployment / IaC | `cmd/outbox_relay.go` |
+| ⑥ | schedule `cmd job outbox-gc [--batch-size=N]` (k8s CronJob / cron) to prune `published` rows past retention | scheduler | `controller/job/outboxgc` |
+| ⑦ | alert on the `outbox.dead` counter / `outbox.lag_seconds` gauge and run `outbox-relay replay [--message-id=<uuid>]` to recover | runbook | `cmd outbox-relay replay` |
+
+> The relay, GC, and replay all reuse the shared infra wiring; only the resident relay process carries the non-standard HTTP publisher profile. The GC job lives in the main server's job group, so `cmd job outbox-gc` is available from the same binary — it does not run on its own.
+
+---
+
+## 5. Glossary
+
+| Term | Meaning |
+| --- | --- |
+| **transactional outbox** | The pattern of recording "intent to publish" as a DB row in the same tx as the domain change, then delivering it asynchronously. Avoids the dual-write anomaly. |
+| **emit** | The synchronous half: `EmitUsecase.Emit` INSERTs one row inside the caller's business tx (`internal/usecase/outbox/emit.go`). |
+| **relay** | The asynchronous half: a resident `Engine` poll loop that claims, publishes, and marks pending rows (`controller/outbox` + `usecase/outbox/relay.go`). |
+| **Store** | The persistence port for the outbox table (`usecase/boundary/outbox`). Implemented over sqlc gen in `infrastructure/rdb/system_query/outbox`. |
+| **Publisher** | The send port (`usecase/boundary/publisher`). The HTTP impl POSTs to `OUTBOX_ENDPOINT`. |
+| **status** | The row's lifecycle column — exactly `pending` / `published` / `dead` (CHECK-constrained). There is no `failed` status; a failed publish stays `pending`. |
+| **attempts / last_error** | Publish try count and latest failure reason. `MarkFailed` advances both; the row stays `pending` until `attempts ≥ MaxAttempts`. |
+| **MaxAttempts** | Publish tries before a row is marked `dead` (`DefaultMaxAttempts = 10`). |
+| **dead** | A row that exhausted `MaxAttempts`. Terminal until an operator replays it. Counted by `outbox.dead`. |
+| **replay** | Returning `dead` rows to `pending` (`attempts=0`, `last_error=NULL`). `ReplayUsecase` / `outbox-relay replay [--message-id]`. |
+| **GC (SweepPublished)** | Deleting `published` rows older than `Retention` (`DefaultRetention = 7d`) in batches of `DefaultGCBatchSize = 10000`. Run via `cmd job outbox-gc`. |
+| **message_id** | The stable per-row UUID (assigned at INSERT). Propagated as the HTTP `Idempotency-Key` for receiver dedup. |
+| **traceparent** | W3C trace context captured into `headers` at emit time and replayed by the publisher, so the receiver joins the originating trace. |
+| **FOR UPDATE SKIP LOCKED** | The claim mechanism that makes multi-instance relay safe — a locked row is skipped by other instances until the holding tx settles. |
+| **retry-by-poll** | The relay's at-least-once mechanism: a publish failure is left `pending` and retried on the next poll. Transport retry is disabled (`MaxAttempts=1`) to avoid doubling it (D10). |
+| **PollInterval / ErrorBackoff** | Sleep after a non-progressing poll (`OUTBOX_POLL_INTERVAL = 1s`) / after a DB-level `RelayBatch` error (`OUTBOX_ERROR_BACKOFF = 5s`). A full-but-zero-published batch is forced to wait. |
+| **BatchSize** | Rows claimed per poll (`OUTBOX_BATCH_SIZE = 100`; clamped to `DefaultBatchSize = 100` if ≤ 0). |
+| **outbox.lag_seconds / outbox.dead** | The subsystem's own SLIs (meter `go-boilerplate/outbox`): age of the oldest pending row / count of rows dead-lettered. Publish latency/errors come from the `httpclient` downstream=`outbox` instrumentation. |
+| **SupervisedRunner** | The lifecycle helper (`di/lifecycle`) that runs the relay loop on OnStart and cancels + drains it on OnStop. |
+| **OutboxRelayModule** | The fx module for the relay-only process; nests `outboxPublisherModule` so the non-standard HTTP profile never leaks elsewhere. |

--- a/docs/design/rest.md
+++ b/docs/design/rest.md
@@ -38,7 +38,7 @@ Design principles (invariants):
 stateDiagram-v2
     [*] --> Building: NewApplicationCore() → fx.New (config→logging→o11y→db→infra→usecase→controller→server)
     Building --> Wired: BindHandler×N (RegisterHandlers) + ApplyExtends (sort & apply middleware) + RegisterHTTPServerHooks
-    Wired --> Listening: fx OnStart → net listen :port → go e.Start()
+    Wired --> Listening: fx OnStart → net listen port → go e.Start()
     Listening --> Serving: request → middleware chain → handler → response (resident)
     Serving --> Listening: response sent
     Listening --> Draining: SIGINT/SIGTERM → ctx.Done() in RunServer

--- a/docs/ja/design/job.ja.md
+++ b/docs/ja/design/job.ja.md
@@ -165,7 +165,7 @@ sequenceDiagram
     Run->>J: Execute(ctx, args)  // span 開始, usecase 呼び出し
     J-->>Run: nil / error
     Run-->>Hook: result
-    Hook->>Hook: done <- result; close(done); sd.Shutdown()
+    Hook->>Hook: done <- result, close(done), sd.Shutdown()
     CLI->>CLI: err := <-done（timeout 時は waitCtx.Done()）
     CLI->>DI: gracefulStop → stop(ctx) ＝ app.Stop（≤30s）
     CLI-->>Cobra: return err（終了コード）

--- a/docs/ja/design/outbox.ja.md
+++ b/docs/ja/design/outbox.ja.md
@@ -1,0 +1,266 @@
+# Outbox サブシステム設計リファレンス
+
+[Outbox Store README（日本語）](../../../internal/usecase/boundary/outbox/README.ja.md) | English: [outbox.md](../../design/outbox.md)
+
+本書は transactional outbox サブシステムの **役割論・状態遷移・実装箇所・integrator が書く箇所・用語** を、実装を精査して 1 枚にまとめた参照資料です。各パッケージの概要は README、採用判断は `docs/decisions.md` の ADR を参照。
+
+---
+
+## 1. 役割論（なにが・なんのために）
+
+transactional outbox は **dual-write 異常の排除** のために存在します。ドメイン状態を変更し、かつ外部へ通知する必要があるとき、「DB への書き込み」と「外部エンドポイントへの publish」は別々の失敗点です。commit 後に publish すれば lost し、commit 前に publish すれば phantom になる。outbox は「publish する意図」を **ドメイン変更と同一 DB トランザクション** に畳み込み（outbox 行を 1 行 INSERT）、その後に別の **relay** が **at-least-once** で非同期送出します。
+
+サブシステムは、決して同じ呼吸で走らない 2 つの半身に分かれます。
+
+- **emit** — 同期。呼び出し側の業務 tx 内。イベントを 1 行として記録する。
+- **relay / gc / replay** — 非同期。専用の常駐プロセス内。行を捌き・刈り・回復する。
+
+責務分担（誰がなにを持つか）:
+
+| コンポーネント | 層 | 責務 | 持たないもの |
+| --- | --- | --- | --- |
+| **EmitUsecase**（`emit.go`） | usecase | 呼び出し側 tx 内で 1 行 INSERT、`traceparent` を headers へ capture | tx 制御（呼び出し側が持つ）・送出 |
+| **RelayUsecase**（`relay.go`） | usecase | バッチ単位で claim → publish → mark（`published` / attempts++ / `dead`）を 1 tx で・lag 記録 | ループ周期・broker 詳細 |
+| **GCUsecase** / **ReplayUsecase**（`gc.go` / `replay.go`） | usecase | 古い `published` 行の剪定 / `dead` 行を `pending` へ戻す | スケジューリング・CLI パース |
+| **Store** / **Publisher** / **tx.Manager** | usecase/boundary | seam: 永続化ポート / 送出ポート / トランザクションポート | 実装 |
+| **Engine**（`controller/outbox/relay.go`） | controller | poll ループの統括: 周期・sleep/backoff・ctx 完了での drain・span | claim/publish/mark の業務（usecase へ委譲） |
+| **outbox-gc job**（`controller/job/outboxgc`） | controller | 外部スケジューラ向けの one-shot GC 入口 | ループ自体（daemon ではなく cron） |
+| **httpPublisher**（`infrastructure/publisher`） | infrastructure | `Publisher` の HTTP 実装: POST + `Idempotency-Key` + 非標準 client profile | retry（poll ループが retry 本体） |
+| **outbox store**（`infrastructure/rdb/system_query/outbox`） | infrastructure | sqlc gen + `pgerror.NormalizeError` 上の `Store` 実装 | 業務判断 |
+| **DI / cli / cmd** | di / cli / cmd(main) | relay プロセスの合成 / サブコマンド / ライフサイクル | 業務ロジック |
+| **OutboxConfig** | config | relay チューニング（`OUTBOX_*`） | broker/endpoint の内部 |
+
+設計上の不変条件:
+
+- **dual-write 回避**: `Emit` はドメイン変更と同じ `tx.Manager.Do` の **中で** 呼ばれるため、業務 tx が巻き戻れば outbox 行も破棄される — lost も phantom も起きない。
+- **at-least-once / retry-by-poll**: publish 失敗は巻き戻さない。行は `pending` のまま `attempts++` され、*次 poll が retry 本体*。よって transport 層 retry は二重化を避けるため無効（`MaxAttempts=1`、D10）。
+- **多インスタンス安全**: `ClaimPending` は `FOR UPDATE SKIP LOCKED` を用い、claim→publish→mark 全体を 1 tx で回すため、行ロックは送出が確定するまで保持される — 2 つの relay が同一行を publish しない。
+- **受信側冪等**: 各行は INSERT 時採番の安定 `message_id` を持ち、HTTP `Idempotency-Key` として伝搬。送出側 at-least-once を受信側 dedup で実効 exactly-once 化する。
+- **trace 継続**: `Emit` は現在 span の `traceparent` を `headers` へ capture し、publisher が再生するため受信側が起点 trace に繋がる。
+
+---
+
+## 2. 状態遷移
+
+### 2.1 outbox 行ライフサイクル（`status` 列: `pending` / `published` / `dead`）
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending: Emit INSERT（業務 tx 内）<br/>status=pending, attempts=0
+    Pending --> Published: publish 成功 → MarkPublished<br/>published_at=NOW（status=pending に対し冪等）
+    Pending --> Pending: publish 失敗 → MarkFailed<br/>attempts++, last_error 記録（pending のまま・次 poll で再送）
+    Pending --> Dead: MarkFailed が attempts ≥ MaxAttempts(10) を返す → MarkDead<br/>（IncDead メトリクス + warn ログ）
+    Dead --> Pending: ReplayDead（運用者）→ attempts=0, last_error=NULL
+    Published --> [*]: GC が now-Retention(7d) より古い行を削除
+
+    note right of Pending
+      failed は status 値ではない。attempts / last_error が
+      進んだ pending 行のこと。status は 3 値のみ
+      （CHECK 制約 = pending / published / dead）。
+    end note
+    note right of Dead
+      replay されるまで終端。outbox.dead カウンタで顕在化し、
+      CLI replay サブコマンドで回復する。
+    end note
+```
+
+### 2.2 relay poll ループ（`Engine.Run` + `RelayUsecase.RelayBatch`）
+
+```mermaid
+stateDiagram-v2
+    [*] --> Polling: Engine.Run(ctx)
+    Polling --> Batch: RelayBatch(BatchSize) を 1 tx で<br/>ClaimPending → 各 deliver → mark
+    Batch --> RecordLag: 成功 → observeLag（best-effort・失敗時もループ継続）
+    RecordLag --> Continue: Claimed が BatchSize と等しく Published が 1 以上
+    RecordLag --> WaitPoll: 空振り / 部分消化 / 満杯だが publish 0 件
+    Batch --> WaitBackoff: RelayBatch エラー（DB レベルのみ）→ log
+    Continue --> Polling: 待機なし（仕事が残る間は積極的に捌く）
+    WaitPoll --> Polling: Sleeper.Sleep(PollInterval = 1s)
+    WaitBackoff --> Polling: Sleeper.Sleep(ErrorBackoff = 5s)
+    Polling --> [*]: ctx 完了 → nil を返す（graceful）
+
+    note right of WaitPoll
+      publish 0 件の満杯バッチは必ず待機させる。さもないと
+      下流停止時にホットループしてバッチ全体を即時 dead 化する。
+    end note
+    note right of Batch
+      publish 失敗は tx を巻き戻さない（行は次 poll 用に保持）。
+      DB / mark 失敗のみ巻き戻し、ループエラーとして返す。
+    end note
+```
+
+---
+
+## 3. 実装箇所（アーキテクチャ上のどこに在り、どう働くか）
+
+### 3.1 パッケージ配置と依存方向
+
+```mermaid
+flowchart TD
+    subgraph cmdL["cmd (main)"]
+        CMD["cmd/outbox_relay.go<br/>outbox-relay + replay サブコマンド / SIGTERM"]
+        CMDJOB["cmd/job.go → job outbox-gc"]
+    end
+    subgraph cliL["internal/cli/outbox"]
+        CLIR["relay.go: RunRelay（start → ctx 待ち → grace 付き stop）"]
+        CLIP["replay.go: RunReplayWith（UUID parse → di.RunOutboxReplay）"]
+    end
+    subgraph diL["internal/di"]
+        DIM["module/outboxrelay.go: OutboxRelayModule（relay 専用プロセス）"]
+        DIP["module/outboxpublisher.go: outboxPublisherModule（非標準 profile）"]
+        DIPER["module/persistence.go: outbox Store（共有）"]
+        DIJOB["module/job.go: outbox-gc job（共有・main server）"]
+        DIH["outboxrelay/hook: RegisterRelayHooks → SupervisedRunner"]
+        DIREP["outboxrelay.go: RunOutboxReplay（一時 app・relay ループ無し）"]
+    end
+    subgraph ctrlL["internal/controller"]
+        ENG["outbox/relay.go: Engine（poll ループ・sleep/backoff・span）"]
+        GCJ["job/outboxgc: GC job（one-shot）"]
+    end
+    subgraph ucL["internal/usecase/outbox"]
+        EMIT["emit.go: EmitUsecase"]
+        REL["relay.go: RelayUsecase + deliver"]
+        GC["gc.go: GCUsecase"]
+        RPL["replay.go: ReplayUsecase"]
+    end
+    subgraph seamL["internal/usecase/boundary"]
+        STORE["outbox.Store（Insert/Claim/Mark*/Replay/Delete/Oldest）"]
+        PUB["publisher.Publisher（Publish）"]
+        TXM["tx.Manager（Do / DoWithResult）"]
+        CLK["clock.Clock / Sleeper"]
+    end
+    subgraph infraL["internal/infrastructure"]
+        SQ["rdb/system_query/outbox: Store 実装（sqlc gen + pgerror）"]
+        HTTP["publisher/http_publisher.go: httpPublisher（POST, Idempotency-Key）"]
+    end
+    subgraph crossL["cross-cutting"]
+        OBS["observability: OutboxMetrics（outbox.lag_seconds / outbox.dead）"]
+        CFG["config: OutboxConfig（OUTBOX_*）"]
+        HC["infrastructure/httpclient（downstream=outbox）"]
+    end
+
+    CMD --> CLIR
+    CMD --> CLIP
+    CMDJOB --> GCJ
+    CLIR --> DIM
+    CLIP --> DIREP
+    DIM --> DIP
+    DIM --> ENG
+    DIM --> DIH
+    DIH --> ENG
+    DIPER --> SQ
+    DIJOB --> GCJ
+    ENG --> REL
+    GCJ --> GC
+    DIREP --> RPL
+    EMIT --> STORE
+    REL --> STORE
+    REL --> PUB
+    REL --> TXM
+    REL --> OBS
+    GC --> STORE
+    RPL --> STORE
+    SQ -- implements --> STORE
+    HTTP -- implements --> PUB
+    HTTP --> HC
+    DIP --> HTTP
+    ENG --> CLK
+    DIM --> CFG
+
+    classDef done fill:#e6ffed,stroke:#2da44e;
+    class CMD,CMDJOB,CLIR,CLIP,DIM,DIP,DIPER,DIJOB,DIH,DIREP,ENG,GCJ,EMIT,REL,GC,RPL,STORE,PUB,TXM,CLK,SQ,HTTP,OBS,CFG,HC done;
+```
+
+> 緑 = サブシステムが提供。依存は内向き: `controller`/`infrastructure` → `usecase`/`boundary`、逆は無い。relay の非標準 HTTP profile（`MaxAttempts=1`・`PropagateTrace=false`・`AllowPrivateNetwork=false`）は `outboxPublisherModule` が寄与し、これは **`OutboxRelayModule` の中に入れ子** にしてあるため他プロセスへ漏れない。
+
+### 3.2 バッチ単位のアクション列（relay プロセス）
+
+```mermaid
+sequenceDiagram
+    participant E as Engine (controller)
+    participant U as RelayUsecase
+    participant T as tx.Manager
+    participant S as Store (infra/rdb)
+    participant P as httpPublisher (infra)
+    participant R as Receiver (外部)
+    E->>U: RelayBatch(BatchSize)
+    U->>T: DoWithResult(fn)  // バッチ全体を 1 tx で囲う
+    T->>S: ClaimPending(limit)  // FOR UPDATE SKIP LOCKED
+    S-->>T: []PendingMessage
+    loop 各行
+        U->>P: Publish(Message{MessageID, EventType, Payload, Headers})
+        P->>R: POST endpoint (Content-Type json, Idempotency-Key=message_id, traceparent)
+        alt 2xx
+            R-->>P: ok
+            U->>S: MarkPublished(id)
+        else 非 2xx / transport 失敗
+            R-->>P: error (apperror)
+            U->>S: MarkFailed(id, err) → attempts
+            opt attempts ≥ MaxAttempts(10)
+                U->>S: MarkDead(id) + IncDead + warn
+            end
+        end
+    end
+    T-->>U: RelayResult{Claimed, Published}
+    U-->>E: result
+    E->>U: RecordLag()  // best-effort SLI
+    E->>E: sleep 判定（continue / PollInterval / ErrorBackoff）
+```
+
+---
+
+## 4. integrator が書く箇所（サブシステムが提供しない部分）
+
+サブシステムは **機構一式** を同梱します: emit/relay/gc/replay の各 usecase、RDB `Store`、HTTP `Publisher`、relay `Engine`、GC job、DI 結線、`outbox-relay` / `replay` / `job outbox-gc` の各入口。既定ではイベントは流れません — integrator が両端（生産する呼び出しと消費するエンドポイント）を結線し、プロセスを運用します。
+
+```mermaid
+flowchart LR
+    EM["① 業務 tx 内で Emit を呼ぶ<br/>（ドメイン変更と一緒に）"]:::need
+    PL["② payload + event_type を定義<br/>（snapshot + version の自己完結）"]:::need
+    RC["③ 受信エンドポイントを作る<br/>（Idempotency-Key で冪等）"]:::need
+    CF["④ OUTBOX_ENDPOINT を設定（+ tuning）"]:::need
+    DP["⑤ relay プロセスをデプロイ<br/>（cmd outbox-relay・常駐）"]:::need
+    GC["⑥ GC をスケジュール<br/>（cron → cmd job outbox-gc）"]:::need
+    OP["⑦ dead 行を運用<br/>（outbox.dead 監視 → replay）"]:::need
+    EM --> PL --> RC --> CF --> DP --> GC --> OP
+    classDef need fill:#fff8c5,stroke:#bf8700;
+```
+
+| # | 必要な実装 | 箇所 / やり方 | 参照 |
+| --- | --- | --- | --- |
+| ① | ドメイン書き込みと同じ `tx.Manager.Do` の中で `EmitUsecase.Emit` を呼ぶ | 集約を変更する usecase | `emit.go` `EmitInput` |
+| ② | `EventType`（`+version`）を選び、**自己完結 snapshot** payload を marshal。`Headers` に `Authorization`/`Cookie` を入れない（そのまま外部送出される） | `Emit` の呼び出し側 | `EmitInput.Payload` / `.Headers` doc |
+| ③ | **`Idempotency-Key`（= `message_id`）で dedup** し、永続受理時のみ 2xx を返す受信エンドポイント | 外部サービス | `httpPublisher.Publish` |
+| ④ | `OUTBOX_ENDPOINT`（必須。空/不正 URL は relay が起動拒否）+ 任意の `OUTBOX_POLL_INTERVAL` / `OUTBOX_ERROR_BACKOFF` / `OUTBOX_BATCH_SIZE` | `env/` & IaC | `OutboxConfig` 既定値 |
+| ⑤ | `cmd outbox-relay` を常駐プロセスとして起動（SIGTERM まで常駐・stop で drain） | デプロイ / IaC | `cmd/outbox_relay.go` |
+| ⑥ | `cmd job outbox-gc [--batch-size=N]` をスケジュール（k8s CronJob / cron）し retention 超過の `published` 行を剪定 | スケジューラ | `controller/job/outboxgc` |
+| ⑦ | `outbox.dead` カウンタ / `outbox.lag_seconds` ゲージで alert し `outbox-relay replay [--message-id=<uuid>]` で回復 | runbook | `cmd outbox-relay replay` |
+
+> relay・GC・replay は共有 infra 結線を再利用し、非標準 HTTP publisher profile を持つのは常駐 relay プロセスだけ。GC job は main server の job group に在るため `cmd job outbox-gc` は同一バイナリから使える — 単独では走らない。
+
+---
+
+## 5. 用語
+
+| 用語 | 意味 |
+| --- | --- |
+| **transactional outbox** | 「publish する意図」をドメイン変更と同一 tx の DB 行として記録し、非同期に送出するパターン。dual-write 異常を回避する。 |
+| **emit** | 同期側の半身: `EmitUsecase.Emit` が呼び出し側の業務 tx 内で 1 行 INSERT する（`internal/usecase/outbox/emit.go`）。 |
+| **relay** | 非同期側の半身: pending 行を claim・publish・mark する常駐 `Engine` poll ループ（`controller/outbox` + `usecase/outbox/relay.go`）。 |
+| **Store** | outbox テーブルの永続化ポート（`usecase/boundary/outbox`）。`infrastructure/rdb/system_query/outbox` で sqlc gen 上に実装。 |
+| **Publisher** | 送出ポート（`usecase/boundary/publisher`）。HTTP 実装が `OUTBOX_ENDPOINT` へ POST する。 |
+| **status** | 行のライフサイクル列 — 厳密に `pending` / `published` / `dead`（CHECK 制約）。`failed` という status は無く、publish 失敗は `pending` のまま。 |
+| **attempts / last_error** | publish 試行回数と直近失敗理由。`MarkFailed` が両方を進める。`attempts ≥ MaxAttempts` まで行は `pending`。 |
+| **MaxAttempts** | 行を `dead` にするまでの publish 試行回数（`DefaultMaxAttempts = 10`）。 |
+| **dead** | `MaxAttempts` を使い切った行。運用者が replay するまで終端。`outbox.dead` で計上。 |
+| **replay** | `dead` 行を `pending` へ戻す（`attempts=0`・`last_error=NULL`）。`ReplayUsecase` / `outbox-relay replay [--message-id]`。 |
+| **GC（SweepPublished）** | `Retention`（`DefaultRetention = 7d`）より古い `published` 行を `DefaultGCBatchSize = 10000` 件ずつ削除。`cmd job outbox-gc` で実行。 |
+| **message_id** | 行ごとの安定 UUID（INSERT 時採番）。受信側 dedup 用に HTTP `Idempotency-Key` として伝搬。 |
+| **traceparent** | W3C trace context。emit 時に `headers` へ capture し publisher が再生するため、受信側が起点 trace に繋がる。 |
+| **FOR UPDATE SKIP LOCKED** | 多インスタンス relay を安全にする claim 機構 — ロック中の行は保持 tx が確定するまで他インスタンスがスキップする。 |
+| **retry-by-poll** | relay の at-least-once 機構: publish 失敗は `pending` のまま残し、次 poll で再送する。二重化回避のため transport retry は無効（`MaxAttempts=1`、D10）。 |
+| **PollInterval / ErrorBackoff** | 進捗なし poll の後の待機（`OUTBOX_POLL_INTERVAL = 1s`）/ DB レベルの `RelayBatch` エラー後の待機（`OUTBOX_ERROR_BACKOFF = 5s`）。満杯だが publish 0 件のバッチは必ず待機させる。 |
+| **BatchSize** | 1 poll で claim する行数（`OUTBOX_BATCH_SIZE = 100`。≤ 0 なら `DefaultBatchSize = 100` へ clamp）。 |
+| **outbox.lag_seconds / outbox.dead** | サブシステム固有 SLI（meter `go-boilerplate/outbox`）: 最古 pending 行の経過秒数 / dead 化した行数。publish の latency/error は `httpclient` downstream=`outbox` 計装が賄う。 |
+| **SupervisedRunner** | relay ループを OnStart で起動し OnStop で cancel + drain するライフサイクルヘルパ（`di/lifecycle`）。 |
+| **OutboxRelayModule** | relay 専用プロセスの fx module。`outboxPublisherModule` を入れ子にして非標準 HTTP profile が他へ漏れないようにする。 |

--- a/docs/ja/design/rest.ja.md
+++ b/docs/ja/design/rest.ja.md
@@ -38,7 +38,7 @@ REST は **「request-in driving adapter」、Usecase 層への同期 HTTP 入�
 stateDiagram-v2
     [*] --> Building: NewApplicationCore() → fx.New (config→logging→o11y→db→infra→usecase→controller→server)
     Building --> Wired: BindHandler×N (RegisterHandlers) ＋ ApplyExtends (middleware ソート＆適用) ＋ RegisterHTTPServerHooks
-    Wired --> Listening: fx OnStart → net listen :port → go e.Start()
+    Wired --> Listening: fx OnStart → net listen port → go e.Start()
     Listening --> Serving: request → middleware チェーン → handler → 応答（常駐）
     Serving --> Listening: 応答送出
     Listening --> Draining: SIGINT/SIGTERM → RunServer の ctx.Done()

--- a/docs/portal/manifest.yaml
+++ b/docs/portal/manifest.yaml
@@ -203,6 +203,14 @@ rest-design:
   - src: docs/ja/design/rest.ja.md
     dst: docs/portal/guides/ja/rest-design.ja.md
 
+outbox-design:
+  # English
+  - src: docs/design/outbox.md
+    dst: docs/portal/guides/outbox-design.md
+  # Japanese
+  - src: docs/ja/design/outbox.ja.md
+    dst: docs/portal/guides/ja/outbox-design.ja.md
+
 domain:
   # English
   - src: internal/domain/README.md

--- a/internal/di/README.ja.md
+++ b/internal/di/README.ja.md
@@ -60,7 +60,7 @@ fx.Provide(
 flowchart TD
 
 Controller --> Usecase
-Usecase --> Domain Interface
+Usecase --> DomainInterface
 Infrastructure --> DomainInterface
 ```
 

--- a/internal/di/README.md
+++ b/internal/di/README.md
@@ -56,7 +56,7 @@ The dependencies between layers are as follows:
 flowchart TD
 
 Controller --> Usecase
-Usecase --> Domain Interface
+Usecase --> DomainInterface
 Infrastructure --> DomainInterface
 ```
 

--- a/internal/infrastructure/rdb/testkit/README.ja.md
+++ b/internal/infrastructure/rdb/testkit/README.ja.md
@@ -92,7 +92,7 @@ func (t *testTxManager) WithinTx(fn func(ctx context.Context))
 ```mermaid
 flowchart TD
     A[Transaction Begin]
-    B[fn(ctx) 実行]
+    B["fn(ctx) 実行"]
     C[rollbackForTestError を返す]
     D[Rollback]
 
@@ -103,7 +103,7 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    A[Do(fn)]
+    A["Do(fn)"]
     B[error を返すことで rollback]
 
     A --> B

--- a/internal/infrastructure/rdb/testkit/README.md
+++ b/internal/infrastructure/rdb/testkit/README.md
@@ -90,7 +90,7 @@ Processing flow:
 ```mermaid
 flowchart TD
     A[Transaction Begin]
-    B[Execute fn(ctx)]
+    B["Execute fn(ctx)"]
     C[Return rollbackForTestError]
     D[Rollback]
 
@@ -101,7 +101,7 @@ Internally, it uses `tx.Manager.Do`.
 
 ```mermaid
 flowchart TD
-    A[Do(fn)]
+    A["Do(fn)"]
     B[Return error to trigger rollback]
 
     A --> B

--- a/scripts/README.ja.md
+++ b/scripts/README.ja.md
@@ -15,6 +15,7 @@ scripts/
 ├── stamp-openapi-version.mjs   # release/vX.Y.Z のブランチ名から openapi.yaml の info.version を同期
 ├── sync-versions/              # mise.toml の go / node / python を go.mod と Dockerfile FROM へ反映（Go 実装）
 ├── make_help.mjs                # Make ターゲットのヘルプ出力生成
+├── mermaid-lint.mjs            # Markdown 内の ```mermaid フェンスを mermaid パーサで構文検証
 ├── genctxkey/                  # コンテキストキーコードジェネレータ（Go）
 └── setup/                     # プロジェクト初期設定スクリプト
     ├── replace-module.mjs
@@ -34,6 +35,12 @@ scripts/
 |`gen-portal-docs.mjs`|`manifest.yaml` に基づきソースドキュメントをポータルの `guides/` にコピー|`make gen-docs`|
 |`gen-docs-json.mjs`|ポータルアプリ用のナビゲーション `docs.json` を生成|`make gen-docs`|
 |`build-portal.mjs`|ポータルフロントエンド（`docs/portal/src/main.jsx`）を esbuild で `docs/portal/dist/` 配下（`bundle.js` / `bundle.css` + 遅延チャンク）へバンドルし、`mermaid.min.js` も同じく dist/ へ配置。従来の CDN + ブラウザ内 Babel 構成を置き換え。|`make gen-portal-build`|
+
+### Lint
+
+|スクリプト|説明|実行元|
+|---|---|---|
+|`mermaid-lint.mjs`|リポジトリ内 Markdown の ` ```mermaid ` フェンスを全抽出し（除外範囲は `markdownlint-cli2` と同一）、実 `mermaid.parse` で構文検証する（DOM は `linkedom` で供給）。壊れた図が 1 つでもあれば非 0 で終了。`markdownlint` は Markdown の体裁しか見ず図の文法を見ない、その穴を塞ぐ。|`make md-lint` / `make md-mermaid-lint`|
 
 ### バージョニング
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,6 +15,7 @@ scripts/
 ├── stamp-openapi-version.mjs   # Sync openapi.yaml info.version from the release/vX.Y.Z branch name
 ├── sync-versions/              # Mirror mise.toml go / node / python values to go.mod and Dockerfile FROM (Go)
 ├── make_help.mjs                # Generate Make target help output
+├── mermaid-lint.mjs            # Validate ```mermaid fences in Markdown with the real mermaid parser
 ├── genctxkey/                  # Context key code generator (Go)
 └── setup/                     # Initial project setup scripts
     ├── replace-module.mjs
@@ -34,6 +35,12 @@ scripts/
 |`gen-portal-docs.mjs`|Copy source docs to portal `guides/` based on `manifest.yaml`|`make gen-docs`|
 |`gen-docs-json.mjs`|Generate `docs.json` navigation for the portal app|`make gen-docs`|
 |`build-portal.mjs`|Bundle the portal frontend (`docs/portal/src/main.jsx`) into `docs/portal/dist/` (`bundle.js` / `bundle.css` + lazy chunks) with esbuild, and copy `mermaid.min.js` there too. Replaces the former CDN + in-browser Babel setup.|`make gen-portal-build`|
+
+### Linting
+
+|Script|Description|Invoked By|
+|---|---|---|
+|`mermaid-lint.mjs`|Extract every ` ```mermaid ` fence from the repo's Markdown (same exclusions as `markdownlint-cli2`) and validate each with the real `mermaid.parse` (DOM provided by `linkedom`). Exits non-zero on the first broken diagram. Fills the gap that `markdownlint` only checks Markdown shape, never the diagram grammar.|`make md-lint` / `make md-mermaid-lint`|
 
 ### Versioning
 

--- a/scripts/mermaid-lint.mjs
+++ b/scripts/mermaid-lint.mjs
@@ -2,8 +2,8 @@
 // markdownlint-cli2 は Markdown の体裁しか見ず mermaid 図の文法は素通りするため、その穴を塞ぐ。
 // node_tool_runner コンテナ内で `make md-lint-ci` から呼ばれる前提（mermaid / linkedom は scripts/node_modules）。
 //
-// mermaid.parse は flowchart の DOMPurify サニタイズで DOM を要求するため、import 前に linkedom で
-// 最小の window/document を用意してから mermaid を動的 import する。1 つでも壊れた図があれば非 0 で終了する。
+// mermaid.parse は DOMPurify サニタイズで DOM を要求するため、mermaid のロードには DOM 環境が要る。
+// 1 つでも壊れた図があれば非 0 で終了する。
 import fs from "node:fs"
 import path from "node:path"
 import { createRequire } from "node:module"
@@ -69,7 +69,8 @@ function extractMermaidBlocks(content) {
     const body = []
     let j = i + 1
     for (; j < lines.length; j++) {
-      if (close.test(lines[j]) && !lines[j].trim().endsWith("mermaid")) break
+      // close は `\s*$` 終端のため、フェンス文字のみの行だけが閉じになる（```mermaid 等は閉じ扱いにならない）。
+      if (close.test(lines[j])) break
       body.push(lines[j])
     }
     blocks.push({ startLine: i + 1, code: body.join("\n") })
@@ -92,8 +93,8 @@ for (const rel of files) {
   try {
     content = fs.readFileSync(path.join(repoRoot, rel), "utf8")
   } catch {
-    // 読めないファイル（壊れた symlink ＝ コンテナ内では実体の無い tmp/ 配下の git 外プラン等、
-    // または権限エラー）は検証対象外としてスキップする。markdownlint も壊れた symlink を黙って飛ばす。
+    // 読めないファイル（壊れた symlink や権限エラー）は検証対象外としてスキップする。
+    // markdownlint も壊れた symlink を黙って飛ばすため挙動を揃える。
     skipped.push(rel)
     continue
   }

--- a/scripts/mermaid-lint.mjs
+++ b/scripts/mermaid-lint.mjs
@@ -80,13 +80,23 @@ function extractMermaidBlocks(content) {
 
 const repoRoot = process.cwd()
 const files = collectMarkdown(repoRoot)
+const suffix = (n) => (n > 0 ? `（読めず skip: ${n} 件）` : "")
 
 let blockCount = 0
 let fileWithBlocks = 0
 const failures = []
+const skipped = []
 
 for (const rel of files) {
-  const content = fs.readFileSync(path.join(repoRoot, rel), "utf8")
+  let content
+  try {
+    content = fs.readFileSync(path.join(repoRoot, rel), "utf8")
+  } catch {
+    // 読めないファイル（壊れた symlink ＝ コンテナ内では実体の無い tmp/ 配下の git 外プラン等、
+    // または権限エラー）は検証対象外としてスキップする。markdownlint も壊れた symlink を黙って飛ばす。
+    skipped.push(rel)
+    continue
+  }
   const blocks = extractMermaidBlocks(content)
   if (blocks.length > 0) fileWithBlocks++
   for (let b = 0; b < blocks.length; b++) {
@@ -111,4 +121,4 @@ if (failures.length > 0) {
   process.exit(1)
 }
 
-console.log(`✓ mermaid-lint: ${blockCount} ブロック / ${fileWithBlocks} ファイル すべて OK`)
+console.log(`✓ mermaid-lint: ${blockCount} ブロック / ${fileWithBlocks} ファイル すべて OK${suffix(skipped.length)}`)

--- a/scripts/mermaid-lint.mjs
+++ b/scripts/mermaid-lint.mjs
@@ -1,0 +1,114 @@
+// Mermaid のコードフェンス（```mermaid）を実際の mermaid パーサで構文検証する lint スクリプト。
+// markdownlint-cli2 は Markdown の体裁しか見ず mermaid 図の文法は素通りするため、その穴を塞ぐ。
+// node_tool_runner コンテナ内で `make md-lint-ci` から呼ばれる前提（mermaid / linkedom は scripts/node_modules）。
+//
+// mermaid.parse は flowchart の DOMPurify サニタイズで DOM を要求するため、import 前に linkedom で
+// 最小の window/document を用意してから mermaid を動的 import する。1 つでも壊れた図があれば非 0 で終了する。
+import fs from "node:fs"
+import path from "node:path"
+import { createRequire } from "node:module"
+
+// import 順の都合で mermaid より先に DOM を globalThis へ載せる必要があるため require で先行ロードする。
+const require = createRequire(import.meta.url)
+const { parseHTML } = require("linkedom")
+
+const { window, document } = parseHTML("<!doctype html><html><head></head><body></body></html>")
+globalThis.window = window
+globalThis.document = document
+Object.defineProperty(globalThis, "navigator", { value: window.navigator, configurable: true })
+globalThis.location = window.location
+globalThis.requestAnimationFrame = (fn) => setTimeout(fn, 0)
+globalThis.MutationObserver = window.MutationObserver
+
+const mermaidModule = await import("mermaid")
+const mermaid = mermaidModule.default ?? mermaidModule
+// logLevel:5(fatal) でパース失敗時の冗長な内部ログを抑止し、本スクリプトの整形済み出力に一本化する。
+mermaid.initialize({ startOnLoad: false, securityLevel: "loose", logLevel: 5 })
+
+// markdownlint-cli2 の MD_GLOBS と対象範囲を揃える（生成物・vendor・AGENTS.md を除外）。
+const EXCLUDE_DIRS = new Set(["vendor", "node_modules", ".git"])
+const EXCLUDE_PREFIXES = [
+  "docs/portal/guides/",
+  "docs/coverage/",
+  "docs/db-schema/",
+]
+const EXCLUDE_FILES = new Set(["AGENTS.md"])
+
+// repoRoot 配下の *.md を再帰収集する（除外ディレクトリは降りない）。
+function collectMarkdown(repoRoot) {
+  const out = []
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const abs = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        if (EXCLUDE_DIRS.has(entry.name)) continue
+        walk(abs)
+        continue
+      }
+      if (!entry.name.endsWith(".md")) continue
+      const rel = path.relative(repoRoot, abs)
+      if (EXCLUDE_FILES.has(rel)) continue
+      if (EXCLUDE_PREFIXES.some((p) => rel.startsWith(p))) continue
+      out.push(rel)
+    }
+  }
+  walk(repoRoot)
+  return out.sort()
+}
+
+// Markdown から ```mermaid フェンスを開始行付きで抜き出す。
+function extractMermaidBlocks(content) {
+  const lines = content.split("\n")
+  const blocks = []
+  const fence = /^(\s*)(`{3,}|~{3,})\s*mermaid\s*$/
+  for (let i = 0; i < lines.length; i++) {
+    const m = fence.exec(lines[i])
+    if (!m) continue
+    const marker = m[2][0].repeat(m[2].length)
+    const close = new RegExp(`^\\s*${marker[0] === "`" ? "`" : "~"}{${m[2].length},}\\s*$`)
+    const body = []
+    let j = i + 1
+    for (; j < lines.length; j++) {
+      if (close.test(lines[j]) && !lines[j].trim().endsWith("mermaid")) break
+      body.push(lines[j])
+    }
+    blocks.push({ startLine: i + 1, code: body.join("\n") })
+    i = j
+  }
+  return blocks
+}
+
+const repoRoot = process.cwd()
+const files = collectMarkdown(repoRoot)
+
+let blockCount = 0
+let fileWithBlocks = 0
+const failures = []
+
+for (const rel of files) {
+  const content = fs.readFileSync(path.join(repoRoot, rel), "utf8")
+  const blocks = extractMermaidBlocks(content)
+  if (blocks.length > 0) fileWithBlocks++
+  for (let b = 0; b < blocks.length; b++) {
+    blockCount++
+    try {
+      await mermaid.parse(blocks[b].code)
+    } catch (e) {
+      const msg = (e && e.message ? e.message : String(e)).trim()
+      failures.push({ rel, startLine: blocks[b].startLine, index: b + 1, msg })
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`✘ mermaid-lint: ${failures.length} 件の壊れた mermaid ブロック\n`)
+  for (const f of failures) {
+    console.error(`  ${f.rel}:${f.startLine}  (block #${f.index})`)
+    for (const line of f.msg.split("\n")) console.error(`    ${line}`)
+    console.error("")
+  }
+  console.error(`検証 ${blockCount} ブロック / ${fileWithBlocks} ファイル中 ${failures.length} 件 NG`)
+  process.exit(1)
+}
+
+console.log(`✓ mermaid-lint: ${blockCount} ブロック / ${fileWithBlocks} ファイル すべて OK`)


### PR DESCRIPTION
# 概要

Markdown 内の mermaid 図を実 mermaid パーサで構文検証する lint を md-lint に統合し、
既存の壊れた図を修正。あわせて、これまで欠けていた transactional outbox の
設計リファレンスを追加する。production 挙動の変更は無し（doc + ツールのみ）。

## 変更内容

- **ツール / ビルド**: `scripts/mermaid-lint.mjs` を追加し `md-lint(-ci)` へ連結。Node で `mermaid.parse` を動かす DOM 供給のため `linkedom` を tools 依存へ追加（import ライブラリのため mise ではなく `docker/tools/package.json` 管理）
- **ドキュメント（新規）**: outbox 設計リファレンスを en/ja で追加し portal manifest に登録
- **ドキュメント（修正）**: 新 lint が検出した既存の壊れた mermaid 図を修正（`docs/design/job|rest`、`di`/`testkit` README）— `;` 文区切り / 内部コロン / ノード id 空白 / 括弧 quote
- **ドキュメント（追記）**: `scripts` / `.makefiles` / `docker/tools` の README(en/ja)
- **不具合修正**: 読めない `.md`（コンテナ内で実体の無い `tmp/` の壊れた symlink）で lint がクラッシュするのを防止

## 動作確認方法

1. `make tool-runners-build`（linkedom をイメージへ取り込み）
2. `make md-lint` → markdownlint 0 error + mermaid 333 ブロック OK（skip 1）
3. 故意に壊した mermaid ブロックで exit 1 になることを確認済み