### PR TITLE
Fix: スタックトレースログから cockroachdb/errors のガターを除去する

### DIFF
--- a/internal/logging/field.go
+++ b/internal/logging/field.go
@@ -133,7 +133,9 @@ func Stacktrace(key fieldKey, err error) *Field {
 
 // SplitStackLines は、スタックトレース文字列を改行で分割し行配列に変換します。
 // 末尾の空行は除去し、空文字列または改行のみの入力では nil を返します。
-// 配列化により行境界が構造として表現されるため、`\t<file>:<line>` の先頭タブは除去します。
+// 配列化により行境界とネスト深さが構造として表現されるため、cockroachdb/errors の
+// `%+v` が各行頭に付与するガター（`  | ` の空白・パイプや `\t<file>:<line>` の先頭タブ）は
+// 冗長になる。各行頭の空白・`|`・タブをまとめて除去し、内容だけを残す。
 func SplitStackLines(s string) []string {
 	trimmed := strings.TrimRight(s, "\n")
 	if trimmed == "" {
@@ -141,7 +143,7 @@ func SplitStackLines(s string) []string {
 	}
 	lines := strings.Split(trimmed, "\n")
 	for i, line := range lines {
-		lines[i] = strings.TrimLeft(line, "\t")
+		lines[i] = strings.TrimLeft(line, " |\t")
 	}
 	return lines
 }

--- a/internal/logging/field_test.go
+++ b/internal/logging/field_test.go
@@ -270,6 +270,18 @@ func TestSplitStackLines(t *testing.T) {
 			assert.Equal(t, expected, SplitStackLines(input))
 		})
 
+		t.Run("cockroachdb_errorsのガター（空白・パイプ・タブ）を行頭から除去する", func(t *testing.T) {
+			t.Parallel()
+
+			input := "  | go-boilerplate/pkg/xerrors.Join\n  | \t/app/pkg/xerrors/errors.go:34\n  -- stack trace:"
+			expected := []string{
+				"go-boilerplate/pkg/xerrors.Join",
+				"/app/pkg/xerrors/errors.go:34",
+				"-- stack trace:",
+			}
+			assert.Equal(t, expected, SplitStackLines(input))
+		})
+
 		t.Run("末尾改行は分割結果から除去される", func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
# 概要

エラーログの `internal_stacktrace` 各行に、cockroachdb/errors の `%+v` がネスト表現として付与する `  | ` ガター（空白・パイプ）や `\t` が残り、`  | \t/app/...` のように冗長で読みにくくなっていた問題を修正する。

## 変更内容

- 内部ロジック: `internal/logging/field.go`
  - `SplitStackLines` の行頭クリーニングを `TrimLeft(line, "\t")` から `TrimLeft(line, " |\t")` に変更し、行頭の空白・パイプ・タブをまとめて除去
  - 配列化により行境界とネスト深さは構造として表現されるため、ガターは不要
- テスト: `internal/logging/field_test.go`
  - cockroachdb/errors のガター（空白・パイプ・タブ）が行頭から除去されることを検証するケースを追加

## 動作確認方法

1. `make test`（または `go test ./internal/logging/ -run TestSplitStackLines`）で追加ケースを含むテストが通ることを確認
2. `make serve` で起動後、エラーを誘発するリクエストを送り、出力ログの `internal_stacktrace` から `  | ` / `\t` が消えていることを確認