### PR TITLE
Build: ツールランナービルドのメッセージから「画像」を削除する

### DIFF
--- a/.makefiles/app/server.mk
+++ b/.makefiles/app/server.mk
@@ -4,8 +4,8 @@
 .PHONY: serve-build-clean ## キャッシュ無効・base image を pull したクリーンビルド後、開発環境を起動する
 .PHONY: tools ## 開発支援サービス(DB/docs/SQL viewer)を起動する
 .PHONY: all ## 全サービス(開発/ツール)を一括起動する
-.PHONY: tool-runners-build ## ツールランナー画像(go/node/python)をビルドする（キャッシュ利用・起動はしない）
-.PHONY: tool-runners-build-clean ## ツールランナー画像をクリーンビルドする（--no-cache --pull・起動はしない）
+.PHONY: tool-runners-build ## ツールランナー(go/node/python)をビルドする（キャッシュ利用・起動はしない）
+.PHONY: tool-runners-build-clean ## ツールランナーをクリーンビルドする（--no-cache --pull・起動はしない）
 
 serve:
 	@echo "🔄 開発環境を起動します。"
@@ -34,11 +34,11 @@ all:
 	@echo "✅ 全サービスの起動が完了しました。Grafana: http://localhost:3000"
 
 tool-runners-build:
-	@echo "🧰 ツールランナー画像をビルドします。"
+	@echo "🧰 ツールランナーをビルドします。"
 	@docker compose build go_tool_runner node_tool_runner python_tool_runner
-	@echo "✅ ツールランナー画像のビルドが完了しました。"
+	@echo "✅ ツールランナーのビルドが完了しました。"
 
 tool-runners-build-clean:
-	@echo "🧹 ツールランナー画像をクリーンビルドします（--no-cache --pull）。"
+	@echo "🧹 ツールランナーをクリーンビルドします（--no-cache --pull）。"
 	@docker compose build --no-cache --pull go_tool_runner node_tool_runner python_tool_runner
-	@echo "✅ ツールランナー画像のクリーンビルドが完了しました。"
+	@echo "✅ ツールランナーのクリーンビルドが完了しました。"


### PR DESCRIPTION
# 概要

`make tool-runners-build` / `tool-runners-build-clean` の `.PHONY` コメントと echo メッセージから「画像」という表現を削除し、「ツールランナー」の文言に統一する。ロジック変更はない。

## 変更内容

- 内部ツール / ビルド: `.makefiles/app/server.mk`
  - `tool-runners-build` / `tool-runners-build-clean` の `.PHONY` コメントから「画像」を削除
  - 両ターゲットの実行時 echo メッセージ（開始 / 完了）から「画像」を削除

## 動作確認方法

1. `make tool-runners-build` を実行し、出力メッセージが「ツールランナーをビルドします / ビルドが完了しました」になっていることを確認
2. `make tool-runners-build-clean` を実行し、メッセージから「画像」が消えていることを確認