### PR TITLE
ルートパッケージを env→root に改名し godoc ランディングを整備

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	rootenv "go-boilerplate"
+	root "go-boilerplate"
 	climigrate "go-boilerplate/internal/cli/migrate"
 	"go-boilerplate/internal/config"
 	"go-boilerplate/internal/infrastructure/rdb/driver"
@@ -94,7 +94,7 @@ func buildMigrateInstance(database string) (climigrate.Migrator, error) {
 	dbCfg := config.NewDatabaseConfig(cfg)
 	osCfg := config.NewOperatingSystemConfig(cfg)
 
-	src, err := iofs.New(rootenv.FS, migrateFilePlace)
+	src, err := iofs.New(root.FS, migrateFilePlace)
 	if err != nil {
 		return nil, xerrors.Wrap(err, "failed to create migration source")
 	}

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,12 @@
+// Package root は go-boilerplate（軽量 Onion Architecture による RESTful API のひな形）の
+// モジュールルートであり、godoc のランディングを兼ねます。
+//
+// アーキテクチャは controller → usecase → domain の依存方向で構成し、infrastructure が
+// domain のインターフェースを実装します。OpenAPI ファースト・sqlc による型安全な DB アクセスを
+// 採用し、ビジネスロジックは internal/ 配下に閉じます。各レイヤの詳細は README.md および
+// docs/architecture.md を参照してください。
+//
+// ルートパッケージ自体は、バイナリへ焼き込む設定とマイグレーションを embed.FS として公開する
+// 役割だけを持ちます（FS を参照）。go:embed が親ディレクトリを遡れない制約上、埋め込み対象の
+// env/.env と database/migrations を参照できるモジュールルートに配置しています。
+package root

--- a/embed.go
+++ b/embed.go
@@ -1,5 +1,4 @@
-// Package env は、バイナリへ焼き込む設定とマイグレーションを embed.FS として公開します。
-package env
+package root
 
 import "embed"
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"os"
 
-	rootenv "go-boilerplate"
+	root "go-boilerplate"
 	"go-boilerplate/pkg/xerrors"
 
 	"github.com/joho/godotenv"
@@ -13,7 +13,7 @@ import (
 // Load は、埋め込まれた env ファイルから環境変数を設定します。
 // 既に設定済みの環境変数は上書きしません（実行時注入を優先）。
 func Load() error {
-	b, err := rootenv.FS.ReadFile("env/.env")
+	b, err := root.FS.ReadFile("env/.env")
 	if err != nil {
 		return xerrors.Join(ErrFailedToLoadEnvFile, err)
 	}


### PR DESCRIPTION
# 概要

モジュールルート（import path `go-boilerplate`）のパッケージ名がディレクトリ概念と紛らわしい `env` で、godoc のトップに embed の一文だけが表示されていました。パッケージ名を `root` に改名し、`doc.go` にプロジェクト概要を置いて godoc のランディングを整備します。挙動の変更はありません。

## 変更内容

- **ランディング整備**
  - `doc.go`（新規・`package root`）: go-boilerplate の概要（Onion Architecture / OpenAPI ファースト / sqlc、詳細は README・architecture.md へ誘導）を package doc 化。ルートが embed ホルダである理由（`go:embed` が親ディレクトリを遡れない制約）も明記。
  - `embed.go`: `package env` → `package root`。概要を `doc.go` に一本化するため package doc 行を削除（`FS` の doc は維持）。
- **importer 追従**
  - `cmd/migrate.go` / `internal/config/loader.go`: import alias を `rootenv` → `root` に更新（参照は `root.FS`）。
- `embed.go` は `go:embed` 制約のためルートに据え置き。`var FS embed.FS`（`env/.env` / `database/migrations` 埋め込み）は不変。

## 動作確認方法

1. `go doc .` → ヘッダが `package root // import "go-boilerplate"`、概要がプロジェクト説明であること
2. `make lint` → 0 issues
3. `make test` → 全パス（`internal/config` で embed 経由の env 読込を含む）