### PR TITLE
coverage HTML を決定的化し、同梱 OS パッケージのライセンスを README に明記

### DIFF
--- a/.makefiles/go/test.mk
+++ b/.makefiles/go/test.mk
@@ -28,7 +28,7 @@ gen-test-repo:
 		| grep -Ev '$(GO_TEST_EXCLUDE)' \
 		| tr '\n' ',' \
 		| sed 's/,$$//')"; \
-	go test $$TGT_PKGS -coverpkg=$$COVER_PKGS -coverprofile=docs/coverage/coverage.out -covermode=atomic  >/dev/null 2>&1
+	go test $$TGT_PKGS -coverpkg=$$COVER_PKGS -coverprofile=docs/coverage/coverage.out -covermode=set  >/dev/null 2>&1
 	go tool cover -html=docs/coverage/coverage.out -o docs/coverage/index.html
 	rm -f docs/coverage/coverage.out
 	@echo "✅ テストレポートの生成が完了しました。"

--- a/README.ja.md
+++ b/README.ja.md
@@ -250,4 +250,13 @@ Infra --> External["External Systems"]
 
 ## ライセンス
 
-MIT License — [LICENSE](LICENSE) を参照してください。
+本プロジェクト自身のソースコードは **MIT License** で公開しています — [LICENSE](LICENSE) を参照してください。
+
+配布するコンテナイメージには、ベースイメージ由来のサードパーティ OS パッケージが同梱されます。
+たとえば本番用の `runtime` イメージは `alpine:3.23` をベースにしており、その基本パッケージ
+（`busybox` / `apk-tools` / `alpine-baselayout` / `ssl_client` など）は **GPL-2.0-only** です。
+これらは *mere aggregation（単なる同梱）* にあたります。独立したプログラムとして動作し、Go バイナリには
+**リンクされない**ため、コピーレフトの条件が本プロジェクトのコードに波及することはなく、商用利用を
+**制限しません**。義務は Linux ベースイメージを再配布する際の通常の対応（対応するパッケージソースの
+入手手段を提供すること。upstream の Alpine が既に提供済み）のみです。イメージ詳細:
+[docker/README.md](docker/README.md)。

--- a/README.md
+++ b/README.md
@@ -256,4 +256,13 @@ Planned future releases: Frontend / Infrastructure / Observability boilerplates.
 
 ## License
 
-MIT License — see [LICENSE](LICENSE).
+This project's own source code is released under the **MIT License** — see [LICENSE](LICENSE).
+
+The container images the project ships bundle third-party OS packages from their base images —
+for example the production `runtime` image is built on `alpine:3.23`, whose base packages
+(`busybox`, `apk-tools`, `alpine-baselayout`, `ssl_client`, …) are licensed under
+**GPL-2.0-only**. These are included as *mere aggregation*: they run as independent programs and
+are **not** linked into the Go binary, so their copyleft terms do not extend to this project's
+code and do **not** restrict commercial use. The only obligation is the ordinary one for
+redistributing any Linux base image — make the corresponding package sources available, which
+upstream Alpine already does. Image details: [docker/README.md](docker/README.md).

--- a/docs/coverage/index.html
+++ b/docs/coverage/index.html
@@ -574,17 +574,8 @@
 			<div id="legend">
 				<span>not tracked</span>
 			
-				<span class="cov0">no coverage</span>
-				<span class="cov1">low coverage</span>
-				<span class="cov2">*</span>
-				<span class="cov3">*</span>
-				<span class="cov4">*</span>
-				<span class="cov5">*</span>
-				<span class="cov6">*</span>
-				<span class="cov7">*</span>
-				<span class="cov8">*</span>
-				<span class="cov9">*</span>
-				<span class="cov10">high coverage</span>
+				<span class="cov0">not covered</span>
+				<span class="cov8">covered</span>
 			
 			</div>
 		</div>
@@ -640,7 +631,7 @@ type Generator struct {
 }
 
 // NewGenerator は、dump-schema 用のジェネレーターインスタンスを生成します。
-func NewGenerator(logger logging.Logger, workDir string) *Generator <span class="cov1" title="1">{
+func NewGenerator(logger logging.Logger, workDir string) *Generator <span class="cov8" title="1">{
         return &amp;Generator{
                 logger:          logger,
                 callerSkipCount: 1,
@@ -656,20 +647,20 @@ func NewGenerator(logger logging.Logger, workDir string) *Generator <span class=
 
 // RunDump は、DSN 解決・スキーマダンプ・整形を行い、schema.gen.sql を sqlc が読み込める形で書き出します。
 // loadDSN は (パスワード非含有 DSN, パスワード) を返します。
-func RunDump(ctx context.Context, gen *Generator, loadDSN func() (string, string, error)) error <span class="cov4" title="4">{
+func RunDump(ctx context.Context, gen *Generator, loadDSN func() (string, string, error)) error <span class="cov8" title="1">{
         dbURL, password, err := loadDSN()
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov3" title="3">if err := gen.dumpSchema(ctx, dbURL, password); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err := gen.dumpSchema(ctx, dbURL, password); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov2" title="2">return gen.sanitizeSchemaInPlace()</span>
+        <span class="cov8" title="1">return gen.sanitizeSchemaInPlace()</span>
 }
 
 // dumpSchema は、ダンプコマンドを実行してスキーマのDDLを取得し、schema.gen.sqlとして保存します。
-func (g *Generator) dumpSchema(ctx context.Context, dbURL, password string) error <span class="cov5" title="6">{
+func (g *Generator) dumpSchema(ctx context.Context, dbURL, password string) error <span class="cov8" title="1">{
         args := append([]string{dbURL}, g.dumpArgs...)
         env := []string{"PGPASSWORD=" + password}
 
@@ -678,7 +669,7 @@ func (g *Generator) dumpSchema(ctx context.Context, dbURL, password string) erro
         )
 
         out, err := g.runner.Output(ctx, g.workDir, env, g.dumpCommand, args)
-        if err != nil </span><span class="cov2" title="2">{
+        if err != nil </span><span class="cov8" title="1">{
                 g.logger.CallerSkip(g.callerSkipCount).Named("dumpschema.dumpSchema").Warn("pg_dump failed",
                         logging.String("out", g.schemaRelPath),
                         logging.Error(logging.ErrorKey, err),
@@ -686,12 +677,12 @@ func (g *Generator) dumpSchema(ctx context.Context, dbURL, password string) erro
                 return xerrors.Wrap(err, "pg_dump failed")
         }</span>
 
-        <span class="cov4" title="4">schemaAbs := filepath.Join(g.workDir, g.schemaRelPath)
-        if err := g.fs.WriteFile(schemaAbs, out, g.permission); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">schemaAbs := filepath.Join(g.workDir, g.schemaRelPath)
+        if err := g.fs.WriteFile(schemaAbs, out, g.permission); err != nil </span><span class="cov8" title="1">{
                 return xerrors.Wrap(err, "failed to write schema file")
         }</span>
 
-        <span class="cov3" title="3">g.logger.CallerSkip(g.callerSkipCount).Named("dumpschema.dumpSchema").Info("pg_dump schema completed",
+        <span class="cov8" title="1">g.logger.CallerSkip(g.callerSkipCount).Named("dumpschema.dumpSchema").Info("pg_dump schema completed",
                 logging.String("out", g.schemaRelPath),
         )
 
@@ -700,35 +691,35 @@ func (g *Generator) dumpSchema(ctx context.Context, dbURL, password string) erro
 
 // sanitizeSchemaInPlace は、schema.sql を sqlc 向けに整形します。
 // trimPrefixes 一致のメタ行に加え、空行（空白のみ・元から空）も除去します（空行除去まで含むのは意図的）。
-func (g *Generator) sanitizeSchemaInPlace() error <span class="cov5" title="5">{
+func (g *Generator) sanitizeSchemaInPlace() error <span class="cov8" title="1">{
         srcAbs := filepath.Join(g.workDir, g.schemaRelPath)
 
         b, err := g.fs.ReadFile(srcAbs)
-        if err != nil </span><span class="cov2" title="2">{
+        if err != nil </span><span class="cov8" title="1">{
                 return xerrors.Wrap(err, "read schema")
         }</span>
 
-        <span class="cov3" title="3">lines := strings.Split(string(b), "\n")
+        <span class="cov8" title="1">lines := strings.Split(string(b), "\n")
         out := make([]string, 0, len(lines))
-        for _, ln := range lines </span><span class="cov7" title="12">{
+        for _, ln := range lines </span><span class="cov8" title="1">{
                 trim := strings.TrimSpace(ln)
-                for _, prefix := range trimPrefixes </span><span class="cov10" title="33">{
-                        if strings.HasPrefix(trim, prefix) </span><span class="cov3" title="3">{
+                for _, prefix := range trimPrefixes </span><span class="cov8" title="1">{
+                        if strings.HasPrefix(trim, prefix) </span><span class="cov8" title="1">{
                                 trim = ""
                                 break</span>
                         }
                 }
-                <span class="cov7" title="12">if trim == "" </span><span class="cov6" title="8">{
+                <span class="cov8" title="1">if trim == "" </span><span class="cov8" title="1">{
                         continue</span>
                 }
-                <span class="cov4" title="4">out = append(out, ln)</span>
+                <span class="cov8" title="1">out = append(out, ln)</span>
         }
 
-        <span class="cov3" title="3">if err := g.fs.WriteFile(srcAbs, []byte(strings.Join(out, "\n")), g.permission); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err := g.fs.WriteFile(srcAbs, []byte(strings.Join(out, "\n")), g.permission); err != nil </span><span class="cov8" title="1">{
                 return xerrors.Wrap(err, "write sanitized schema")
         }</span>
 
-        <span class="cov2" title="2">g.logger.CallerSkip(g.callerSkipCount).Named("dumpschema.sanitizeSchemaInPlace").Info("schema sanitized for sqlc",
+        <span class="cov8" title="1">g.logger.CallerSkip(g.callerSkipCount).Named("dumpschema.sanitizeSchemaInPlace").Info("schema sanitized for sqlc",
                 logging.String("schema", g.schemaRelPath),
         )
         return nil</span>
@@ -755,32 +746,32 @@ const (
 
 // RunFix は、DB 名の検証・DSN 解決・collation 修正のオーケストレーションを行います。
 // loadDSN は (パスワード非含有 DSN, パスワード) を返します。
-func RunFix(ctx context.Context, runner exec.Runner, logger logging.Logger, database string, loadDSN func() (string, string, error)) error <span class="cov6" title="3">{
-        if err := validateDatabaseName(database); err != nil </span><span class="cov1" title="1">{
+func RunFix(ctx context.Context, runner exec.Runner, logger logging.Logger, database string, loadDSN func() (string, string, error)) error <span class="cov8" title="1">{
+        if err := validateDatabaseName(database); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov4" title="2">dbURL, password, err := loadDSN()
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">dbURL, password, err := loadDSN()
+        if err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov1" title="1">return fixCollation(ctx, runner, logger, dbURL, password, database)</span>
+        <span class="cov8" title="1">return fixCollation(ctx, runner, logger, dbURL, password, database)</span>
 }
 
 // validateDatabaseName は、許可済みのローカル向け DB 名のみを受け付けます。
-func validateDatabaseName(name string) error <span class="cov10" title="7">{
+func validateDatabaseName(name string) error <span class="cov8" title="1">{
         switch name </span>{
-        case "local", "test":<span class="cov7" title="4">
+        case "local", "test":<span class="cov8" title="1">
                 return nil</span>
-        default:<span class="cov6" title="3">
+        default:<span class="cov8" title="1">
                 return xerrors.New("invalid database name: " + name)</span>
         }
 }
 
 // fixCollation は、collation mismatch 修正 SQL を psql 経由で順に実行します。
 // パスワードは引数に載せず PGPASSWORD で渡します。
-func fixCollation(ctx context.Context, runner exec.Runner, logger logging.Logger, dbURL, password, database string) error <span class="cov7" title="4">{
+func fixCollation(ctx context.Context, runner exec.Runner, logger logging.Logger, dbURL, password, database string) error <span class="cov8" title="1">{
         log := logger.CallerSkip(callerSkipCount).Named("fixcollation")
         log.Info("start collation fix", logging.String("database", database))
 
@@ -791,9 +782,9 @@ func fixCollation(ctx context.Context, runner exec.Runner, logger logging.Logger
 
         env := []string{"PGPASSWORD=" + password}
         // 依存順序があるため、照合順序修正 SQL は並列ではなく順番に流します。
-        for _, sql := range sqlStatements </span><span class="cov10" title="7">{
+        for _, sql := range sqlStatements </span><span class="cov8" title="1">{
                 args := []string{dbURL, "-v", "ON_ERROR_STOP=1", "-c", sql}
-                if _, err := runner.Output(ctx, workDir, env, psqlCommand, args); err != nil </span><span class="cov4" title="2">{
+                if _, err := runner.Output(ctx, workDir, env, psqlCommand, args); err != nil </span><span class="cov8" title="1">{
                         log.Error("psql command failed",
                                 logging.String("database", database),
                                 logging.String("sql", sql),
@@ -803,7 +794,7 @@ func fixCollation(ctx context.Context, runner exec.Runner, logger logging.Logger
                 }</span>
         }
 
-        <span class="cov4" title="2">log.Info("collation fix completed successfully", logging.String("database", database))
+        <span class="cov8" title="1">log.Info("collation fix completed successfully", logging.String("database", database))
         return nil</span>
 }
 </pre>
@@ -833,7 +824,7 @@ func RunJobWith(
         timeout time.Duration,
         grace time.Duration,
         provide func() (StartFunc, StopFunc),
-) error <span class="cov1" title="1">{
+) error <span class="cov8" title="1">{
         start, stop := provide()
         return runJob(ctx, name, args, timeout, grace, start, stop)
 }</span>
@@ -847,21 +838,21 @@ func runJob(
         grace time.Duration,
         start StartFunc,
         stop StopFunc,
-) error <span class="cov9" title="9">{
+) error <span class="cov8" title="1">{
         done := start(ctx, name, args)
 
-        if timeout &lt;= 0 </span><span class="cov6" title="4">{
+        if timeout &lt;= 0 </span><span class="cov8" title="1">{
                 err := &lt;-done
                 return xerrors.Join(err, gracefulStop(ctx, grace, stop))
         }</span>
 
-        <span class="cov7" title="5">waitCtx, cancel := context.WithTimeout(ctx, timeout)
+        <span class="cov8" title="1">waitCtx, cancel := context.WithTimeout(ctx, timeout)
         defer cancel()
 
         select </span>{
-        case err := &lt;-done:<span class="cov3" title="2">
+        case err := &lt;-done:<span class="cov8" title="1">
                 return xerrors.Join(err, gracefulStop(ctx, grace, stop))</span>
-        case &lt;-waitCtx.Done():<span class="cov5" title="3">
+        case &lt;-waitCtx.Done():<span class="cov8" title="1">
                 // waitCtx は ctx の子。タイムアウト(DeadlineExceeded)・親キャンセル(Canceled)の両方で発火する。
                 // 停止は期限切れの waitCtx ではなく専用 context を作り直して猶予を与える。
                 return xerrors.Join(waitCtx.Err(), gracefulStop(ctx, grace, stop))</span>
@@ -872,7 +863,7 @@ func runJob(
 // その結果を返します。SIGINT 伝播や親 ctx タイムアウト後でも OTel flush / DB pool close に
 // grace の全猶予が保証されます。停止失敗を呼び出し元のエラーチェーンに含め exit code へ
 // 反映できるよう、エラーは破棄せず返します。
-func gracefulStop(ctx context.Context, grace time.Duration, stop StopFunc) error <span class="cov10" title="10">{
+func gracefulStop(ctx context.Context, grace time.Duration, stop StopFunc) error <span class="cov8" title="1">{
         stopCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), grace)
         defer cancel()
         return stop(stopCtx)
@@ -941,70 +932,70 @@ type Generator struct {
         fs FileSystem
 }
 
-func (osFileSystem) ListSubDirNames(base string) ([]string, error) <span class="cov3" title="2">{
+func (osFileSystem) ListSubDirNames(base string) ([]string, error) <span class="cov8" title="1">{
         ents, err := os.ReadDir(base)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov1" title="1">dirs := make([]string, 0, len(ents))
-        for _, e := range ents </span><span class="cov4" title="3">{
-                if e.IsDir() </span><span class="cov3" title="2">{
+        <span class="cov8" title="1">dirs := make([]string, 0, len(ents))
+        for _, e := range ents </span><span class="cov8" title="1">{
+                if e.IsDir() </span><span class="cov8" title="1">{
                         dirs = append(dirs, e.Name())
                 }</span>
         }
-        <span class="cov1" title="1">sort.Strings(dirs)
+        <span class="cov8" title="1">sort.Strings(dirs)
         return dirs, nil</span>
 }
 
-func (osFileSystem) ListGenFileNames(genDir string) ([]string, error) <span class="cov3" title="2">{
+func (osFileSystem) ListGenFileNames(genDir string) ([]string, error) <span class="cov8" title="1">{
         ents, err := os.ReadDir(genDir)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov1" title="1">names := make([]string, 0, len(ents))
-        for _, e := range ents </span><span class="cov3" title="2">{
-                if !e.IsDir() </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">names := make([]string, 0, len(ents))
+        for _, e := range ents </span><span class="cov8" title="1">{
+                if !e.IsDir() </span><span class="cov8" title="1">{
                         names = append(names, e.Name())
                 }</span>
         }
-        <span class="cov1" title="1">return names, nil</span>
+        <span class="cov8" title="1">return names, nil</span>
 }
 
-func (osFileSystem) FindSQLFiles(dir string) ([]string, error) <span class="cov3" title="2">{
+func (osFileSystem) FindSQLFiles(dir string) ([]string, error) <span class="cov8" title="1">{
         var files []string
-        err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error </span><span class="cov6" title="6">{
-                if err != nil </span><span class="cov1" title="1">{
+        err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error </span><span class="cov8" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
-                <span class="cov6" title="5">if d.IsDir() </span><span class="cov3" title="2">{
+                <span class="cov8" title="1">if d.IsDir() </span><span class="cov8" title="1">{
                         return nil
                 }</span>
-                <span class="cov4" title="3">if filepath.Ext(path) == ".sql" </span><span class="cov3" title="2">{
+                <span class="cov8" title="1">if filepath.Ext(path) == ".sql" </span><span class="cov8" title="1">{
                         files = append(files, path)
                 }</span>
-                <span class="cov4" title="3">return nil</span>
+                <span class="cov8" title="1">return nil</span>
         })
-        <span class="cov3" title="2">if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov1" title="1">sort.Strings(files)
+        <span class="cov8" title="1">sort.Strings(files)
         return files, nil</span>
 }
 
-func (osFileSystem) ReadFile(name string) ([]byte, error) <span class="cov3" title="2">{
+func (osFileSystem) ReadFile(name string) ([]byte, error) <span class="cov8" title="1">{
         return os.ReadFile(name) //nolint:gosec // src は固定ルート配下で検証済み・ユーザー入力由来ではない
 }</span>
 
-func (osFileSystem) WriteFile(name string, data []byte, perm os.FileMode) error <span class="cov4" title="3">{
+func (osFileSystem) WriteFile(name string, data []byte, perm os.FileMode) error <span class="cov8" title="1">{
         return os.WriteFile(name, data, perm)
 }</span>
 
-func (osFileSystem) Remove(name string) error <span class="cov3" title="2">{
+func (osFileSystem) Remove(name string) error <span class="cov8" title="1">{
         return os.Remove(name)
 }</span>
 
 // NewGenerator は、merge-dml 用のジェネレーターインスタンスを生成します。
-func NewGenerator(logger logging.Logger, workDir string) *Generator <span class="cov1" title="1">{
+func NewGenerator(logger logging.Logger, workDir string) *Generator <span class="cov8" title="1">{
         return &amp;Generator{
                 logger:          logger,
                 callerSkipCount: 1,
@@ -1017,56 +1008,56 @@ func NewGenerator(logger logging.Logger, workDir string) *Generator <span class=
 }</span>
 
 // RunMerge は、DMLファイルをマージして、カテゴリごとに単一ファイルにまとめます。
-func RunMerge(ctx context.Context, gen *Generator, targetType string) error <span class="cov7" title="7">{
+func RunMerge(ctx context.Context, gen *Generator, targetType string) error <span class="cov8" title="1">{
         logger := gen.logger
 
         categories, err := gen.fs.ListSubDirNames(gen.dmlTypeRootAbs(targetType))
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 logger.CallerSkip(gen.callerSkipCount).Named("mergedml.listDirs").Error("failed to list directories",
                         logging.Error(logging.ErrorKey, err),
                 )
                 return err
         }</span>
-        <span class="cov6" title="6">if len(categories) == 0 </span><span class="cov3" title="2">{
+        <span class="cov8" title="1">if len(categories) == 0 </span><span class="cov8" title="1">{
                 logger.CallerSkip(gen.callerSkipCount).Named("mergedml.NoCategories").Info(
                         "no categories found under dml directory, cleanup only",
                         logging.String("dml_path", gen.dmlRootDir+targetType),
                 )
 
                 // ★ 0件でも stale を消す（=このtypeの生成物を全消しに近い挙動）
-                if err := gen.cleanupStaleGeneratedFiles(nil, targetType); err != nil </span><span class="cov1" title="1">{
+                if err := gen.cleanupStaleGeneratedFiles(nil, targetType); err != nil </span><span class="cov8" title="1">{
                         logger.CallerSkip(gen.callerSkipCount).Named("mergedml.cleanupStaleGeneratedFiles").Error(
                                 "failed to cleanup stale generated sql files",
                                 logging.Error(logging.ErrorKey, err),
                         )
                         return err
                 }</span>
-                <span class="cov1" title="1">return nil</span>
+                <span class="cov8" title="1">return nil</span>
         }
 
-        <span class="cov5" title="4">eg, egCtx := errgroup.WithContext(ctx)
+        <span class="cov8" title="1">eg, egCtx := errgroup.WithContext(ctx)
         sem := semaphore.NewWeighted(int64(resolveConcurrencyConst()))
 
-        for _, category := range categories </span><span class="cov5" title="4">{
+        for _, category := range categories </span><span class="cov8" title="1">{
                 cat := category
-                eg.Go(func() error </span><span class="cov5" title="4">{
-                        if err := sem.Acquire(egCtx, 1); err != nil </span><span class="cov1" title="1">{
+                eg.Go(func() error </span><span class="cov8" title="1">{
+                        if err := sem.Acquire(egCtx, 1); err != nil </span><span class="cov8" title="1">{
                                 return err
                         }</span>
-                        <span class="cov4" title="3">defer sem.Release(1)
+                        <span class="cov8" title="1">defer sem.Release(1)
 
                         return gen.buildCategorySQLFile(cat, targetType)</span>
                 })
         }
 
-        <span class="cov5" title="4">if err := eg.Wait(); err != nil </span><span class="cov3" title="2">{
+        <span class="cov8" title="1">if err := eg.Wait(); err != nil </span><span class="cov8" title="1">{
                 gen.logger.CallerSkip(gen.callerSkipCount).Named("mergedml.buildMergedQueries").Error("failed to build merged sql files",
                         logging.Error(logging.ErrorKey, err),
                 )
                 return err
         }</span>
 
-        <span class="cov3" title="2">if err := gen.cleanupStaleGeneratedFiles(categories, targetType); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err := gen.cleanupStaleGeneratedFiles(categories, targetType); err != nil </span><span class="cov8" title="1">{
                 gen.logger.CallerSkip(gen.callerSkipCount).Named("mergedml.cleanupStaleGeneratedFiles").Error(
                         "failed to cleanup stale generated sql files",
                         logging.Error(logging.ErrorKey, err),
@@ -1074,40 +1065,40 @@ func RunMerge(ctx context.Context, gen *Generator, targetType string) error <spa
                 return err
         }</span>
 
-        <span class="cov1" title="1">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // dmlTypeRootAbs は、指定されたタイプのDMLルートディレクトリの絶対パスを返します。
-func (g *Generator) dmlTypeRootAbs(targetType string) string <span class="cov7" title="8">{
+func (g *Generator) dmlTypeRootAbs(targetType string) string <span class="cov8" title="1">{
         return filepath.Join(g.workDir, g.dmlRootDir, targetType)
 }</span>
 
 // buildCategorySQLFile は、指定されたカテゴリのSQLファイルを連結して1つのSQLファイルにまとめます。
-func (g *Generator) buildCategorySQLFile(category, targetType string) error <span class="cov8" title="12">{
+func (g *Generator) buildCategorySQLFile(category, targetType string) error <span class="cov8" title="1">{
         // 入力走査も workDir 起点で統一する。CWD 起点だと CWD != workDir のとき走査結果が 0 件になり、
         // 「入力なし」分岐に入って workDir 配下の生成物を誤って削除してしまうため。
         dmlDir := filepath.Join(g.workDir, g.dmlRootDir, targetType, category)
 
         files, err := g.fs.FindSQLFiles(dmlDir)
-        if err != nil </span><span class="cov3" title="2">{
+        if err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov8" title="10">outName := fmt.Sprintf("%s_%s.gen.sql", category, targetType) // 例: prefecture_repository.gen.sql
+        <span class="cov8" title="1">outName := fmt.Sprintf("%s_%s.gen.sql", category, targetType) // 例: prefecture_repository.gen.sql
         // 出力先も workDir 起点で統一し、相対/絶対の二系統を排除する。
         dstPath := filepath.Join(g.workDir, g.genRootDir, outName)
 
-        if len(files) == 0 </span><span class="cov5" title="4">{
+        if len(files) == 0 </span><span class="cov8" title="1">{
                 // 「カテゴリは存在するが SQL が空」の場合は、生成物を消すのが最新状態とみなします。
-                if err := g.ensureUnderDir(dstPath); err != nil </span><span class="cov1" title="1">{
+                if err := g.ensureUnderDir(dstPath); err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
 
-                <span class="cov4" title="3">if err := g.fs.Remove(dstPath); err != nil &amp;&amp; !os.IsNotExist(err) </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">if err := g.fs.Remove(dstPath); err != nil &amp;&amp; !os.IsNotExist(err) </span><span class="cov8" title="1">{
                         return err
                 }</span>
 
-                <span class="cov3" title="2">g.logger.CallerSkip(g.callerSkipCount).Named("mergedml.buildCategorySQLFile").Info(
+                <span class="cov8" title="1">g.logger.CallerSkip(g.callerSkipCount).Named("mergedml.buildCategorySQLFile").Info(
                         "no sql files found, remove generated file if exists",
                         logging.String("category", category),
                         logging.String("type", targetType),
@@ -1116,60 +1107,60 @@ func (g *Generator) buildCategorySQLFile(category, targetType string) error <spa
                 return nil</span>
         }
 
-        <span class="cov6" title="6">g.logger.CallerSkip(g.callerSkipCount).Named("mergedml.buildCategorySQLFile").Info("build merged sql for sqlc",
+        <span class="cov8" title="1">g.logger.CallerSkip(g.callerSkipCount).Named("mergedml.buildCategorySQLFile").Info("build merged sql for sqlc",
                 logging.String("category", category),
                 logging.String("type", targetType),
                 logging.String("dst", dstPath),
                 logging.Int("files", len(files)),
         )
 
-        if err := g.ensureUnderDir(dstPath); err != nil </span><span class="cov1" title="1">{
+        if err := g.ensureUnderDir(dstPath); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
         // 成功時のみ一括書き込みし、途中失敗でも部分生成物を残しません。
-        <span class="cov6" title="5">var buf bytes.Buffer
-        for _, fpath := range files </span><span class="cov6" title="6">{
+        <span class="cov8" title="1">var buf bytes.Buffer
+        for _, fpath := range files </span><span class="cov8" title="1">{
                 // 由来が分かるように見出しを入れる（sqlcはSQLコメントなら無害）
                 _, _ = fmt.Fprintf(&amp;buf, "\n-- === source: %s ===\n", filepath.ToSlash(fpath))
 
                 b, err := g.fs.ReadFile(fpath)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
-                <span class="cov6" title="5">buf.Write(b)
+                <span class="cov8" title="1">buf.Write(b)
 
                 // ファイル末尾に改行が無いケースでも連結が壊れないように
-                if len(b) &gt; 0 &amp;&amp; b[len(b)-1] != '\n' </span><span class="cov6" title="5">{
+                if len(b) &gt; 0 &amp;&amp; b[len(b)-1] != '\n' </span><span class="cov8" title="1">{
                         buf.WriteByte('\n')
                 }</span>
         }
 
-        <span class="cov5" title="4">return g.fs.WriteFile(dstPath, buf.Bytes(), genFilePerm)</span>
+        <span class="cov8" title="1">return g.fs.WriteFile(dstPath, buf.Bytes(), genFilePerm)</span>
 }
 
 // ensureUnderDir は path が baseDir 配下かを検証します。
-func (g *Generator) ensureUnderDir(path string) error <span class="cov10" title="18">{
+func (g *Generator) ensureUnderDir(path string) error <span class="cov8" title="1">{
         // 誤ったパス解決や path traversal により、想定外の場所を操作しないようにします。
         absPath, err := filepath.Abs(path)
         if err != nil </span><span class="cov0" title="0">{
                 return err
         }</span>
 
-        <span class="cov10" title="18">absBase, err := filepath.Abs(filepath.Join(g.workDir, g.genRootDir))
+        <span class="cov8" title="1">absBase, err := filepath.Abs(filepath.Join(g.workDir, g.genRootDir))
         if err != nil </span><span class="cov0" title="0">{
                 return err
         }</span>
 
-        <span class="cov10" title="18">rel, err := filepath.Rel(absBase, absPath)
+        <span class="cov8" title="1">rel, err := filepath.Rel(absBase, absPath)
         if err != nil </span><span class="cov0" title="0">{
                 return err
         }</span>
-        <span class="cov10" title="18">rel = filepath.Clean(rel)
-        if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) </span><span class="cov5" title="4">{
+        <span class="cov8" title="1">rel = filepath.Clean(rel)
+        if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) </span><span class="cov8" title="1">{
                 return xerrors.New(fmt.Sprintf("path is outside of baseDir: path=%s base=%s", absPath, absBase))
         }</span>
-        <span class="cov9" title="14">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // resolveConcurrencyConst は、SQLCの同時実行数を解決します。
@@ -1178,56 +1169,56 @@ func (g *Generator) ensureUnderDir(path string) error <span class="cov10" title=
 //   - 下限: minSQLCConcurrency
 //
 // Docker/CIで全コア占有を避けるため、固定上限を設けています。
-func resolveConcurrencyConst() int <span class="cov6" title="5">{
+func resolveConcurrencyConst() int <span class="cov8" title="1">{
         return resolveConcurrency(runtime.NumCPU())
 }</span>
 
 // resolveConcurrency は、CPU 数を [minSQLCConcurrency, maxSQLCConcurrency] にクランプして同時実行数を返します。
-func resolveConcurrency(numCPU int) int <span class="cov8" title="10">{
+func resolveConcurrency(numCPU int) int <span class="cov8" title="1">{
         return max(min(numCPU, maxSQLCConcurrency), minSQLCConcurrency)
 }</span>
 
-func (g *Generator) cleanupStaleGeneratedFiles(categories []string, targetType string) error <span class="cov7" title="9">{
+func (g *Generator) cleanupStaleGeneratedFiles(categories []string, targetType string) error <span class="cov8" title="1">{
         keep := make(map[string]struct{}, len(categories))
-        for _, cat := range categories </span><span class="cov6" title="5">{
+        for _, cat := range categories </span><span class="cov8" title="1">{
                 keep[fmt.Sprintf("%s_%s.gen.sql", cat, targetType)] = struct{}{}
         }</span>
 
-        <span class="cov7" title="9">genAbs := filepath.Join(g.workDir, g.genRootDir) // /app/database/gen
+        <span class="cov8" title="1">genAbs := filepath.Join(g.workDir, g.genRootDir) // /app/database/gen
         names, err := g.fs.ListGenFileNames(genAbs)
-        if err != nil </span><span class="cov4" title="3">{
+        if err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov6" title="6">suffix := fmt.Sprintf("_%s.gen.sql", targetType)
+        <span class="cov8" title="1">suffix := fmt.Sprintf("_%s.gen.sql", targetType)
 
-        for _, name := range names </span><span class="cov8" title="10">{
-                if !strings.HasSuffix(name, suffix) </span><span class="cov3" title="2">{
+        for _, name := range names </span><span class="cov8" title="1">{
+                if !strings.HasSuffix(name, suffix) </span><span class="cov8" title="1">{
                         continue</span>
                 }
 
-                <span class="cov7" title="8">if _, ok := keep[name]; ok </span><span class="cov3" title="2">{
+                <span class="cov8" title="1">if _, ok := keep[name]; ok </span><span class="cov8" title="1">{
                         continue</span>
                 }
 
-                <span class="cov6" title="6">full := filepath.Join(genAbs, name)
+                <span class="cov8" title="1">full := filepath.Join(genAbs, name)
 
-                if err := g.ensureUnderDir(full); err != nil </span><span class="cov1" title="1">{
+                if err := g.ensureUnderDir(full); err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
 
-                <span class="cov6" title="5">if err := g.fs.Remove(full); err != nil </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">if err := g.fs.Remove(full); err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
 
-                <span class="cov5" title="4">g.logger.CallerSkip(g.callerSkipCount).Named("mergedml.cleanupStaleGeneratedFiles").Info(
+                <span class="cov8" title="1">g.logger.CallerSkip(g.callerSkipCount).Named("mergedml.cleanupStaleGeneratedFiles").Info(
                         "remove stale generated sql",
                         logging.String("file", filepath.ToSlash(full)),
                         logging.String("type", targetType),
                 )</span>
         }
 
-        <span class="cov5" title="4">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 </pre>
 		
@@ -1245,33 +1236,33 @@ import (
 
 // MigrateDownRun は、データベースマイグレーションを Down 方向に適用します。
 // steps=0 なら全マイグレーションをロールバックし、正数なら段数分だけ戻します。steps が負の場合はエラーを返します。dirty 状態の DB は Force で整合を取ってから Down します。
-func MigrateDownRun(steps int, database string, logger logging.Logger, newMigrator MigratorFactory) error <span class="cov9" title="8">{
-        if steps &lt; 0 </span><span class="cov1" title="1">{
+func MigrateDownRun(steps int, database string, logger logging.Logger, newMigrator MigratorFactory) error <span class="cov8" title="1">{
+        if steps &lt; 0 </span><span class="cov8" title="1">{
                 // 負値を許すと符号反転で Up 方向へ進んでしまうため、Down コマンドでは弾きます。
                 err := xerrors.New(fmt.Sprintf("steps must be zero or positive, got %d", steps))
                 logger.Named("migrateDownRun").Error("invalid steps", logging.Error(logging.ErrorKey, err))
                 return err
         }</span>
 
-        <span class="cov8" title="7">m, err := newMigrator(database)
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">m, err := newMigrator(database)
+        if err != nil </span><span class="cov8" title="1">{
                 logger.Named("migrateDownRun.buildMigrateInstance").Error("failed to create migrate instance",
                         logging.Error(logging.ErrorKey, err),
                 )
                 return err
         }</span>
 
-        <span class="cov8" title="6">if steps == 0 </span><span class="cov5" title="3">{
+        <span class="cov8" title="1">if steps == 0 </span><span class="cov8" title="1">{
                 logger.Named("migrateDownRun").Info("running full migration down")
-                if err := executeMigrateFullDown(m); err != nil </span><span class="cov1" title="1">{
+                if err := executeMigrateFullDown(m); err != nil </span><span class="cov8" title="1">{
                         logger.Named("migrateDownRun.executeMigrateFullDown").Error("down migration failed",
                                 logging.Error(logging.ErrorKey, err),
                         )
                         return err
                 }</span>
-        } else<span class="cov5" title="3"> {
+        } else<span class="cov8" title="1"> {
                 logger.Named("migrateDownRun").Info("running migration down steps", logging.Int("steps", steps))
-                if err := executeMigrateDownSteps(m, steps); err != nil </span><span class="cov1" title="1">{
+                if err := executeMigrateDownSteps(m, steps); err != nil </span><span class="cov8" title="1">{
                         logger.Named("migrateDownRun.executeMigrateDownSteps").Error("down migration steps failed",
                                 logging.Error(logging.ErrorKey, err),
                         )
@@ -1279,39 +1270,39 @@ func MigrateDownRun(steps int, database string, logger logging.Logger, newMigrat
                 }</span>
         }
 
-        <span class="cov6" title="4">logger.Named("migrateDownRun").Info("✅ migration down completed")
+        <span class="cov8" title="1">logger.Named("migrateDownRun").Info("✅ migration down completed")
         return nil</span>
 }
 
 // executeMigrateDownSteps は、現在位置から steps 段だけ Down します。無変更（ErrNoChange）は成功扱いです。
-func executeMigrateDownSteps(m Migrator, steps int) error <span class="cov5" title="3">{
+func executeMigrateDownSteps(m Migrator, steps int) error <span class="cov8" title="1">{
         // golang-migrate の Steps は負数を渡すとその段数だけ Down するため、検証済みの正値を反転します。
-        if err := m.Steps(-steps); err != nil &amp;&amp; !xerrors.Is(err, migrate.ErrNoChange) </span><span class="cov1" title="1">{
+        if err := m.Steps(-steps); err != nil &amp;&amp; !xerrors.Is(err, migrate.ErrNoChange) </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov3" title="2">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // executeMigrateFullDown は、マイグレーションを全てダウングレードして、DBを初期状態に戻します。
-func executeMigrateFullDown(m Migrator) error <span class="cov10" title="10">{
+func executeMigrateFullDown(m Migrator) error <span class="cov8" title="1">{
         // dirty 状態のままでは Down できないため、現在バージョンで整合を取り直してから巻き戻します。
         v, dirty, err := m.Version()
-        if err != nil &amp;&amp; !xerrors.Is(err, migrate.ErrNilVersion) </span><span class="cov1" title="1">{
+        if err != nil &amp;&amp; !xerrors.Is(err, migrate.ErrNilVersion) </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov9" title="9">if dirty </span><span class="cov7" title="5">{
+        <span class="cov8" title="1">if dirty </span><span class="cov8" title="1">{
                 safeValue, err := safecast.UintToInt(v)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
-                <span class="cov6" title="4">if err := m.Force(safeValue); err != nil </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">if err := m.Force(safeValue); err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
         }
-        <span class="cov8" title="7">if err := m.Down(); err != nil &amp;&amp; !xerrors.Is(err, migrate.ErrNoChange) </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err := m.Down(); err != nil &amp;&amp; !xerrors.Is(err, migrate.ErrNoChange) </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov8" title="6">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 </pre>
 		
@@ -1328,50 +1319,50 @@ import (
 
 // MigrateUpRun は、データベースマイグレーションを Up 方向に適用します。
 // steps=0 なら全マイグレーションを適用し、正数なら段数分だけ適用します。steps が負の場合はエラーを返します。既に最新の場合（ErrNoChange）は成功扱いです。
-func MigrateUpRun(steps int, database string, logger logging.Logger, newMigrator MigratorFactory) error <span class="cov10" title="8">{
-        if steps &lt; 0 </span><span class="cov1" title="1">{
+func MigrateUpRun(steps int, database string, logger logging.Logger, newMigrator MigratorFactory) error <span class="cov8" title="1">{
+        if steps &lt; 0 </span><span class="cov8" title="1">{
                 err := xerrors.New(fmt.Sprintf("steps must be zero or positive, got %d", steps))
                 logger.Named("migrateUpRun").Error("invalid steps", logging.Error(logging.ErrorKey, err))
                 return err
         }</span>
 
-        <span class="cov9" title="7">m, err := newMigrator(database)
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">m, err := newMigrator(database)
+        if err != nil </span><span class="cov8" title="1">{
                 logger.Named("migrateUpRun.buildMigrateInstance").Error("failed to create migrate instance",
                         logging.Error(logging.ErrorKey, err),
                 )
                 return err
         }</span>
 
-        <span class="cov8" title="6">if steps == 0 </span><span class="cov5" title="3">{
+        <span class="cov8" title="1">if steps == 0 </span><span class="cov8" title="1">{
                 logger.Named("migrateUpRun").Info("running full migration up")
-        }</span> else<span class="cov5" title="3"> {
+        }</span> else<span class="cov8" title="1"> {
                 logger.Named("migrateUpRun").Info("running migration up steps", logging.Int("steps", steps))
         }</span>
-        <span class="cov8" title="6">if err := executeMigrateUp(m, steps); err != nil </span><span class="cov4" title="2">{
+        <span class="cov8" title="1">if err := executeMigrateUp(m, steps); err != nil </span><span class="cov8" title="1">{
                 logger.Named("migrateUpRun.executeMigrateUp").Error("migration failed",
                         logging.Error(logging.ErrorKey, err),
                 )
                 return err
         }</span>
-        <span class="cov7" title="4">logger.Named("migrateUpRun").Info("✅ migration completed")
+        <span class="cov8" title="1">logger.Named("migrateUpRun").Info("✅ migration completed")
 
         return nil</span>
 }
 
 // executeMigrateUp は、steps が 0 なら全件、正なら段数指定で Up します。無変更（ErrNoChange）は成功扱いです。
-func executeMigrateUp(m Migrator, steps int) error <span class="cov8" title="6">{
+func executeMigrateUp(m Migrator, steps int) error <span class="cov8" title="1">{
         var err error
-        if steps == 0 </span><span class="cov5" title="3">{
+        if steps == 0 </span><span class="cov8" title="1">{
                 err = m.Up()
-        }</span> else<span class="cov5" title="3"> {
+        }</span> else<span class="cov8" title="1"> {
                 err = m.Steps(steps)
         }</span>
         // 既に最新であれば ErrNoChange になるため、両経路とも成功扱いとして握りつぶします。
-        <span class="cov8" title="6">if err != nil &amp;&amp; !xerrors.Is(err, migrate.ErrNoChange) </span><span class="cov4" title="2">{
+        <span class="cov8" title="1">if err != nil &amp;&amp; !xerrors.Is(err, migrate.ErrNoChange) </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov7" title="4">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 </pre>
 		
@@ -1391,12 +1382,12 @@ func RunRelay(
         shutdownTimeout time.Duration,
         startApp func(context.Context) error,
         stopApp func(context.Context) error,
-) error <span class="cov10" title="3">{
-        if err := startApp(ctx); err != nil </span><span class="cov1" title="1">{
+) error <span class="cov8" title="1">{
+        if err := startApp(ctx); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov6" title="2">&lt;-ctx.Done()
+        <span class="cov8" title="1">&lt;-ctx.Done()
 
         stopCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
         defer cancel()
@@ -1418,16 +1409,16 @@ type ReplayFunc func(ctx context.Context, messageID *uuid.UUID) (int64, error)
 
 // RunReplayWith は、rawMessageID を解釈して replay を実行し、戻した件数を返します。
 // rawMessageID が空なら全 dead 行、指定時は当該 message_id のみを対象とします。
-func RunReplayWith(ctx context.Context, rawMessageID string, replay ReplayFunc) (int64, error) <span class="cov10" title="4">{
+func RunReplayWith(ctx context.Context, rawMessageID string, replay ReplayFunc) (int64, error) <span class="cov8" title="1">{
         var id *uuid.UUID
-        if rawMessageID != "" </span><span class="cov5" title="2">{
+        if rawMessageID != "" </span><span class="cov8" title="1">{
                 parsed, err := uuid.Parse(rawMessageID)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return 0, err
                 }</span>
-                <span class="cov1" title="1">id = &amp;parsed</span>
+                <span class="cov8" title="1">id = &amp;parsed</span>
         }
-        <span class="cov8" title="3">return replay(ctx, id)</span>
+        <span class="cov8" title="1">return replay(ctx, id)</span>
 }
 </pre>
 		
@@ -1459,50 +1450,50 @@ func RunDBSeed(
         fsys fs.FS,
         database string,
         openDB func(logging.Logger, string) (driver.DatabaseDriver, error),
-) error <span class="cov6" title="5">{
+) error <span class="cov8" title="1">{
         db, err := openDB(logger, database)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 logger.Named("dbSeedRun.dbOpen").Error("failed to open database connection", logging.Error(logging.ErrorKey, err))
                 return err
         }</span>
-        <span class="cov5" title="4">defer func() </span><span class="cov5" title="4">{
-                if cerr := db.Close(); cerr != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">defer func() </span><span class="cov8" title="1">{
+                if cerr := db.Close(); cerr != nil </span><span class="cov8" title="1">{
                         logger.Named("dbSeedRun.dbClose").Error("failed to close database connection", logging.Error(logging.ErrorKey, cerr))
                 }</span>
         }()
 
-        <span class="cov5" title="4">files, err := fsys.Glob(seedFilePlace + "/*.sql")
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">files, err := fsys.Glob(seedFilePlace + "/*.sql")
+        if err != nil </span><span class="cov8" title="1">{
                 logger.Named("dbSeedRun.globSeedFiles").Error("failed to glob seed files", logging.Error(logging.ErrorKey, err))
                 return err
         }</span>
 
-        <span class="cov4" title="3">ctx := context.Background()
+        <span class="cov8" title="1">ctx := context.Background()
         return runSeeds(ctx, fsys, db, logger, files)</span>
 }
 
 // runSeeds は、seed ファイル群を昇順で順次実行します。実行エラーは握り潰さず呼び出し元へ返しつつ、
 // 他ファイルの投入は継続します（テーブル未作成のスキップは execSeedFile 側で吸収）。
-func runSeeds(ctx context.Context, fsys fs.FS, db driver.DatabaseDriver, logger logging.Logger, files []string) error <span class="cov6" title="5">{
+func runSeeds(ctx context.Context, fsys fs.FS, db driver.DatabaseDriver, logger logging.Logger, files []string) error <span class="cov8" title="1">{
         var seedErr error
         sort.Strings(files)
-        for _, f := range files </span><span class="cov7" title="6">{
-                if err := execSeedFile(ctx, fsys, db, logger, f); err != nil </span><span class="cov3" title="2">{
+        for _, f := range files </span><span class="cov8" title="1">{
+                if err := execSeedFile(ctx, fsys, db, logger, f); err != nil </span><span class="cov8" title="1">{
                         seedErr = xerrors.Join(seedErr, err)
                 }</span>
         }
-        <span class="cov6" title="5">if seedErr != nil </span><span class="cov3" title="2">{
+        <span class="cov8" title="1">if seedErr != nil </span><span class="cov8" title="1">{
                 return seedErr
         }</span>
-        <span class="cov4" title="3">logger.Named("dbSeedRun").Info("✅ seeding completed")
+        <span class="cov8" title="1">logger.Named("dbSeedRun").Info("✅ seeding completed")
 
         return nil</span>
 }
 
 // execSeedFile は、1つの seed ファイルの読み込みと SQL 実行を担当します。
-func execSeedFile(ctx context.Context, fsys fs.FS, db driver.DatabaseDriver, logger logging.Logger, filePath string) error <span class="cov9" title="10">{
+func execSeedFile(ctx context.Context, fsys fs.FS, db driver.DatabaseDriver, logger logging.Logger, filePath string) error <span class="cov8" title="1">{
         data, err := fsys.ReadFile(filePath)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 logger.Named("dbSeedRun.os.ReadFile").Error(
                         "failed to read seed file",
                         logging.String("file", filePath),
@@ -1511,16 +1502,16 @@ func execSeedFile(ctx context.Context, fsys fs.FS, db driver.DatabaseDriver, log
                 return err
         }</span>
 
-        <span class="cov8" title="9">_, err = db.Exec(ctx, string(data))
+        <span class="cov8" title="1">_, err = db.Exec(ctx, string(data))
         return handleSeedExecResult(logger, filePath, err)</span>
 }
 
 // handleSeedExecResult は、seed 実行結果を PostgreSQL 固有エラーの種類に応じて記録し、
 // スキップ可能なケース（成功・対象テーブル未作成）では nil を、それ以外の実行エラーでは
 // そのエラーを返します。
-func handleSeedExecResult(logger logging.Logger, filePath string, err error) error <span class="cov10" title="13">{
+func handleSeedExecResult(logger logging.Logger, filePath string, err error) error <span class="cov8" title="1">{
         log := logger.Named("dbSeedRun.Exec")
-        if err == nil </span><span class="cov7" title="6">{
+        if err == nil </span><span class="cov8" title="1">{
                 log.Info(
                         "seed file executed successfully",
                         logging.String("file", filePath),
@@ -1528,10 +1519,10 @@ func handleSeedExecResult(logger logging.Logger, filePath string, err error) err
                 return nil
         }</span>
 
-        <span class="cov7" title="7">var pgErr *pgconn.PgError
+        <span class="cov8" title="1">var pgErr *pgconn.PgError
         isPgErr := xerrors.As(err, &amp;pgErr)
         // seed 対象テーブルが未作成の環境では警告に留め、他の seed 実行を継続します（スキップ扱い）。
-        if isPgErr &amp;&amp; pgErr.Code == relationDoesNotExistCode </span><span class="cov3" title="2">{
+        if isPgErr &amp;&amp; pgErr.Code == relationDoesNotExistCode </span><span class="cov8" title="1">{
                 log.Warn(
                         "table does not exist, skipping seed",
                         logging.String("file", filePath),
@@ -1540,12 +1531,12 @@ func handleSeedExecResult(logger logging.Logger, filePath string, err error) err
                 return nil
         }</span>
 
-        <span class="cov6" title="5">message := "failed to exec seed file"
-        if !isPgErr </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">message := "failed to exec seed file"
+        if !isPgErr </span><span class="cov8" title="1">{
                 message = "failed to exec seed file (non-postgres error)"
         }</span>
 
-        <span class="cov6" title="5">log.Error(
+        <span class="cov8" title="1">log.Error(
                 message,
                 logging.String("file", filePath),
                 logging.Error(logging.ErrorKey, err),
@@ -1576,7 +1567,7 @@ const (
 )
 
 // metricsServer は、メトリクス/pprof（DefaultServeMux）を公開する補助 HTTP サーバーを生成します。
-func metricsServer(mtcCfg *config.MetricsConfig) *http.Server <span class="cov8" title="4">{
+func metricsServer(mtcCfg *config.MetricsConfig) *http.Server <span class="cov8" title="1">{
         return &amp;http.Server{
                 // pprof / metrics は DefaultServeMux に登録される前提で補助サーバーとして公開します。
                 Addr:              mtcCfg.Host() + ":" + strconv.Itoa(mtcCfg.Port()),
@@ -1589,27 +1580,27 @@ func metricsServer(mtcCfg *config.MetricsConfig) *http.Server <span class="cov8"
 }</span>
 
 // NewMetricsServer は、メトリクスサーバーの開始および終了関数を生成します。
-func NewMetricsServer(mtcCfg *config.MetricsConfig, logger logging.Logger) (func(), func(ctx context.Context)) <span class="cov7" title="3">{
+func NewMetricsServer(mtcCfg *config.MetricsConfig, logger logging.Logger) (func(), func(ctx context.Context)) <span class="cov8" title="1">{
         metricsSrv := metricsServer(mtcCfg)
 
-        start := func() </span><span class="cov4" title="2">{
-                go func() </span><span class="cov4" title="2">{
+        start := func() </span><span class="cov8" title="1">{
+                go func() </span><span class="cov8" title="1">{
                         logListenError(logger, metricsSrv.ListenAndServe())
                 }</span>()
         }
-        <span class="cov7" title="3">end := func(ctx context.Context) </span><span class="cov7" title="3">{
+        <span class="cov8" title="1">end := func(ctx context.Context) </span><span class="cov8" title="1">{
                 // 停止失敗でアプリ本体を巻き込まないよう、panic せずログに留める（start 側の goroutine と同方針）。
-                if err := metricsSrv.Shutdown(ctx); err != nil </span><span class="cov1" title="1">{
+                if err := metricsSrv.Shutdown(ctx); err != nil </span><span class="cov8" title="1">{
                         logger.Named("metrics.Shutdown").Error("metrics server shutdown error", logging.Error(logging.ErrorKey, err))
                 }</span>
         }
-        <span class="cov7" title="3">return start, end</span>
+        <span class="cov8" title="1">return start, end</span>
 }
 
 // logListenError は、補助サーバーの ListenAndServe 戻り値を判定し、正常停止(ErrServerClosed)以外の
 // エラーのみをログ記録します。bind 失敗等でアプリ本体を巻き込まないよう、panic せずログに留めます。
-func logListenError(logger logging.Logger, err error) <span class="cov10" title="5">{
-        if err != nil &amp;&amp; !xerrors.Is(err, http.ErrServerClosed) </span><span class="cov1" title="1">{
+func logListenError(logger logging.Logger, err error) <span class="cov8" title="1">{
+        if err != nil &amp;&amp; !xerrors.Is(err, http.ErrServerClosed) </span><span class="cov8" title="1">{
                 logger.Named("metrics.ListenAndServe").Error("metrics server error", logging.Error(logging.ErrorKey, err))
         }</span>
 }
@@ -1627,11 +1618,11 @@ import (
 
 // ResolveMetricsStop は、本番モードでない場合のみ補助メトリクスサーバーを起動し、その停止関数を返します。
 // 本番モードでは起動せず nil を返します（呼び出し側は nil を「停止不要」として扱います）。
-func ResolveMetricsStop(appCfg *config.ApplicationConfig, newMetrics func() (func(), func(context.Context))) func(context.Context) <span class="cov5" title="2">{
-        if appCfg.IsProductionMode() </span><span class="cov1" title="1">{
+func ResolveMetricsStop(appCfg *config.ApplicationConfig, newMetrics func() (func(), func(context.Context))) func(context.Context) <span class="cov8" title="1">{
+        if appCfg.IsProductionMode() </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov1" title="1">startMetrics, stopMetrics := newMetrics()
+        <span class="cov8" title="1">startMetrics, stopMetrics := newMetrics()
         startMetrics()
         return stopMetrics</span>
 }
@@ -1645,12 +1636,12 @@ func RunServer(
         startApp func(context.Context) error,
         stopApp func(context.Context) error,
         stopMetrics func(context.Context),
-) error <span class="cov10" title="4">{
-        if err := startApp(ctx); err != nil </span><span class="cov1" title="1">{
+) error <span class="cov8" title="1">{
+        if err := startApp(ctx); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov8" title="3">&lt;-ctx.Done()
+        <span class="cov8" title="1">&lt;-ctx.Done()
 
         // 停止処理は無期限に待たず、シャットダウン開始時点から設定タイムアウト内で完了させます。
         // タイムアウトを起動直後ではなくこの時点で計測することで、稼働時間に消費されないようにします。
@@ -1660,11 +1651,11 @@ func RunServer(
         // メトリクスサーバーとアプリ本体を、同じシャットダウン用 context で順に停止します。
         // 停止用 context は ctx を継承しない（ctx は既にキャンセル済みのため、継承すると即時に
         // 期限切れになり停止猶予が無くなる）。これは意図した設計なので contextcheck を抑制する。
-        if stopMetrics != nil </span><span class="cov1" title="1">{
+        if stopMetrics != nil </span><span class="cov8" title="1">{
                 stopMetrics(stopCtx) //nolint:contextcheck // 停止用 context は意図的に ctx を継承しない
         }</span>
 
-        <span class="cov8" title="3">return stopApp(stopCtx)</span> //nolint:contextcheck // 停止用 context は意図的に ctx を継承しない
+        <span class="cov8" title="1">return stopApp(stopCtx)</span> //nolint:contextcheck // 停止用 context は意図的に ctx を継承しない
 }
 </pre>
 		
@@ -1689,7 +1680,7 @@ const (
 // NewHealthServer は、liveness(/healthz) と readiness(/readyz) を公開する health listener の
 // 開始・終了関数を返します。ready は readiness 判定（例: engine.Healthy）を渡します。
 // metrics サーバーと異なり専用の ServeMux を使い、pprof/metrics と衝突しません。
-func NewHealthServer(addr string, ready func() bool, logger logging.Logger) (func(), func(context.Context)) <span class="cov9" title="11">{
+func NewHealthServer(addr string, ready func() bool, logger logging.Logger) (func(), func(context.Context)) <span class="cov8" title="1">{
         srv := &amp;http.Server{
                 Addr:              addr,
                 Handler:           healthMux(ready),
@@ -1699,38 +1690,38 @@ func NewHealthServer(addr string, ready func() bool, logger logging.Logger) (fun
                 IdleTimeout:       healthIdleTimeout,
         }
 
-        start := func() </span><span class="cov8" title="8">{
-                go func() </span><span class="cov8" title="8">{
-                        if err := srv.ListenAndServe(); err != nil &amp;&amp; !xerrors.Is(err, http.ErrServerClosed) </span><span class="cov1" title="1">{
+        start := func() </span><span class="cov8" title="1">{
+                go func() </span><span class="cov8" title="1">{
+                        if err := srv.ListenAndServe(); err != nil &amp;&amp; !xerrors.Is(err, http.ErrServerClosed) </span><span class="cov8" title="1">{
                                 logger.Named("worker.health").Error("health server error", logging.Error(logging.ErrorKey, err))
                         }</span>
                 }()
         }
-        <span class="cov9" title="11">stop := func(ctx context.Context) </span><span class="cov7" title="7">{
-                if err := srv.Shutdown(ctx); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">stop := func(ctx context.Context) </span><span class="cov8" title="1">{
+                if err := srv.Shutdown(ctx); err != nil </span><span class="cov8" title="1">{
                         logger.Named("worker.health").Error("health server shutdown error", logging.Error(logging.ErrorKey, err))
                 }</span>
         }
-        <span class="cov9" title="11">return start, stop</span>
+        <span class="cov8" title="1">return start, stop</span>
 }
 
 // healthMux は、liveness(/healthz) と readiness(/readyz) を提供する ServeMux を構築します。
-func healthMux(ready func() bool) *http.ServeMux <span class="cov10" title="14">{
+func healthMux(ready func() bool) *http.ServeMux <span class="cov8" title="1">{
         mux := http.NewServeMux()
-        mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) </span><span class="cov1" title="1">{
+        mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) </span><span class="cov8" title="1">{
                 w.WriteHeader(http.StatusOK)
                 _, _ = w.Write([]byte("ok"))
         }</span>)
-        <span class="cov10" title="14">mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) </span><span class="cov4" title="3">{
-                if ready() </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) </span><span class="cov8" title="1">{
+                if ready() </span><span class="cov8" title="1">{
                         w.WriteHeader(http.StatusOK)
                         _, _ = w.Write([]byte("ready"))
                         return
                 }</span>
-                <span class="cov1" title="1">w.WriteHeader(http.StatusServiceUnavailable)
+                <span class="cov8" title="1">w.WriteHeader(http.StatusServiceUnavailable)
                 _, _ = w.Write([]byte("not ready"))</span>
         })
-        <span class="cov10" title="14">return mux</span>
+        <span class="cov8" title="1">return mux</span>
 }
 </pre>
 		
@@ -1756,14 +1747,14 @@ func RunWorkerWith(
         args []string,
         grace time.Duration,
         provide func() (StartFunc, StopFunc),
-) error <span class="cov1" title="1">{
+) error <span class="cov8" title="1">{
         start, stop := provide()
         return runWorker(ctx, name, args, grace, start, stop)
 }</span>
 
 // runWorker は、worker を起動して常駐させ、SIGTERM(ctx 完了) もしくは engine 自走停止で
 // グレースフルに停止します。job と異なり完了 channel を待ち続ける常駐型です。
-func runWorker(ctx context.Context, name string, args []string, grace time.Duration, start StartFunc, stop StopFunc) error <span class="cov7" title="4">{
+func runWorker(ctx context.Context, name string, args []string, grace time.Duration, start StartFunc, stop StopFunc) error <span class="cov8" title="1">{
         done := start(ctx, name, args)
 
         var (
@@ -1771,31 +1762,31 @@ func runWorker(ctx context.Context, name string, args []string, grace time.Durat
                 selfStopped bool
         )
         select </span>{
-        case runErr = &lt;-done:<span class="cov1" title="1">
+        case runErr = &lt;-done:<span class="cov8" title="1">
                 // engine が自走停止（Fatal / unknown worker）。done は消費済み。
                 selfStopped = true</span>
-        case &lt;-ctx.Done():<span class="cov6" title="3"></span>
+        case &lt;-ctx.Done():<span class="cov8" title="1"></span>
                 // SIGTERM。engine を drain して停止し、停止後に結果を確認する。
         }
 
-        <span class="cov7" title="4">gracefulStop(ctx, grace, stop)
+        <span class="cov8" title="1">gracefulStop(ctx, grace, stop)
 
         // SIGTERM 経路では engine の実際の終了結果を必ず待ち切る。
         // grace が engine の drain 完了より先に満了して OnStop が早期 return しても、
         // engine goroutine は drain 後に必ず done へ結果を書く（DrainTimeout で有界。
         // 起動時 validation で DrainTimeout &lt; grace を保証）。
         // 非ブロッキングで default を取ると、その間に発生した Fatal を取りこぼし exit 0 になってしまう。
-        if !selfStopped </span><span class="cov6" title="3">{
+        if !selfStopped </span><span class="cov8" title="1">{
                 runErr = &lt;-done
         }</span>
-        <span class="cov7" title="4">return runErr</span>
+        <span class="cov8" title="1">return runErr</span>
 }
 
 // gracefulStop は、停止開始時点から grace の猶予を与えて後始末を実行します。
 // ctx は SIGTERM で既にキャンセル済みのため、停止用 context はキャンセルだけ切り離して
 // （trace/baggage は引き継ぎつつ）作り直します。
 // 停止エラーは worker 本体の実行結果（runErr）で返すため、後始末失敗は exit code に含めない。
-func gracefulStop(ctx context.Context, grace time.Duration, stop StopFunc) <span class="cov10" title="6">{
+func gracefulStop(ctx context.Context, grace time.Duration, stop StopFunc) <span class="cov8" title="1">{
         stopCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), grace)
         defer cancel()
         _ = stop(stopCtx)
@@ -1820,24 +1811,24 @@ import (
 const exporterNone = "none"
 
 // New は、アプリケーションの設定を初期化します。
-func New() (*Config, error) <span class="cov5" title="24">{
+func New() (*Config, error) <span class="cov8" title="1">{
         cfg, err := env.ParseAs[Loader]()
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Join(ErrFailedToParseConfig, err)
         }</span>
 
-        <span class="cov5" title="23">if err := validateConfig(cfg); err != nil </span><span class="cov1" title="2">{
+        <span class="cov8" title="1">if err := validateConfig(cfg); err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
         // CIDR は解析が検証を兼ねる（parse, don't validate）。値が必要な New で
         // 一度だけ解析し、検証済みの *net.IPNet を直接 Config へ格納する。
-        <span class="cov5" title="21">cidr, err := parseCIDR(cfg.Security.CIDR)
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">cidr, err := parseCIDR(cfg.Security.CIDR)
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov4" title="20">return &amp;Config{
+        <span class="cov8" title="1">return &amp;Config{
                 os: OperatingSystemConfig{
                         timezone: cfg.OS.Timezone,
                 },
@@ -1942,164 +1933,164 @@ func New() (*Config, error) <span class="cov5" title="24">{
 }
 
 // validateConfig は、Loaderの内容を検証します。
-func validateConfig(cfg Loader) error <span class="cov5" title="30">{
-        if err := validateApplicationConfig(cfg.App); err != nil </span><span class="cov2" title="3">{
+func validateConfig(cfg Loader) error <span class="cov8" title="1">{
+        if err := validateApplicationConfig(cfg.App); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov5" title="27">if err := validateServerConfig(cfg.Server); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err := validateServerConfig(cfg.Server); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov5" title="26">if err := validateDatabaseConfig(cfg.Database); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err := validateDatabaseConfig(cfg.Database); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov5" title="25">if err := validateDBConnectionConfig(cfg.DBConnection); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err := validateDBConnectionConfig(cfg.DBConnection); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov5" title="24">if err := validateSecurityConfig(cfg.Security); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err := validateSecurityConfig(cfg.Security); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov5" title="23">if err := validateAuthConfig(cfg.Auth); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err := validateAuthConfig(cfg.Auth); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov5" title="22">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // validateApplicationConfig は、アプリケーション設定を検証します。
-func validateApplicationConfig(appCfg Application) error <span class="cov5" title="33">{
-        if appCfg.Mode != DevelopmentMode &amp;&amp; appCfg.Mode != ProductionMode </span><span class="cov2" title="4">{
+func validateApplicationConfig(appCfg Application) error <span class="cov8" title="1">{
+        if appCfg.Mode != DevelopmentMode &amp;&amp; appCfg.Mode != ProductionMode </span><span class="cov8" title="1">{
                 return ErrInvalidAppMode
         }</span>
-        <span class="cov5" title="29">switch appCfg.LogLevel </span>{
-        case LogLevelDebug, LogLevelInfo, LogLevelWarn, LogLevelError:<span class="cov5" title="28"></span>
-        default:<span class="cov1" title="1">
+        <span class="cov8" title="1">switch appCfg.LogLevel </span>{
+        case LogLevelDebug, LogLevelInfo, LogLevelWarn, LogLevelError:<span class="cov8" title="1"></span>
+        default:<span class="cov8" title="1">
                 return ErrInvalidLogLevel</span>
         }
-        <span class="cov5" title="28">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // validatePortRange は、ポート番号が許容範囲内かを検証します。
-func validatePortRange(port int, outOfRangeErr error) error <span class="cov6" title="68">{
-        if port &lt; MinPort || MaxPort &lt; port </span><span class="cov2" title="4">{
+func validatePortRange(port int, outOfRangeErr error) error <span class="cov8" title="1">{
+        if port &lt; MinPort || MaxPort &lt; port </span><span class="cov8" title="1">{
                 return outOfRangeErr
         }</span>
-        <span class="cov6" title="64">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // validateServerConfig は、サーバー設定を検証します。
-func validateServerConfig(srvCfg Server) error <span class="cov5" title="37">{
-        if err := validatePortRange(srvCfg.Port, ErrInvalidPortRange); err != nil </span><span class="cov1" title="2">{
+func validateServerConfig(srvCfg Server) error <span class="cov8" title="1">{
+        if err := validatePortRange(srvCfg.Port, ErrInvalidPortRange); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov5" title="35">if srvCfg.ReadHeaderTimeout &lt;= 0 </span><span class="cov1" title="2">{
+        <span class="cov8" title="1">if srvCfg.ReadHeaderTimeout &lt;= 0 </span><span class="cov8" title="1">{
                 return ErrInvalidReadHeaderTimeout
         }</span>
 
-        <span class="cov5" title="33">if srvCfg.ReadTimeout &lt;= 0 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if srvCfg.ReadTimeout &lt;= 0 </span><span class="cov8" title="1">{
                 return ErrInvalidReadTimeout
         }</span>
 
-        <span class="cov5" title="32">if srvCfg.WriteTimeout &lt;= 0 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if srvCfg.WriteTimeout &lt;= 0 </span><span class="cov8" title="1">{
                 return ErrInvalidWriteTimeout
         }</span>
 
-        <span class="cov5" title="31">if srvCfg.IdleTimeout &lt;= 0 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if srvCfg.IdleTimeout &lt;= 0 </span><span class="cov8" title="1">{
                 return ErrInvalidIdleTimeout
         }</span>
 
-        <span class="cov5" title="30">if srvCfg.ReadHeaderTimeout &gt; srvCfg.ReadTimeout </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if srvCfg.ReadHeaderTimeout &gt; srvCfg.ReadTimeout </span><span class="cov8" title="1">{
                 return ErrReadHeaderTimeoutExceedsReadTimeout
         }</span>
 
-        <span class="cov5" title="29">if srvCfg.WriteTimeout &lt; srvCfg.RequestTimeout </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if srvCfg.WriteTimeout &lt; srvCfg.RequestTimeout </span><span class="cov8" title="1">{
                 return ErrWriteTimeoutBelowRequestTimeout
         }</span>
-        <span class="cov5" title="28">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // validateDatabaseConfig は、データベース設定を検証します。
-func validateDatabaseConfig(dbCfg Database) error <span class="cov5" title="31">{
-        if err := validatePortRange(dbCfg.Port, ErrInvalidDBPortRange); err != nil </span><span class="cov1" title="2">{
+func validateDatabaseConfig(dbCfg Database) error <span class="cov8" title="1">{
+        if err := validatePortRange(dbCfg.Port, ErrInvalidDBPortRange); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov5" title="29">if dbCfg.PingTimeout &lt;= 0 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if dbCfg.PingTimeout &lt;= 0 </span><span class="cov8" title="1">{
                 return ErrInvalidDBPingTimeout
         }</span>
-        <span class="cov5" title="28">if dbCfg.SlowQueryWarnThreshold &lt; 0 </span><span class="cov1" title="2">{
+        <span class="cov8" title="1">if dbCfg.SlowQueryWarnThreshold &lt; 0 </span><span class="cov8" title="1">{
                 return ErrInvalidSlowQueryWarnThreshold
         }</span>
-        <span class="cov5" title="26">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // validateDBConnectionConfig は、データベース接続設定を検証します。
-func validateDBConnectionConfig(dbConnCfg DBConnection) error <span class="cov5" title="27">{
-        if dbConnCfg.MinConns &gt; dbConnCfg.MaxConns </span><span class="cov1" title="2">{
+func validateDBConnectionConfig(dbConnCfg DBConnection) error <span class="cov8" title="1">{
+        if dbConnCfg.MinConns &gt; dbConnCfg.MaxConns </span><span class="cov8" title="1">{
                 return ErrInvalidExceedMaxConns
         }</span>
-        <span class="cov5" title="25">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // validateSecurityConfig は、セキュリティ設定を検証します。
 // CIDR は解析が検証を兼ねるため、ここでは扱わず New の parseCIDR に委ねる。
-func validateSecurityConfig(secCfg Security) error <span class="cov5" title="31">{
-        if len(secCfg.AllowedOrigins) == 0 </span><span class="cov1" title="2">{
+func validateSecurityConfig(secCfg Security) error <span class="cov8" title="1">{
+        if len(secCfg.AllowedOrigins) == 0 </span><span class="cov8" title="1">{
                 return ErrEmptyAllowedOrigins
         }</span>
 
-        <span class="cov5" title="29">if secCfg.BcryptCost &lt; bcrypt.MinCost || bcrypt.MaxCost &lt; secCfg.BcryptCost </span><span class="cov1" title="2">{
+        <span class="cov8" title="1">if secCfg.BcryptCost &lt; bcrypt.MinCost || bcrypt.MaxCost &lt; secCfg.BcryptCost </span><span class="cov8" title="1">{
                 return ErrInvalidBcryptCost
         }</span>
 
-        <span class="cov5" title="27">for _, origin := range secCfg.AllowedOrigins </span><span class="cov6" title="51">{
+        <span class="cov8" title="1">for _, origin := range secCfg.AllowedOrigins </span><span class="cov8" title="1">{
                 parsedURL, err := url.Parse(origin)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return ErrHTTPOnlyAllowedForLocalhost
                 }</span>
                 // スキームは url.Parse で小文字正規化されるが、念のため EqualFold で大小無視判定する。
-                <span class="cov6" title="50">if strings.EqualFold(parsedURL.Scheme, "http") &amp;&amp;
-                        parsedURL.Hostname() != "localhost" &amp;&amp; parsedURL.Hostname() != "127.0.0.1" </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">if strings.EqualFold(parsedURL.Scheme, "http") &amp;&amp;
+                        parsedURL.Hostname() != "localhost" &amp;&amp; parsedURL.Hostname() != "127.0.0.1" </span><span class="cov8" title="1">{
                         return ErrHTTPOnlyAllowedForLocalhost
                 }</span>
         }
 
-        <span class="cov5" title="25">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // parseCIDR は、CIDR 文字列を *net.IPNet へ解析します。
-func parseCIDR(s string) (*net.IPNet, error) <span class="cov5" title="21">{
+func parseCIDR(s string) (*net.IPNet, error) <span class="cov8" title="1">{
         _, cidr, err := net.ParseCIDR(s)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Join(ErrFailedToParseCIDR, err)
         }</span>
-        <span class="cov4" title="20">return cidr, nil</span>
+        <span class="cov8" title="1">return cidr, nil</span>
 }
 
 // validateAuthConfig は、認証設定を検証します。
-func validateAuthConfig(authCfg Auth) error <span class="cov5" title="27">{
-        if authCfg.CookieName == "" &amp;&amp; authCfg.HeaderName == "" </span><span class="cov1" title="2">{
+func validateAuthConfig(authCfg Auth) error <span class="cov8" title="1">{
+        if authCfg.CookieName == "" &amp;&amp; authCfg.HeaderName == "" </span><span class="cov8" title="1">{
                 return ErrAuthConfigMissing
         }</span>
-        <span class="cov5" title="25">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // buildStatusCodeSet は、HTTPステータスコードのセットを構築します。
-func buildStatusCodeSet(codes []int) map[int]bool <span class="cov6" title="95">{
+func buildStatusCodeSet(codes []int) map[int]bool <span class="cov8" title="1">{
         m := make(map[int]bool, len(codes))
-        for _, code := range codes </span><span class="cov10" title="943">{
+        for _, code := range codes </span><span class="cov8" title="1">{
                 m[code] = true
         }</span>
-        <span class="cov6" title="95">return m</span>
+        <span class="cov8" title="1">return m</span>
 }
 
 // isActiveExporter は、exporter 指定が送出を行う有効値かどうかを返します。
 // 空文字（未設定）と "none" は無効（送出しない）とみなします。
-func isActiveExporter(v string) bool <span class="cov8" title="222">{
+func isActiveExporter(v string) bool <span class="cov8" title="1">{
         return v != "" &amp;&amp; !strings.EqualFold(v, exporterNone)
 }</span>
 </pre>
@@ -2250,7 +2241,7 @@ var (
 )
 
 // MockConfigForTest は、テスト用のConfigを返します。
-func MockConfigForTest(tb testing.TB) *Config <span class="cov10" title="287">{
+func MockConfigForTest(tb testing.TB) *Config <span class="cov8" title="1">{
         tb.Helper()
         return &amp;Config{
                 os: OperatingSystemConfig{
@@ -2357,7 +2348,7 @@ func MockConfigForTest(tb testing.TB) *Config <span class="cov10" title="287">{
 }</span>
 
 // mockLoader は、テスト用のLoaderを返します。
-func mockLoader(tb testing.TB) Loader <span class="cov6" title="39">{
+func mockLoader(tb testing.TB) Loader <span class="cov8" title="1">{
         tb.Helper()
 
         return Loader{
@@ -2441,7 +2432,7 @@ func mockLoader(tb testing.TB) Loader <span class="cov6" title="39">{
         }
 }</span>
 
-func setEnvVarsForTesting(t *testing.T) <span class="cov3" title="4">{ //nolint:funlen // テスト用の環境変数設定のため長くなるのは許容する
+func setEnvVarsForTesting(t *testing.T) <span class="cov8" title="1">{ //nolint:funlen // テスト用の環境変数設定のため長くなるのは許容する
         t.Helper()
         // OS
         t.Setenv("OS_TZ", expectedOSTimeZone)
@@ -2526,131 +2517,131 @@ import (
 // SetApplicationMode は、テスト用にサーバーのAppModeを設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (a *ApplicationConfig) SetApplicationMode(tb testing.TB, mode string) <span class="cov10" title="19">{
+func (a *ApplicationConfig) SetApplicationMode(tb testing.TB, mode string) <span class="cov8" title="1">{
         tb.Helper()
         prev := a.Mode()
         a.mode = mode
-        tb.Cleanup(func() </span><span class="cov10" title="19">{ a.mode = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ a.mode = prev }</span>)
 }
 
 // SetApplicationEnv は、テスト用にアプリケーションの環境を設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (a *ApplicationConfig) SetApplicationEnv(tb testing.TB, env string) <span class="cov9" title="14">{
+func (a *ApplicationConfig) SetApplicationEnv(tb testing.TB, env string) <span class="cov8" title="1">{
         tb.Helper()
         prev := a.Env()
         a.env = env
-        tb.Cleanup(func() </span><span class="cov9" title="14">{ a.env = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ a.env = prev }</span>)
 }
 
 // SetApplicationLogLevel は、テスト用にアプリケーションのログレベルを設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (a *ApplicationConfig) SetApplicationLogLevel(tb testing.TB, level string) <span class="cov6" title="6">{
+func (a *ApplicationConfig) SetApplicationLogLevel(tb testing.TB, level string) <span class="cov8" title="1">{
         tb.Helper()
         prev := a.LogLevel()
         a.logLevel = level
-        tb.Cleanup(func() </span><span class="cov6" title="6">{ a.logLevel = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ a.logLevel = prev }</span>)
 }
 
 // SetServerPort は、テスト用にサーバーのポートを設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (s *ServerConfig) SetServerPort(tb testing.TB, port int) <span class="cov6" title="6">{
+func (s *ServerConfig) SetServerPort(tb testing.TB, port int) <span class="cov8" title="1">{
         tb.Helper()
         prev := s.Port()
         s.port = port
-        tb.Cleanup(func() </span><span class="cov6" title="6">{ s.port = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ s.port = prev }</span>)
 }
 
 // SetObservabilityMaskedDBQueryArgs は、テスト用にオブザーバビリティのDBクエリ引数の設定を行います。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (o *ObservabilityConfig) SetObservabilityMaskedDBQueryArgs(tb testing.TB, val bool) <span class="cov1" title="1">{
+func (o *ObservabilityConfig) SetObservabilityMaskedDBQueryArgs(tb testing.TB, val bool) <span class="cov8" title="1">{
         tb.Helper()
         prev := o.MaskedDBQueryArgs()
         o.maskedDBQueryArgs = val
-        tb.Cleanup(func() </span><span class="cov1" title="1">{ o.maskedDBQueryArgs = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ o.maskedDBQueryArgs = prev }</span>)
 }
 
 // SetObservabilityTracesExporter は、テスト用に trace exporter 指定を設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (o *ObservabilityConfig) SetObservabilityTracesExporter(tb testing.TB, val string) <span class="cov5" title="5">{
+func (o *ObservabilityConfig) SetObservabilityTracesExporter(tb testing.TB, val string) <span class="cov8" title="1">{
         tb.Helper()
         prev := o.tracesExporter
         o.tracesExporter = val
-        tb.Cleanup(func() </span><span class="cov5" title="5">{ o.tracesExporter = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ o.tracesExporter = prev }</span>)
 }
 
 // SetObservabilityMetricsExporter は、テスト用に metric exporter 指定を設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (o *ObservabilityConfig) SetObservabilityMetricsExporter(tb testing.TB, val string) <span class="cov5" title="5">{
+func (o *ObservabilityConfig) SetObservabilityMetricsExporter(tb testing.TB, val string) <span class="cov8" title="1">{
         tb.Helper()
         prev := o.metricsExporter
         o.metricsExporter = val
-        tb.Cleanup(func() </span><span class="cov5" title="5">{ o.metricsExporter = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ o.metricsExporter = prev }</span>)
 }
 
 // SetObservabilityLogsExporter は、テスト用に log exporter 指定を設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (o *ObservabilityConfig) SetObservabilityLogsExporter(tb testing.TB, val string) <span class="cov5" title="5">{
+func (o *ObservabilityConfig) SetObservabilityLogsExporter(tb testing.TB, val string) <span class="cov8" title="1">{
         tb.Helper()
         prev := o.logsExporter
         o.logsExporter = val
-        tb.Cleanup(func() </span><span class="cov5" title="5">{ o.logsExporter = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ o.logsExporter = prev }</span>)
 }
 
 // SetObservabilityOTLPProtocol は、テスト用に OTLP プロトコル指定を設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (o *ObservabilityConfig) SetObservabilityOTLPProtocol(tb testing.TB, val string) <span class="cov7" title="9">{
+func (o *ObservabilityConfig) SetObservabilityOTLPProtocol(tb testing.TB, val string) <span class="cov8" title="1">{
         tb.Helper()
         prev := o.otlpProtocol
         o.otlpProtocol = val
-        tb.Cleanup(func() </span><span class="cov7" title="9">{ o.otlpProtocol = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ o.otlpProtocol = prev }</span>)
 }
 
 // SetObservabilityOTLPEndpoint は、テスト用に OTLP エンドポイント指定を設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (o *ObservabilityConfig) SetObservabilityOTLPEndpoint(tb testing.TB, val string) <span class="cov4" title="3">{
+func (o *ObservabilityConfig) SetObservabilityOTLPEndpoint(tb testing.TB, val string) <span class="cov8" title="1">{
         tb.Helper()
         prev := o.otlpEndpoint
         o.otlpEndpoint = val
-        tb.Cleanup(func() </span><span class="cov4" title="3">{ o.otlpEndpoint = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ o.otlpEndpoint = prev }</span>)
 }
 
 // SetDatabaseHost は、テスト用にデータベースのホスト名を設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (d *DatabaseConfig) SetDatabaseHost(tb testing.TB, host string) <span class="cov7" title="8">{
+func (d *DatabaseConfig) SetDatabaseHost(tb testing.TB, host string) <span class="cov8" title="1">{
         tb.Helper()
         prev := d.Host()
         d.host = host
-        tb.Cleanup(func() </span><span class="cov7" title="8">{ d.host = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ d.host = prev }</span>)
 }
 
 // SetDatabaseName は、テスト用にデータベースの名前を設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (d *DatabaseConfig) SetDatabaseName(tb testing.TB, name string) <span class="cov3" title="2">{
+func (d *DatabaseConfig) SetDatabaseName(tb testing.TB, name string) <span class="cov8" title="1">{
         tb.Helper()
         prev := d.DBName()
         d.name = name
-        tb.Cleanup(func() </span><span class="cov3" title="2">{ d.name = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ d.name = prev }</span>)
 }
 
 // SetMetricsPort は、テスト用にメトリクスサーバーのポートを設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (m *MetricsConfig) SetMetricsPort(tb testing.TB, port int) <span class="cov4" title="3">{
+func (m *MetricsConfig) SetMetricsPort(tb testing.TB, port int) <span class="cov8" title="1">{
         tb.Helper()
         prev := m.Port()
         m.port = port
-        tb.Cleanup(func() </span><span class="cov4" title="3">{ m.port = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ m.port = prev }</span>)
 }
 
 // SetHealthListenAddr は、テスト用に worker health listener の待ち受けアドレスを設定します。
@@ -2658,91 +2649,91 @@ func (m *MetricsConfig) SetMetricsPort(tb testing.TB, port int) <span class="cov
 // 並列サブテストでは固定ポート（既定 :8081）が衝突するため "127.0.0.1:0" を渡して
 // OS 割り当ての空きポートを使わせる用途を想定します。t.Setenv と異なり t.Parallel と併用可能です。
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (w *WorkerConfig) SetHealthListenAddr(tb testing.TB, addr string) <span class="cov4" title="3">{
+func (w *WorkerConfig) SetHealthListenAddr(tb testing.TB, addr string) <span class="cov8" title="1">{
         tb.Helper()
         prev := w.HealthListenAddr()
         w.healthListenAddr = addr
-        tb.Cleanup(func() </span><span class="cov4" title="3">{ w.healthListenAddr = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ w.healthListenAddr = prev }</span>)
 }
 
 // SetMaxConns は、テスト用にDB接続の最大オープン数を設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (c *DBConnectionConfig) SetMaxConns(tb testing.TB, maxConns int32) <span class="cov3" title="2">{
+func (c *DBConnectionConfig) SetMaxConns(tb testing.TB, maxConns int32) <span class="cov8" title="1">{
         tb.Helper()
         prev := c.MaxConns()
         c.maxConns = maxConns
-        tb.Cleanup(func() </span><span class="cov3" title="2">{ c.maxConns = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ c.maxConns = prev }</span>)
 }
 
 // SetCIDR は、テスト用にセキュリティのCIDRを設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (s *SecurityConfig) SetCIDR(tb testing.TB, cidr *net.IPNet) <span class="cov5" title="5">{
+func (s *SecurityConfig) SetCIDR(tb testing.TB, cidr *net.IPNet) <span class="cov8" title="1">{
         tb.Helper()
         prev := s.CIDR()
         s.cidr = cidr
-        tb.Cleanup(func() </span><span class="cov5" title="5">{ s.cidr = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ s.cidr = prev }</span>)
 }
 
 // SetHeaderName は、テスト用に認証のヘッダ名を設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (a *AuthConfig) SetHeaderName(tb testing.TB, headerName string) <span class="cov5" title="4">{
+func (a *AuthConfig) SetHeaderName(tb testing.TB, headerName string) <span class="cov8" title="1">{
         tb.Helper()
         prev := a.headerName
         a.headerName = headerName
-        tb.Cleanup(func() </span><span class="cov5" title="4">{ a.headerName = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ a.headerName = prev }</span>)
 }
 
 // SetAllowedHeaderBearer は、テスト用に認証の許可されたヘッダベアラーを設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (a *AuthConfig) SetAllowedHeaderBearer(tb testing.TB, allowed bool) <span class="cov4" title="3">{
+func (a *AuthConfig) SetAllowedHeaderBearer(tb testing.TB, allowed bool) <span class="cov8" title="1">{
         tb.Helper()
         prev := a.allowedHeaderBearer
         a.allowedHeaderBearer = allowed
-        tb.Cleanup(func() </span><span class="cov4" title="3">{ a.allowedHeaderBearer = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ a.allowedHeaderBearer = prev }</span>)
 }
 
 // SetOutboxBatchSize は、テスト用に outbox relay の batch size を設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (o *OutboxConfig) SetOutboxBatchSize(tb testing.TB, batchSize int) <span class="cov5" title="4">{
+func (o *OutboxConfig) SetOutboxBatchSize(tb testing.TB, batchSize int) <span class="cov8" title="1">{
         tb.Helper()
         prev := o.batchSize
         o.batchSize = batchSize
-        tb.Cleanup(func() </span><span class="cov5" title="4">{ o.batchSize = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ o.batchSize = prev }</span>)
 }
 
 // SetOutboxEndpoint は、テスト用に outbox relay の送信先エンドポイントを設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (o *OutboxConfig) SetOutboxEndpoint(tb testing.TB, endpoint string) <span class="cov3" title="2">{
+func (o *OutboxConfig) SetOutboxEndpoint(tb testing.TB, endpoint string) <span class="cov8" title="1">{
         tb.Helper()
         prev := o.endpoint
         o.endpoint = endpoint
-        tb.Cleanup(func() </span><span class="cov3" title="2">{ o.endpoint = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ o.endpoint = prev }</span>)
 }
 
 // SetSameSite は、テスト用にセキュアクッキーの SameSite 強制値を設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (s *SecureCookieConfig) SetSameSite(tb testing.TB, sameSite string) <span class="cov3" title="2">{
+func (s *SecureCookieConfig) SetSameSite(tb testing.TB, sameSite string) <span class="cov8" title="1">{
         tb.Helper()
         prev := s.sameSite
         s.sameSite = sameSite
-        tb.Cleanup(func() </span><span class="cov3" title="2">{ s.sameSite = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ s.sameSite = prev }</span>)
 }
 
 // SetDomain は、テスト用にセキュアクッキーの Domain 強制値を設定します。
 //
 // 実行後は、元の値に戻すためのクリーンアップ関数が登録されます。
-func (s *SecureCookieConfig) SetDomain(tb testing.TB, domain string) <span class="cov3" title="2">{
+func (s *SecureCookieConfig) SetDomain(tb testing.TB, domain string) <span class="cov8" title="1">{
         tb.Helper()
         prev := s.domain
         s.domain = domain
-        tb.Cleanup(func() </span><span class="cov3" title="2">{ s.domain = prev }</span>)
+        tb.Cleanup(func() </span><span class="cov8" title="1">{ s.domain = prev }</span>)
 }
 </pre>
 		
@@ -2760,26 +2751,26 @@ import (
 
 // Load は、埋め込まれた env ファイルから環境変数を設定します。
 // 既に設定済みの環境変数は上書きしません（実行時注入を優先）。
-func Load() error <span class="cov5" title="21">{
+func Load() error <span class="cov8" title="1">{
         b, err := root.FS.ReadFile("env/.env")
         if err != nil </span><span class="cov0" title="0">{
                 return xerrors.Join(ErrFailedToLoadEnvFile, err)
         }</span>
 
-        <span class="cov5" title="21">kv, err := godotenv.Parse(bytes.NewReader(b))
+        <span class="cov8" title="1">kv, err := godotenv.Parse(bytes.NewReader(b))
         if err != nil </span><span class="cov0" title="0">{
                 return xerrors.Join(ErrFailedToParseConfig, err)
         }</span>
 
-        <span class="cov5" title="21">for k, v := range kv </span><span class="cov10" title="819">{
-                if _, ok := os.LookupEnv(k); ok </span><span class="cov9" title="745">{
+        <span class="cov8" title="1">for k, v := range kv </span><span class="cov8" title="1">{
+                if _, ok := os.LookupEnv(k); ok </span><span class="cov8" title="1">{
                         continue</span>
                 }
-                <span class="cov6" title="74">if err := os.Setenv(k, v); err != nil </span><span class="cov0" title="0">{
+                <span class="cov8" title="1">if err := os.Setenv(k, v); err != nil </span><span class="cov0" title="0">{
                         return xerrors.Join(ErrFailedToParseConfig, err)
                 }</span>
         }
-        <span class="cov5" title="21">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 </pre>
 		
@@ -2932,319 +2923,319 @@ type OutboxConfig struct {
 }
 
 // NewOperatingSystemConfig は、OSの設定を返します。
-func NewOperatingSystemConfig(cfg *Config) *OperatingSystemConfig <span class="cov9" title="105">{ return &amp;cfg.os }</span>
+func NewOperatingSystemConfig(cfg *Config) *OperatingSystemConfig <span class="cov8" title="1">{ return &amp;cfg.os }</span>
 
 // TimeZone は、OSのタイムゾーンを返します。
-func (o *OperatingSystemConfig) TimeZone() string <span class="cov9" title="115">{ return o.timezone }</span>
+func (o *OperatingSystemConfig) TimeZone() string <span class="cov8" title="1">{ return o.timezone }</span>
 
 // NewApplicationConfig は、アプリケーションの設定を返します。
-func NewApplicationConfig(cfg *Config) *ApplicationConfig <span class="cov9" title="98">{ return &amp;cfg.app }</span>
+func NewApplicationConfig(cfg *Config) *ApplicationConfig <span class="cov8" title="1">{ return &amp;cfg.app }</span>
 
 // Env は、デプロイ環境ラベルを返します（自由値）。例: "local" / "staging" / "production"。
-func (a *ApplicationConfig) Env() string <span class="cov10" title="124">{ return a.env }</span>
+func (a *ApplicationConfig) Env() string <span class="cov8" title="1">{ return a.env }</span>
 
 // Mode は、アプリの動作モードを返します（"development" / "production" のみ。挙動切替に使用。Env とは別軸）。
-func (a *ApplicationConfig) Mode() string <span class="cov7" title="26">{ return a.mode }</span>
+func (a *ApplicationConfig) Mode() string <span class="cov8" title="1">{ return a.mode }</span>
 
 // LogLevel は、ログ出力レベル（"debug" / "info" / "warn" / "error"）を返します。
-func (a *ApplicationConfig) LogLevel() string <span class="cov7" title="30">{ return a.logLevel }</span>
+func (a *ApplicationConfig) LogLevel() string <span class="cov8" title="1">{ return a.logLevel }</span>
 
 // Name は、アプリケーションの名前を返します。
-func (a *ApplicationConfig) Name() string <span class="cov8" title="64">{ return a.name }</span>
+func (a *ApplicationConfig) Name() string <span class="cov8" title="1">{ return a.name }</span>
 
 // ShutdownTimeout は、アプリケーションのシャットダウンタイムアウトを返します。
-func (a *ApplicationConfig) ShutdownTimeout() time.Duration <span class="cov5" title="10">{ return a.shutdownTimeout }</span>
+func (a *ApplicationConfig) ShutdownTimeout() time.Duration <span class="cov8" title="1">{ return a.shutdownTimeout }</span>
 
 // IsProductionMode は、アプリケーションが本番環境モードかどうかを返します。
-func (a *ApplicationConfig) IsProductionMode() bool <span class="cov7" title="26">{
+func (a *ApplicationConfig) IsProductionMode() bool <span class="cov8" title="1">{
         return a.mode == ProductionMode
 }</span>
 
 // IsDevelopmentMode は、アプリケーションが開発環境モードかどうかを返します。
-func (a *ApplicationConfig) IsDevelopmentMode() bool <span class="cov7" title="42">{
+func (a *ApplicationConfig) IsDevelopmentMode() bool <span class="cov8" title="1">{
         return a.mode == DevelopmentMode
 }</span>
 
 // NewServerConfig は、サーバーの設定を返します。
-func NewServerConfig(cfg *Config) *ServerConfig <span class="cov6" title="16">{ return &amp;cfg.server }</span>
+func NewServerConfig(cfg *Config) *ServerConfig <span class="cov8" title="1">{ return &amp;cfg.server }</span>
 
 // Host は、サーバーがリッスンするホスト名を返します。
-func (s *ServerConfig) Host() string <span class="cov1" title="1">{ return s.host }</span>
+func (s *ServerConfig) Host() string <span class="cov8" title="1">{ return s.host }</span>
 
 // Port は、サーバーがリッスンするポート番号を返します。
-func (s *ServerConfig) Port() int <span class="cov6" title="17">{ return s.port }</span>
+func (s *ServerConfig) Port() int <span class="cov8" title="1">{ return s.port }</span>
 
 // ReadHeaderTimeout は、サーバーのヘッダー読み取りタイムアウトを返します。
-func (s *ServerConfig) ReadHeaderTimeout() time.Duration <span class="cov5" title="11">{ return s.readHeaderTimeout }</span>
+func (s *ServerConfig) ReadHeaderTimeout() time.Duration <span class="cov8" title="1">{ return s.readHeaderTimeout }</span>
 
 // ReadTimeout は、サーバーの読み取りタイムアウトを返します。
-func (s *ServerConfig) ReadTimeout() time.Duration <span class="cov5" title="11">{ return s.readTimeout }</span>
+func (s *ServerConfig) ReadTimeout() time.Duration <span class="cov8" title="1">{ return s.readTimeout }</span>
 
 // WriteTimeout は、サーバーの書き込みタイムアウトを返します。
-func (s *ServerConfig) WriteTimeout() time.Duration <span class="cov5" title="11">{ return s.writeTimeout }</span>
+func (s *ServerConfig) WriteTimeout() time.Duration <span class="cov8" title="1">{ return s.writeTimeout }</span>
 
 // IdleTimeout は、サーバーのアイドルタイムアウトを返します。
-func (s *ServerConfig) IdleTimeout() time.Duration <span class="cov5" title="11">{ return s.idleTimeout }</span>
+func (s *ServerConfig) IdleTimeout() time.Duration <span class="cov8" title="1">{ return s.idleTimeout }</span>
 
 // BodyLimitMB は、リクエストボディのサイズ上限を MB（10進, 1MB=1,000,000 byte）で返します。
-func (s *ServerConfig) BodyLimitMB() int <span class="cov3" title="4">{ return s.bodyLimitMB }</span>
+func (s *ServerConfig) BodyLimitMB() int <span class="cov8" title="1">{ return s.bodyLimitMB }</span>
 
 // RequestTimeout は、REST リクエスト全体の deadline budget を返します（入口で1点設定し ctx で全層伝播）。
-func (s *ServerConfig) RequestTimeout() time.Duration <span class="cov4" title="5">{ return s.requestTimeout }</span>
+func (s *ServerConfig) RequestTimeout() time.Duration <span class="cov8" title="1">{ return s.requestTimeout }</span>
 
 // NewMetricsConfig は、メトリクスの設定を返します。
-func NewMetricsConfig(cfg *Config) *MetricsConfig <span class="cov5" title="12">{ return &amp;cfg.metrics }</span>
+func NewMetricsConfig(cfg *Config) *MetricsConfig <span class="cov8" title="1">{ return &amp;cfg.metrics }</span>
 
 // Host は、メトリクスサーバーがリッスンするホスト名を返します。
-func (m *MetricsConfig) Host() string <span class="cov4" title="8">{ return m.host }</span>
+func (m *MetricsConfig) Host() string <span class="cov8" title="1">{ return m.host }</span>
 
 // Port は、メトリクスサーバーがリッスンするポート番号を返します。
-func (m *MetricsConfig) Port() int <span class="cov5" title="12">{ return m.port }</span>
+func (m *MetricsConfig) Port() int <span class="cov8" title="1">{ return m.port }</span>
 
 // UserName は、メトリクスサーバーの認証に使用するユーザー名を返します。
-func (m *MetricsConfig) UserName() string <span class="cov5" title="10">{ return m.userName }</span>
+func (m *MetricsConfig) UserName() string <span class="cov8" title="1">{ return m.userName }</span>
 
 // Password は、メトリクスサーバーの認証に使用するパスワードを返します。
-func (m *MetricsConfig) Password() string <span class="cov5" title="10">{ return m.password }</span>
+func (m *MetricsConfig) Password() string <span class="cov8" title="1">{ return m.password }</span>
 
 // NewObservabilityConfig は、可観測の設定を返します。
-func NewObservabilityConfig(cfg *Config) *ObservabilityConfig <span class="cov9" title="115">{ return &amp;cfg.observability }</span>
+func NewObservabilityConfig(cfg *Config) *ObservabilityConfig <span class="cov8" title="1">{ return &amp;cfg.observability }</span>
 
 // Enabled は、可観測が有効かどうかを返します。
-func (o *ObservabilityConfig) Enabled() bool <span class="cov8" title="68">{
+func (o *ObservabilityConfig) Enabled() bool <span class="cov8" title="1">{
         return o.TracesEnabled() || o.MetricsEnabled() || o.LogsEnabled()
 }</span>
 
 // TracesEnabled は、trace exporter が有効値かどうかを返します。
-func (o *ObservabilityConfig) TracesEnabled() bool <span class="cov9" title="102">{ return isActiveExporter(o.tracesExporter) }</span>
+func (o *ObservabilityConfig) TracesEnabled() bool <span class="cov8" title="1">{ return isActiveExporter(o.tracesExporter) }</span>
 
 // MetricsEnabled は、metric exporter が有効値かどうかを返します。
-func (o *ObservabilityConfig) MetricsEnabled() bool <span class="cov8" title="62">{ return isActiveExporter(o.metricsExporter) }</span>
+func (o *ObservabilityConfig) MetricsEnabled() bool <span class="cov8" title="1">{ return isActiveExporter(o.metricsExporter) }</span>
 
 // LogsEnabled は、log exporter が有効値かどうかを返します。
-func (o *ObservabilityConfig) LogsEnabled() bool <span class="cov8" title="58">{ return isActiveExporter(o.logsExporter) }</span>
+func (o *ObservabilityConfig) LogsEnabled() bool <span class="cov8" title="1">{ return isActiveExporter(o.logsExporter) }</span>
 
 // OTLPEndpoint は、OTLP exporter の送出先エンドポイントを返します。
-func (o *ObservabilityConfig) OTLPEndpoint() string <span class="cov5" title="13">{ return o.otlpEndpoint }</span>
+func (o *ObservabilityConfig) OTLPEndpoint() string <span class="cov8" title="1">{ return o.otlpEndpoint }</span>
 
 // OTLPProtocol は、OTLP exporter のプロトコル（"http/protobuf" / "grpc"）を返します。
-func (o *ObservabilityConfig) OTLPProtocol() string <span class="cov6" title="16">{ return o.otlpProtocol }</span>
+func (o *ObservabilityConfig) OTLPProtocol() string <span class="cov8" title="1">{ return o.otlpProtocol }</span>
 
 // MaskedDBQueryArgs は、可観測モードでDBクエリの引数をマスクするかどうかを返します。
-func (o *ObservabilityConfig) MaskedDBQueryArgs() bool <span class="cov7" title="26">{ return o.maskedDBQueryArgs }</span>
+func (o *ObservabilityConfig) MaskedDBQueryArgs() bool <span class="cov8" title="1">{ return o.maskedDBQueryArgs }</span>
 
 // TargetStatusCodeSet は、可観測モードで監視対象となるHTTPステータスコードのセットを返します。
 // 返り値はホットパスで参照される共有マップのため変更してはいけません（read-only）。
-func (o *ObservabilityConfig) TargetStatusCodeSet() map[int]bool <span class="cov5" title="14">{ return o.targetStatusCodeSet }</span>
+func (o *ObservabilityConfig) TargetStatusCodeSet() map[int]bool <span class="cov8" title="1">{ return o.targetStatusCodeSet }</span>
 
 // NewDatabaseConfig は、データベースの設定を返します。
-func NewDatabaseConfig(cfg *Config) *DatabaseConfig <span class="cov9" title="73">{ return &amp;cfg.database }</span>
+func NewDatabaseConfig(cfg *Config) *DatabaseConfig <span class="cov8" title="1">{ return &amp;cfg.database }</span>
 
 // Driver は、データベースのドライバー名を返します。
-func (d *DatabaseConfig) Driver() string <span class="cov3" title="3">{ return d.driver }</span>
+func (d *DatabaseConfig) Driver() string <span class="cov8" title="1">{ return d.driver }</span>
 
 // Host は、データベースのホスト名を返します。
-func (d *DatabaseConfig) Host() string <span class="cov8" title="54">{ return d.host }</span>
+func (d *DatabaseConfig) Host() string <span class="cov8" title="1">{ return d.host }</span>
 
 // Port は、データベースのポート番号を返します。
-func (d *DatabaseConfig) Port() int <span class="cov8" title="45">{ return d.port }</span>
+func (d *DatabaseConfig) Port() int <span class="cov8" title="1">{ return d.port }</span>
 
 // User は、データベースのユーザー名を返します。
-func (d *DatabaseConfig) User() string <span class="cov8" title="45">{ return d.user }</span>
+func (d *DatabaseConfig) User() string <span class="cov8" title="1">{ return d.user }</span>
 
 // Password は、データベースのパスワードを返します。
-func (d *DatabaseConfig) Password() string <span class="cov8" title="44">{ return d.password }</span>
+func (d *DatabaseConfig) Password() string <span class="cov8" title="1">{ return d.password }</span>
 
 // DBName は、データベースの名前を返します。
-func (d *DatabaseConfig) DBName() string <span class="cov8" title="48">{ return d.name }</span>
+func (d *DatabaseConfig) DBName() string <span class="cov8" title="1">{ return d.name }</span>
 
 // SSLMode は、データベースのSSLモードを返します。
-func (d *DatabaseConfig) SSLMode() string <span class="cov8" title="45">{ return d.sslMode }</span>
+func (d *DatabaseConfig) SSLMode() string <span class="cov8" title="1">{ return d.sslMode }</span>
 
 // PingTimeout は、データベースのpingタイムアウトを返します。
-func (d *DatabaseConfig) PingTimeout() time.Duration <span class="cov7" title="32">{ return d.pingTimeout }</span>
+func (d *DatabaseConfig) PingTimeout() time.Duration <span class="cov8" title="1">{ return d.pingTimeout }</span>
 
 // SlowQueryWarnThreshold は、スロークエリ警告の閾値を返します。
 //
 // この値より長く実行されたクエリは警告レベルでログ出力されます。
 // 0以下の値の場合、スロークエリ警告は無効になります。
-func (d *DatabaseConfig) SlowQueryWarnThreshold() time.Duration <span class="cov6" title="24">{ return d.slowQueryWarnThreshold }</span>
+func (d *DatabaseConfig) SlowQueryWarnThreshold() time.Duration <span class="cov8" title="1">{ return d.slowQueryWarnThreshold }</span>
 
 // StatementTimeout は、SQL 文の実行時間上限を返します（0 以下で無効）。ctx を無視する runaway query の backstop。
-func (d *DatabaseConfig) StatementTimeout() time.Duration <span class="cov7" title="32">{ return d.statementTimeout }</span>
+func (d *DatabaseConfig) StatementTimeout() time.Duration <span class="cov8" title="1">{ return d.statementTimeout }</span>
 
 // LockTimeout は、ロック獲得待ちの上限を返します（0 以下で無効）。長時間ロック待ちの backstop。
-func (d *DatabaseConfig) LockTimeout() time.Duration <span class="cov7" title="32">{ return d.lockTimeout }</span>
+func (d *DatabaseConfig) LockTimeout() time.Duration <span class="cov8" title="1">{ return d.lockTimeout }</span>
 
 // TxMaxRetries は、トランザクションのリトライ最大試行回数を返します。
 //
 // serialization failure / deadlock 検出時の有限リトライ上限です。
 // 0 以下の場合は実装側の既定値（3回）にフォールバックします。
-func (d *DatabaseConfig) TxMaxRetries() int <span class="cov7" title="39">{ return d.txMaxRetries }</span>
+func (d *DatabaseConfig) TxMaxRetries() int <span class="cov8" title="1">{ return d.txMaxRetries }</span>
 
 // TxRetryBaseBackoff は、トランザクションリトライ backoff の初期値（指数 backoff の基準値）を返します。
 // 0 以下の場合は実装側の既定値にフォールバックします。
-func (d *DatabaseConfig) TxRetryBaseBackoff() time.Duration <span class="cov7" title="38">{ return d.txRetryBaseBackoff }</span>
+func (d *DatabaseConfig) TxRetryBaseBackoff() time.Duration <span class="cov8" title="1">{ return d.txRetryBaseBackoff }</span>
 
 // TxRetryMaxBackoff は、トランザクションリトライ backoff の上限値（1試行あたりの最大待機時間）を返します。
 // 0 以下の場合は実装側の既定値にフォールバックします。
-func (d *DatabaseConfig) TxRetryMaxBackoff() time.Duration <span class="cov7" title="38">{ return d.txRetryMaxBackoff }</span>
+func (d *DatabaseConfig) TxRetryMaxBackoff() time.Duration <span class="cov8" title="1">{ return d.txRetryMaxBackoff }</span>
 
 // NewDBConnectionConfig は、データベース接続の設定を返します。
-func NewDBConnectionConfig(cfg *Config) *DBConnectionConfig <span class="cov7" title="35">{ return &amp;cfg.dbconnection }</span>
+func NewDBConnectionConfig(cfg *Config) *DBConnectionConfig <span class="cov8" title="1">{ return &amp;cfg.dbconnection }</span>
 
 // MaxConns は、データベースの最大オープン接続数を返します。
-func (c *DBConnectionConfig) MaxConns() int32 <span class="cov7" title="37">{ return c.maxConns }</span>
+func (c *DBConnectionConfig) MaxConns() int32 <span class="cov8" title="1">{ return c.maxConns }</span>
 
 // MinConns は、pgxpool の最小プールサイズ（最小接続数）を返します。
-func (c *DBConnectionConfig) MinConns() int32 <span class="cov7" title="32">{ return c.minConns }</span>
+func (c *DBConnectionConfig) MinConns() int32 <span class="cov8" title="1">{ return c.minConns }</span>
 
 // MaxLifetime は、データベースの接続の最大寿命を返します。
-func (c *DBConnectionConfig) MaxLifetime() time.Duration <span class="cov7" title="32">{ return c.maxLifetime }</span>
+func (c *DBConnectionConfig) MaxLifetime() time.Duration <span class="cov8" title="1">{ return c.maxLifetime }</span>
 
 // MaxIdleTime は、データベースの接続の最大アイドル時間を返します。
-func (c *DBConnectionConfig) MaxIdleTime() time.Duration <span class="cov7" title="32">{ return c.maxIdleTime }</span>
+func (c *DBConnectionConfig) MaxIdleTime() time.Duration <span class="cov8" title="1">{ return c.maxIdleTime }</span>
 
 // NewSecurityConfig は、セキュリティの設定を返します。
-func NewSecurityConfig(cfg *Config) *SecurityConfig <span class="cov7" title="33">{ return &amp;cfg.security }</span>
+func NewSecurityConfig(cfg *Config) *SecurityConfig <span class="cov8" title="1">{ return &amp;cfg.security }</span>
 
 // AllowedOrigins は、CORSを許可するオリジンのリストを返します。
-func (s *SecurityConfig) AllowedOrigins() []string <span class="cov5" title="12">{
+func (s *SecurityConfig) AllowedOrigins() []string <span class="cov8" title="1">{
         return append([]string(nil), s.allowedOrigins...)
 }</span>
 
 // CIDR は、セキュリティ設定で使用されるCIDRを返します。
-func (s *SecurityConfig) CIDR() *net.IPNet <span class="cov5" title="14">{
-        if s.cidr == nil </span><span class="cov2" title="2">{
+func (s *SecurityConfig) CIDR() *net.IPNet <span class="cov8" title="1">{
+        if s.cidr == nil </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov5" title="12">return &amp;net.IPNet{
+        <span class="cov8" title="1">return &amp;net.IPNet{
                 IP:   append(net.IP(nil), s.cidr.IP...),
                 Mask: append(net.IPMask(nil), s.cidr.Mask...),
         }</span>
 }
 
 // ContentTypeNosniff は、X-Content-Type-Optionsヘッダーの値を返します。
-func (s *SecurityConfig) ContentTypeNosniff() string <span class="cov4" title="7">{ return s.contentTypeNosniff }</span>
+func (s *SecurityConfig) ContentTypeNosniff() string <span class="cov8" title="1">{ return s.contentTypeNosniff }</span>
 
 // XFrameOptions は、X-Frame-Optionsヘッダーの値を返します。
-func (s *SecurityConfig) XFrameOptions() string <span class="cov4" title="7">{ return s.xFrameOptions }</span>
+func (s *SecurityConfig) XFrameOptions() string <span class="cov8" title="1">{ return s.xFrameOptions }</span>
 
 // HSTSMaxAge は、HSTSの最大年齢を返します。
-func (s *SecurityConfig) HSTSMaxAge() time.Duration <span class="cov4" title="7">{ return s.hstsMaxAge }</span>
+func (s *SecurityConfig) HSTSMaxAge() time.Duration <span class="cov8" title="1">{ return s.hstsMaxAge }</span>
 
 // HSTSExcludeSubdomains は、HSTSでサブドメインを除外するかどうかを返します。
-func (s *SecurityConfig) HSTSExcludeSubdomains() bool <span class="cov4" title="7">{ return s.hstsExcludeSubdomains }</span>
+func (s *SecurityConfig) HSTSExcludeSubdomains() bool <span class="cov8" title="1">{ return s.hstsExcludeSubdomains }</span>
 
 // HSTSPreloadEnabled は、HSTSのプリロードが有効かどうかを返します。
-func (s *SecurityConfig) HSTSPreloadEnabled() bool <span class="cov4" title="7">{ return s.hstsPreloadEnabled }</span>
+func (s *SecurityConfig) HSTSPreloadEnabled() bool <span class="cov8" title="1">{ return s.hstsPreloadEnabled }</span>
 
 // ReferrerPolicy は、Referrer-Policyヘッダーの値を返します。
-func (s *SecurityConfig) ReferrerPolicy() string <span class="cov4" title="7">{ return s.referrerPolicy }</span>
+func (s *SecurityConfig) ReferrerPolicy() string <span class="cov8" title="1">{ return s.referrerPolicy }</span>
 
 // BcryptCost は、bcryptのコストを返します。
-func (s *SecurityConfig) BcryptCost() int <span class="cov5" title="13">{ return s.bcryptCost }</span>
+func (s *SecurityConfig) BcryptCost() int <span class="cov8" title="1">{ return s.bcryptCost }</span>
 
 // NewSecureCookieConfig は、セキュアクッキーの設定を返します。
-func NewSecureCookieConfig(cfg *Config) *SecureCookieConfig <span class="cov5" title="11">{ return &amp;cfg.secureCookie }</span>
+func NewSecureCookieConfig(cfg *Config) *SecureCookieConfig <span class="cov8" title="1">{ return &amp;cfg.secureCookie }</span>
 
 // Secure は、Secure属性の強制設定を返します。
-func (s *SecureCookieConfig) Secure() *bool <span class="cov5" title="10">{
-        if s.secure == nil </span><span class="cov1" title="1">{
+func (s *SecureCookieConfig) Secure() *bool <span class="cov8" title="1">{
+        if s.secure == nil </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov5" title="9">v := *s.secure
+        <span class="cov8" title="1">v := *s.secure
         return &amp;v</span>
 }
 
 // SameSite は、SameSite属性の強制設定を返します。
-func (s *SecureCookieConfig) SameSite() string <span class="cov5" title="10">{ return s.sameSite }</span>
+func (s *SecureCookieConfig) SameSite() string <span class="cov8" title="1">{ return s.sameSite }</span>
 
 // Domain は、Domain属性の強制設定を返します。
-func (s *SecureCookieConfig) Domain() string <span class="cov5" title="12">{ return s.domain }</span>
+func (s *SecureCookieConfig) Domain() string <span class="cov8" title="1">{ return s.domain }</span>
 
 // NewAuthConfig は、認証の設定を返します。
-func NewAuthConfig(cfg *Config) *AuthConfig <span class="cov6" title="20">{ return &amp;cfg.auth }</span>
+func NewAuthConfig(cfg *Config) *AuthConfig <span class="cov8" title="1">{ return &amp;cfg.auth }</span>
 
 // CookieName は、認証に使用するCookie名を返します。
-func (a *AuthConfig) CookieName() string <span class="cov8" title="43">{ return a.cookieName }</span>
+func (a *AuthConfig) CookieName() string <span class="cov8" title="1">{ return a.cookieName }</span>
 
 // HeaderName は、認証に使用するヘッダー名を返します。
-func (a *AuthConfig) HeaderName() string <span class="cov7" title="26">{ return a.headerName }</span>
+func (a *AuthConfig) HeaderName() string <span class="cov8" title="1">{ return a.headerName }</span>
 
 // AllowedHeaderBearer は、認証に使用するヘッダーのBearerトークンの許可設定を返します。
-func (a *AuthConfig) AllowedHeaderBearer() bool <span class="cov4" title="6">{ return a.allowedHeaderBearer }</span>
+func (a *AuthConfig) AllowedHeaderBearer() bool <span class="cov8" title="1">{ return a.allowedHeaderBearer }</span>
 
 // NewWorkerConfig は、worker engine の設定を返します。
-func NewWorkerConfig(cfg *Config) *WorkerConfig <span class="cov6" title="15">{ return &amp;cfg.worker }</span>
+func NewWorkerConfig(cfg *Config) *WorkerConfig <span class="cov8" title="1">{ return &amp;cfg.worker }</span>
 
 // Concurrency は、同時に Handle を実行する最大数を返します。
-func (w *WorkerConfig) Concurrency() int <span class="cov5" title="11">{ return w.concurrency }</span>
+func (w *WorkerConfig) Concurrency() int <span class="cov8" title="1">{ return w.concurrency }</span>
 
 // MaxInFlight は、受信済み・未確定の最大メッセージ数を返します。
-func (w *WorkerConfig) MaxInFlight() int <span class="cov5" title="9">{ return w.maxInFlight }</span>
+func (w *WorkerConfig) MaxInFlight() int <span class="cov8" title="1">{ return w.maxInFlight }</span>
 
 // BatchSize は、1 回の Receive で取得する最大件数を返します。
-func (w *WorkerConfig) BatchSize() int <span class="cov5" title="9">{ return w.batchSize }</span>
+func (w *WorkerConfig) BatchSize() int <span class="cov8" title="1">{ return w.batchSize }</span>
 
 // ExtendInterval は、Extend を呼ぶ周期を返します（0 以下で無効）。
-func (w *WorkerConfig) ExtendInterval() time.Duration <span class="cov5" title="9">{ return w.extendInterval }</span>
+func (w *WorkerConfig) ExtendInterval() time.Duration <span class="cov8" title="1">{ return w.extendInterval }</span>
 
 // DrainTimeout は、停止時に in-flight の完了を待つ上限を返します。
-func (w *WorkerConfig) DrainTimeout() time.Duration <span class="cov6" title="16">{ return w.drainTimeout }</span>
+func (w *WorkerConfig) DrainTimeout() time.Duration <span class="cov8" title="1">{ return w.drainTimeout }</span>
 
 // ReceiveCountWarnThreshold は、再配送回数の警告閾値を返します（0 以下で無効）。
-func (w *WorkerConfig) ReceiveCountWarnThreshold() int <span class="cov5" title="9">{ return w.receiveCountWarnThreshold }</span>
+func (w *WorkerConfig) ReceiveCountWarnThreshold() int <span class="cov8" title="1">{ return w.receiveCountWarnThreshold }</span>
 
 // CircuitFailureThreshold は、サーキットを Open にする連続失敗数を返します（0 以下で無効）。
-func (w *WorkerConfig) CircuitFailureThreshold() int <span class="cov5" title="9">{ return w.circuitFailureThreshold }</span>
+func (w *WorkerConfig) CircuitFailureThreshold() int <span class="cov8" title="1">{ return w.circuitFailureThreshold }</span>
 
 // CircuitOpenBackoffInitial は、Open の初回 cooldown を返します。
-func (w *WorkerConfig) CircuitOpenBackoffInitial() time.Duration <span class="cov5" title="9">{ return w.circuitOpenBackoffInitial }</span>
+func (w *WorkerConfig) CircuitOpenBackoffInitial() time.Duration <span class="cov8" title="1">{ return w.circuitOpenBackoffInitial }</span>
 
 // CircuitOpenBackoffMax は、Open の cooldown 上限を返します。
-func (w *WorkerConfig) CircuitOpenBackoffMax() time.Duration <span class="cov5" title="9">{ return w.circuitOpenBackoffMax }</span>
+func (w *WorkerConfig) CircuitOpenBackoffMax() time.Duration <span class="cov8" title="1">{ return w.circuitOpenBackoffMax }</span>
 
 // CircuitHalfOpenProbe は、Half-open 時に試行する最大件数を返します。
-func (w *WorkerConfig) CircuitHalfOpenProbe() int <span class="cov5" title="9">{ return w.circuitHalfOpenProbe }</span>
+func (w *WorkerConfig) CircuitHalfOpenProbe() int <span class="cov8" title="1">{ return w.circuitHalfOpenProbe }</span>
 
 // HealthListenAddr は、liveness/readiness を公開する health listener の待ち受けアドレスを返します。
-func (w *WorkerConfig) HealthListenAddr() string <span class="cov5" title="12">{ return w.healthListenAddr }</span>
+func (w *WorkerConfig) HealthListenAddr() string <span class="cov8" title="1">{ return w.healthListenAddr }</span>
 
 // ProgressStaleAfter は、readiness 判定で「進捗なし」とみなすまでの時間を返します。
-func (w *WorkerConfig) ProgressStaleAfter() time.Duration <span class="cov5" title="9">{ return w.progressStaleAfter }</span>
+func (w *WorkerConfig) ProgressStaleAfter() time.Duration <span class="cov8" title="1">{ return w.progressStaleAfter }</span>
 
 // NackBackoffInitial は、retryable 失敗時の per-message 再配送 backoff の初回待機を返します。
-func (w *WorkerConfig) NackBackoffInitial() time.Duration <span class="cov5" title="9">{ return w.nackBackoffInitial }</span>
+func (w *WorkerConfig) NackBackoffInitial() time.Duration <span class="cov8" title="1">{ return w.nackBackoffInitial }</span>
 
 // NackBackoffMax は、per-message 再配送 backoff の上限を返します。
-func (w *WorkerConfig) NackBackoffMax() time.Duration <span class="cov5" title="9">{ return w.nackBackoffMax }</span>
+func (w *WorkerConfig) NackBackoffMax() time.Duration <span class="cov8" title="1">{ return w.nackBackoffMax }</span>
 
 // NewOutboxConfig は、outbox relay の設定を返します。
-func NewOutboxConfig(cfg *Config) *OutboxConfig <span class="cov5" title="10">{ return &amp;cfg.outbox }</span>
+func NewOutboxConfig(cfg *Config) *OutboxConfig <span class="cov8" title="1">{ return &amp;cfg.outbox }</span>
 
 // Endpoint は、メッセージの送信先エンドポイント URL を返します。
-func (o *OutboxConfig) Endpoint() string <span class="cov4" title="8">{ return o.endpoint }</span>
+func (o *OutboxConfig) Endpoint() string <span class="cov8" title="1">{ return o.endpoint }</span>
 
 // PollInterval は、pending を捌き切った後に次 poll まで待機する時間を返します。
-func (o *OutboxConfig) PollInterval() time.Duration <span class="cov4" title="8">{ return o.pollInterval }</span>
+func (o *OutboxConfig) PollInterval() time.Duration <span class="cov8" title="1">{ return o.pollInterval }</span>
 
 // ErrorBackoff は、relay バッチがエラーを返した後に待機する時間を返します。
-func (o *OutboxConfig) ErrorBackoff() time.Duration <span class="cov4" title="8">{ return o.errorBackoff }</span>
+func (o *OutboxConfig) ErrorBackoff() time.Duration <span class="cov8" title="1">{ return o.errorBackoff }</span>
 
 // BatchSize は、1 回の poll で claim する pending 行数を返します。
-func (o *OutboxConfig) BatchSize() int <span class="cov4" title="8">{ return o.batchSize }</span>
+func (o *OutboxConfig) BatchSize() int <span class="cov8" title="1">{ return o.batchSize }</span>
 </pre>
 		
 		<pre class="file" id="file18" style="display: none">package config
 
 // SetUpConfig は、Configを初期化するための関数です。
-func SetUpConfig() (*Config, error) <span class="cov10" title="19">{
+func SetUpConfig() (*Config, error) <span class="cov8" title="1">{
         if err := Load(); err != nil </span><span class="cov0" title="0">{
                 return nil, err
         }</span>
 
-        <span class="cov10" title="19">return New()</span>
+        <span class="cov8" title="1">return New()</span>
 }
 </pre>
 		
@@ -3261,7 +3252,7 @@ import (
 )
 
 // NewTestLocation は、テスト用のタイムゾーンロケーションを生成します。
-func NewTestLocation(t *testing.T) *time.Location <span class="cov2" title="2">{
+func NewTestLocation(t *testing.T) *time.Location <span class="cov8" title="1">{
         t.Helper()
         cfg := MockConfigForTest(t)
         osCfg := NewOperatingSystemConfig(cfg)
@@ -3274,7 +3265,7 @@ func NewTestLocation(t *testing.T) *time.Location <span class="cov2" title="2">{
 // EnsureRepoRootAndEnv は、go.mod のあるリポジトリルートへ作業ディレクトリを移動し、
 // env/.env.&lt;env&gt; の各値を t.Setenv で設定します。埋め込み（local）より対象環境の値が優先されます。
 // 作業ディレクトリと環境変数の復元は t.Chdir / t.Setenv が自動で行います。
-func EnsureRepoRootAndEnv(t *testing.T, env string) <span class="cov4" title="10">{
+func EnsureRepoRootAndEnv(t *testing.T, env string) <span class="cov8" title="1">{
         t.Helper()
 
         root := repoRoot(t)
@@ -3282,22 +3273,22 @@ func EnsureRepoRootAndEnv(t *testing.T, env string) <span class="cov4" title="10
 
         kv, err := godotenv.Read(filepath.Join(root, "env", ".env."+env))
         require.NoError(t, err)
-        for k, v := range kv </span><span class="cov10" title="390">{
+        for k, v := range kv </span><span class="cov8" title="1">{
                 t.Setenv(k, v)
         }</span>
 }
 
 // repoRoot は、go.mod を上方向に探索してリポジトリルートを返します。
-func repoRoot(t *testing.T) string <span class="cov4" title="10">{
+func repoRoot(t *testing.T) string <span class="cov8" title="1">{
         t.Helper()
 
         p, err := os.Getwd()
         require.NoError(t, err)
-        for </span><span class="cov6" title="32">{
-                if _, err := os.Stat(filepath.Join(p, "go.mod")); err == nil </span><span class="cov4" title="10">{
+        for </span><span class="cov8" title="1">{
+                if _, err := os.Stat(filepath.Join(p, "go.mod")); err == nil </span><span class="cov8" title="1">{
                         return p
                 }</span>
-                <span class="cov5" title="22">parent := filepath.Dir(p)
+                <span class="cov8" title="1">parent := filepath.Dir(p)
                 require.NotEqual(t, parent, p, "リポジトリルート（go.mod）が見つかりません")
                 p = parent</span>
         }
@@ -3309,7 +3300,7 @@ func repoRoot(t *testing.T) string <span class="cov4" title="10">{
 import "time"
 
 // NewTimeLocation は、新しい時間ロケーションを作成して返します。
-func NewTimeLocation(osCfg *OperatingSystemConfig) (*time.Location, error) <span class="cov10" title="6">{
+func NewTimeLocation(osCfg *OperatingSystemConfig) (*time.Location, error) <span class="cov8" title="1">{
         return time.LoadLocation(osCfg.TimeZone())
 }</span>
 </pre>
@@ -3321,16 +3312,16 @@ import (
 )
 
 // Email は、OpenAPI 生成の Email を文字列へ変換します。
-func Email(e openapi_types.Email) string <span class="cov10" title="8">{
+func Email(e openapi_types.Email) string <span class="cov8" title="1">{
         return string(e)
 }</span>
 
 // EmailPtr は、任意の OpenAPI 生成 Email を文字列ポインタへ変換します（nil は nil を返す）。
-func EmailPtr(e *openapi_types.Email) *string <span class="cov8" title="6">{
-        if e == nil </span><span class="cov5" title="3">{
+func EmailPtr(e *openapi_types.Email) *string <span class="cov8" title="1">{
+        if e == nil </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov5" title="3">s := string(*e)
+        <span class="cov8" title="1">s := string(*e)
         return &amp;s</span>
 }
 </pre>
@@ -3348,7 +3339,7 @@ import (
 
 // UUID は、OpenAPI 生成の UUID（path / query パラメータ）をドメインの uuid.UUID へ変換します。
 // openapi_types.UUID は検証済みの 16 バイト UUID 値型であり、変換は無条件に成功します。
-func UUID(p openapi_types.UUID) uuid.UUID <span class="cov10" title="16">{
+func UUID(p openapi_types.UUID) uuid.UUID <span class="cov8" title="1">{
         return uuid.FromPrimitive(p)
 }</span>
 </pre>
@@ -3370,27 +3361,27 @@ type authnSlot struct {
 }
 
 // WithAuthn は、空の Authn スロットを ctx に仕込む。
-func WithAuthn(ctx context.Context) context.Context <span class="cov9" title="37">{
+func WithAuthn(ctx context.Context) context.Context <span class="cov8" title="1">{
         return context.WithValue(ctx, authnSlotKey{}, &amp;authnSlot{})
 }</span>
 
 // SetAuthn は、ctx のスロットへ Authn を書き込む。スロットが無ければ false。
-func SetAuthn(ctx context.Context, authn auth.Authn) bool <span class="cov9" title="38">{
+func SetAuthn(ctx context.Context, authn auth.Authn) bool <span class="cov8" title="1">{
         slot, ok := ctx.Value(authnSlotKey{}).(*authnSlot)
-        if !ok </span><span class="cov2" title="2">{
+        if !ok </span><span class="cov8" title="1">{
                 return false
         }</span>
-        <span class="cov9" title="36">slot.authn, slot.set = authn, true
+        <span class="cov8" title="1">slot.authn, slot.set = authn, true
         return true</span>
 }
 
 // GetAuthn は、ctx のスロットから Authn を読む。未設定なら ok=false。
-func GetAuthn(ctx context.Context) (auth.Authn, bool) <span class="cov10" title="40">{
+func GetAuthn(ctx context.Context) (auth.Authn, bool) <span class="cov8" title="1">{
         slot, ok := ctx.Value(authnSlotKey{}).(*authnSlot)
-        if !ok || !slot.set </span><span class="cov6" title="9">{
+        if !ok || !slot.set </span><span class="cov8" title="1">{
                 return auth.Authn{}, false
         }</span>
-        <span class="cov9" title="31">return slot.authn, true</span>
+        <span class="cov8" title="1">return slot.authn, true</span>
 }
 </pre>
 		
@@ -3410,27 +3401,27 @@ var errorhandledKey = errorhandledKeyType{}
 
 // --- std lib context ---
 
-func SetErrorHandled(ctx context.Context, val bool) context.Context <span class="cov9" title="16">{
+func SetErrorHandled(ctx context.Context, val bool) context.Context <span class="cov8" title="1">{
         return context.WithValue(ctx, errorhandledKey, val)
 }</span>
 
-func GetErrorHandled(ctx context.Context) (bool, bool) <span class="cov10" title="18">{
+func GetErrorHandled(ctx context.Context) (bool, bool) <span class="cov8" title="1">{
         val := ctx.Value(errorhandledKey)
-        if v, ok := val.(bool); ok </span><span class="cov5" title="4">{
+        if v, ok := val.(bool); ok </span><span class="cov8" title="1">{
                 return v, true
         }</span>
-        <span class="cov9" title="14">var zero bool
+        <span class="cov8" title="1">var zero bool
         return zero, false</span>
 }
 
 // --- echo.Context wrapper（std lib 版へ委譲） ---
 
-func SetErrorHandledToEcho(c echo.Context, val bool) <span class="cov8" title="13">{
+func SetErrorHandledToEcho(c echo.Context, val bool) <span class="cov8" title="1">{
         ctx := SetErrorHandled(c.Request().Context(), val)
         c.SetRequest(c.Request().WithContext(ctx))
 }</span>
 
-func GetErrorHandledFromEcho(c echo.Context) (bool, bool) <span class="cov9" title="15">{
+func GetErrorHandledFromEcho(c echo.Context) (bool, bool) <span class="cov8" title="1">{
         return GetErrorHandled(c.Request().Context())
 }</span>
 </pre>
@@ -3451,27 +3442,27 @@ var recoveredKey = recoveredKeyType{}
 
 // --- std lib context ---
 
-func SetRecovered(ctx context.Context, val bool) context.Context <span class="cov7" title="9">{
+func SetRecovered(ctx context.Context, val bool) context.Context <span class="cov8" title="1">{
         return context.WithValue(ctx, recoveredKey, val)
 }</span>
 
-func GetRecovered(ctx context.Context) (bool, bool) <span class="cov10" title="18">{
+func GetRecovered(ctx context.Context) (bool, bool) <span class="cov8" title="1">{
         val := ctx.Value(recoveredKey)
-        if v, ok := val.(bool); ok </span><span class="cov6" title="6">{
+        if v, ok := val.(bool); ok </span><span class="cov8" title="1">{
                 return v, true
         }</span>
-        <span class="cov8" title="12">var zero bool
+        <span class="cov8" title="1">var zero bool
         return zero, false</span>
 }
 
 // --- echo.Context wrapper（std lib 版へ委譲） ---
 
-func SetRecoveredToEcho(c echo.Context, val bool) <span class="cov6" title="6">{
+func SetRecoveredToEcho(c echo.Context, val bool) <span class="cov8" title="1">{
         ctx := SetRecovered(c.Request().Context(), val)
         c.SetRequest(c.Request().WithContext(ctx))
 }</span>
 
-func GetRecoveredFromEcho(c echo.Context) (bool, bool) <span class="cov9" title="15">{
+func GetRecoveredFromEcho(c echo.Context) (bool, bool) <span class="cov8" title="1">{
         return GetRecovered(c.Request().Context())
 }</span>
 </pre>
@@ -3499,7 +3490,7 @@ type HTTPErrorResponse struct {
 
 // NewHTTPErrorFromAppError は、err をアプリケーションエラーとして解釈し、対応する HTTP エラーレスポンスを返します。
 // 既知のエラー型に一致しない場合は 500 Internal Server Error として扱います。
-func NewHTTPErrorFromAppError(err error, details ...string) *HTTPErrorResponse <span class="cov8" title="24">{
+func NewHTTPErrorFromAppError(err error, details ...string) *HTTPErrorResponse <span class="cov8" title="1">{
         meta := lookupErrorMetaByAppError(err)
 
         res := newHTTPErrorFromMeta(meta, details...)
@@ -3509,7 +3500,7 @@ func NewHTTPErrorFromAppError(err error, details ...string) *HTTPErrorResponse <
 
 // NewHTTPErrorFromStatus は、指定されたHTTPステータスコードに対応するHTTPエラーレスポンスを生成します。
 // err はログ出力用の元エラーとして Internal に格納されます。
-func NewHTTPErrorFromStatus(httpStatus int, err error, details ...string) *HTTPErrorResponse <span class="cov8" title="26">{
+func NewHTTPErrorFromStatus(httpStatus int, err error, details ...string) *HTTPErrorResponse <span class="cov8" title="1">{
         meta := lookupErrorMetaByHTTPStatus(httpStatus)
 
         res := newHTTPErrorFromMeta(meta, details...)
@@ -3518,20 +3509,20 @@ func NewHTTPErrorFromStatus(httpStatus int, err error, details ...string) *HTTPE
 }</span>
 
 // Error メソッドは、HTTPエラーレスポンスの文字列表現を返します。
-func (e *HTTPErrorResponse) Error() string <span class="cov2" title="2">{
-        if e.Internal != nil </span><span class="cov1" title="1">{
+func (e *HTTPErrorResponse) Error() string <span class="cov8" title="1">{
+        if e.Internal != nil </span><span class="cov8" title="1">{
                 return e.Internal.Error()
         }</span>
-        <span class="cov1" title="1">return fmt.Sprintf("HTTP %d: %s (%s)", e.HTTPStatus, e.Code, e.Message)</span>
+        <span class="cov8" title="1">return fmt.Sprintf("HTTP %d: %s (%s)", e.HTTPStatus, e.Code, e.Message)</span>
 }
 
 // newHTTPErrorFromMeta は、指定されたメタ情報からHTTPエラーレスポンスを生成します。
-func newHTTPErrorFromMeta(meta httpErrorMeta, details ...string) *HTTPErrorResponse <span class="cov10" title="55">{
+func newHTTPErrorFromMeta(meta httpErrorMeta, details ...string) *HTTPErrorResponse <span class="cov8" title="1">{
         var detailsPtr *[]string
-        if len(details) &gt; 0 </span><span class="cov5" title="8">{
+        if len(details) &gt; 0 </span><span class="cov8" title="1">{
                 detailsPtr = new(details)
         }</span>
-        <span class="cov10" title="55">return &amp;HTTPErrorResponse{
+        <span class="cov8" title="1">return &amp;HTTPErrorResponse{
                 ErrorResponse: gen.ErrorResponse{
                         Code:    meta.Code,
                         Message: meta.Message,
@@ -3670,40 +3661,40 @@ type httpErrorMeta struct {
 
 // lookupErrorMetaByHTTPStatus は、HTTPステータスコードに対応するエラーメタデータを取得します。
 // 存在しない場合は、サーバーエラーのメタデータを返します。
-func lookupErrorMetaByHTTPStatus(status int) httpErrorMeta <span class="cov10" title="78">{
-        if meta, ok := errorMeta[status]; ok </span><span class="cov9" title="75">{
+func lookupErrorMetaByHTTPStatus(status int) httpErrorMeta <span class="cov8" title="1">{
+        if meta, ok := errorMeta[status]; ok </span><span class="cov8" title="1">{
                 return meta
         }</span>
-        <span class="cov3" title="3">return errorMeta[http.StatusInternalServerError]</span>
+        <span class="cov8" title="1">return errorMeta[http.StatusInternalServerError]</span>
 }
 
 // lookupErrorMetaByAppError は、アプリケーションエラーに対応するエラーメタデータを取得します。
 // 既知のエラー型に一致しない場合は 500 Internal Server Error のメタを返します。
-func lookupErrorMetaByAppError(err error) httpErrorMeta <span class="cov8" title="40">{
+func lookupErrorMetaByAppError(err error) httpErrorMeta <span class="cov8" title="1">{
         switch </span>{
-        case xerrors.Is(err, apperror.ErrInvalidArgument):<span class="cov3" title="3"> // 400
+        case xerrors.Is(err, apperror.ErrInvalidArgument):<span class="cov8" title="1"> // 400
                 return lookupErrorMetaByHTTPStatus(http.StatusBadRequest)</span>
-        case xerrors.Is(err, apperror.ErrValidation):<span class="cov4" title="5"> // 422
+        case xerrors.Is(err, apperror.ErrValidation):<span class="cov8" title="1"> // 422
                 return lookupErrorMetaByHTTPStatus(http.StatusUnprocessableEntity)</span>
-        case xerrors.Is(err, apperror.ErrUnauthenticated):<span class="cov1" title="1"> // 401
+        case xerrors.Is(err, apperror.ErrUnauthenticated):<span class="cov8" title="1"> // 401
                 return lookupErrorMetaByHTTPStatus(http.StatusUnauthorized)</span>
-        case xerrors.Is(err, apperror.ErrPermissionDenied):<span class="cov2" title="2"> // 403
+        case xerrors.Is(err, apperror.ErrPermissionDenied):<span class="cov8" title="1"> // 403
                 return lookupErrorMetaByHTTPStatus(http.StatusForbidden)</span>
-        case xerrors.Is(err, apperror.ErrNotFound):<span class="cov3" title="3"> // 404
+        case xerrors.Is(err, apperror.ErrNotFound):<span class="cov8" title="1"> // 404
                 return lookupErrorMetaByHTTPStatus(http.StatusNotFound)</span>
-        case xerrors.Is(err, apperror.ErrConflict):<span class="cov1" title="1"> // 409
+        case xerrors.Is(err, apperror.ErrConflict):<span class="cov8" title="1"> // 409
                 return lookupErrorMetaByHTTPStatus(http.StatusConflict)</span>
-        case xerrors.Is(err, apperror.ErrCanceled):<span class="cov1" title="1"> // 499
+        case xerrors.Is(err, apperror.ErrCanceled):<span class="cov8" title="1"> // 499
                 return lookupErrorMetaByHTTPStatus(statusClientClosedRequest)</span>
-        case xerrors.Is(err, apperror.ErrUnavailable):<span class="cov3" title="3"> // 503
+        case xerrors.Is(err, apperror.ErrUnavailable):<span class="cov8" title="1"> // 503
                 return lookupErrorMetaByHTTPStatus(http.StatusServiceUnavailable)</span>
-        case xerrors.Is(err, apperror.ErrUnimplemented):<span class="cov1" title="1"> // 501
+        case xerrors.Is(err, apperror.ErrUnimplemented):<span class="cov8" title="1"> // 501
                 return lookupErrorMetaByHTTPStatus(http.StatusNotImplemented)</span>
-        case xerrors.Is(err, apperror.ErrTooManyRequests):<span class="cov1" title="1"> // 429
+        case xerrors.Is(err, apperror.ErrTooManyRequests):<span class="cov8" title="1"> // 429
                 return lookupErrorMetaByHTTPStatus(http.StatusTooManyRequests)</span>
-        case xerrors.Is(err, apperror.ErrInternal):<span class="cov4" title="5"> // 500
+        case xerrors.Is(err, apperror.ErrInternal):<span class="cov8" title="1"> // 500
                 return lookupErrorMetaByHTTPStatus(http.StatusInternalServerError)</span>
-        default:<span class="cov6" title="14">
+        default:<span class="cov8" title="1">
                 return lookupErrorMetaByHTTPStatus(http.StatusInternalServerError)</span>
         }
 }
@@ -3731,14 +3722,14 @@ type server struct {
 // BindHandler は、ヘルスチェック（health）ハンドラを Echo に登録します。
 func BindHandler(
         e *echo.Echo, tf observability.TracerFactory,
-) <span class="cov10" title="3">{
+) <span class="cov8" title="1">{
         gen.RegisterHandlers(e, gen.NewStrictHandler(&amp;server{
                 tracer: tf.Controller(),
         }, nil))
 }</span>
 
 // GetHealth は、サーバーのヘルスチェックを行います。
-func (s *server) GetHealth(ctx context.Context, _ gen.GetHealthRequestObject) (gen.GetHealthResponseObject, error) <span class="cov6" title="2">{
+func (s *server) GetHealth(ctx context.Context, _ gen.GetHealthRequestObject) (gen.GetHealthResponseObject, error) <span class="cov8" title="1">{
         _, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
@@ -3770,7 +3761,7 @@ type server struct {
 // BindHandler は、liveness 用の healthz ハンドラを Echo に登録します。
 func BindHandler(
         e *echo.Echo, tf observability.TracerFactory,
-) <span class="cov10" title="4">{
+) <span class="cov8" title="1">{
         gen.RegisterHandlers(e, gen.NewStrictHandler(&amp;server{
                 tracer: tf.Controller(),
         }, nil))
@@ -3779,7 +3770,7 @@ func BindHandler(
 // GetHealthz は、サーバーのヘルスチェックを行います。
 func (s *server) GetHealthz(
         ctx context.Context, _ gen.GetHealthzRequestObject,
-) (gen.GetHealthzResponseObject, error) <span class="cov8" title="3">{
+) (gen.GetHealthzResponseObject, error) <span class="cov8" title="1">{
         _, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
@@ -3801,7 +3792,7 @@ import (
 
 // BindHandler は、Prometheusメトリクスエンドポイント（/metrics）をEchoに登録します。
 // Basic認証バリデータを受け取り、エンドポイントへのアクセスを保護します。
-func BindHandler(e *echo.Echo, bav echomw.BasicAuthValidator) <span class="cov10" title="5">{
+func BindHandler(e *echo.Echo, bav echomw.BasicAuthValidator) <span class="cov8" title="1">{
         e.GET("/metrics",
                 echo.WrapHandler(promhttp.Handler()),
                 echomw.BasicAuth(bav),
@@ -3831,7 +3822,7 @@ type server struct {
 }
 
 // BindHandler は、レディネスチェックのハンドラーをEchoに登録します。
-func BindHandler(e *echo.Echo, tf observability.TracerFactory, healthUsecase healthcheckuc.Usecase) <span class="cov10" title="3">{
+func BindHandler(e *echo.Echo, tf observability.TracerFactory, healthUsecase healthcheckuc.Usecase) <span class="cov8" title="1">{
         gen.RegisterHandlers(e, gen.NewStrictHandler(&amp;server{
                 tracer:        tf.Controller(),
                 healthUsecase: healthUsecase,
@@ -3841,15 +3832,15 @@ func BindHandler(e *echo.Echo, tf observability.TracerFactory, healthUsecase hea
 // GetReady は、サーバーのレディネスチェックを行います。
 func (s *server) GetReady(
         ctx context.Context, _ gen.GetReadyRequestObject,
-) (gen.GetReadyResponseObject, error) <span class="cov10" title="3">{
+) (gen.GetReadyResponseObject, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         res, err := s.healthUsecase.CheckHealth(ctx)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov6" title="2">return gen.GetReady200JSONResponse(gen.ReadyResponse{
+        <span class="cov8" title="1">return gen.GetReady200JSONResponse(gen.ReadyResponse{
                 Status:          gen.ReadyResponseStatus(res.Status),
                 ApplicationTime: res.ApplicationTime,
                 DbLatencyMs:     res.DBHealthCheck.Latency.Milliseconds(),
@@ -3874,7 +3865,7 @@ import (
 // AssertJSONEqual は、HTTPレスポンスのJSONボディが期待される値と等しいことを検証します。
 func AssertJSONEqual[T any](
         t *testing.T, expectedCode int, expectedResponse T, actualResponse *httptest.ResponseRecorder,
-) <span class="cov3" title="2">{
+) <span class="cov8" title="1">{
         t.Helper()
 
         assert.Equal(t, expectedCode, actualResponse.Code, "HTTPステータスコードが一致しません")
@@ -3885,21 +3876,21 @@ func AssertJSONEqual[T any](
 }</span>
 
 // AssertEchoRouterMethods は、EchoのルートのHTTPメソッド集合が期待通りであることをアサートします。
-func AssertEchoRouterMethods(t *testing.T, expectedMethods []string, actualRoute []*echo.Route) <span class="cov8" title="9">{
+func AssertEchoRouterMethods(t *testing.T, expectedMethods []string, actualRoute []*echo.Route) <span class="cov8" title="1">{
         t.Helper()
         actualMethods := make([]string, len(actualRoute))
-        for i, r := range actualRoute </span><span class="cov10" title="12">{
+        for i, r := range actualRoute </span><span class="cov8" title="1">{
                 actualMethods[i] = r.Method
         }</span>
 
-        <span class="cov8" title="9">assert.ElementsMatch(t, expectedMethods, actualMethods)</span>
+        <span class="cov8" title="1">assert.ElementsMatch(t, expectedMethods, actualMethods)</span>
 }
 
 // AssertEchoRouterPath は、Echoのルートのパスが期待通りであることをアサートします。
-func AssertEchoRouterPath(t *testing.T, expectedPath string, actualRoute []*echo.Route) <span class="cov8" title="8">{
+func AssertEchoRouterPath(t *testing.T, expectedPath string, actualRoute []*echo.Route) <span class="cov8" title="1">{
         t.Helper()
         require.NotEmpty(t, actualRoute, "ルートが登録されていません")
-        for _, r := range actualRoute </span><span class="cov8" title="9">{
+        for _, r := range actualRoute </span><span class="cov8" title="1">{
                 assert.Equal(t, expectedPath, r.Path)
         }</span>
 }
@@ -3919,7 +3910,7 @@ import (
 )
 
 // MakeAvailableAuthn は、テスト用のコンテキストに認証情報を設定します。
-func MakeAvailableAuthn(ctx context.Context, t *testing.T, subject string) context.Context <span class="cov10" title="16">{
+func MakeAvailableAuthn(ctx context.Context, t *testing.T, subject string) context.Context <span class="cov8" title="1">{
         t.Helper()
         authn, err := auth.New(
                 subject,
@@ -3981,7 +3972,7 @@ type EchoTestClient struct {
 }
 
 // NewEchoTestClient はテスト用のEchoクライアントを生成します。
-func NewEchoTestClient(t *testing.T, e *echo.Echo) *EchoTestClient <span class="cov10" title="15">{
+func NewEchoTestClient(t *testing.T, e *echo.Echo) *EchoTestClient <span class="cov8" title="1">{
         t.Helper()
         return &amp;EchoTestClient{
                 t:       t,
@@ -3992,7 +3983,7 @@ func NewEchoTestClient(t *testing.T, e *echo.Echo) *EchoTestClient <span class="
 
 // WithAppErrorHandler は、本番相当のエラーハンドラを Echo に設定します。
 // 渡された Echo の HTTPErrorHandler を上書きする副作用を持ちます。
-func (c *EchoTestClient) WithAppErrorHandler() *EchoTestClient <span class="cov1" title="1">{
+func (c *EchoTestClient) WithAppErrorHandler() *EchoTestClient <span class="cov8" title="1">{
         c.t.Helper()
         cfg := config.MockConfigForTest(c.t)
         obsCfg := config.NewObservabilityConfig(cfg)
@@ -4002,7 +3993,7 @@ func (c *EchoTestClient) WithAppErrorHandler() *EchoTestClient <span class="cov1
 }</span>
 
 // Method はHTTPメソッドを設定します。
-func (c *EchoTestClient) Method(m string) *EchoTestClient <span class="cov8" title="10">{
+func (c *EchoTestClient) Method(m string) *EchoTestClient <span class="cov8" title="1">{
         c.t.Helper()
         c.method = m
         return c
@@ -4011,7 +4002,7 @@ func (c *EchoTestClient) Method(m string) *EchoTestClient <span class="cov8" tit
 // RoutePattern はルートパターンを設定します。
 //
 // 例: /users/:id, /products/:id
-func (c *EchoTestClient) RoutePattern(p string) *EchoTestClient <span class="cov8" title="9">{
+func (c *EchoTestClient) RoutePattern(p string) *EchoTestClient <span class="cov8" title="1">{
         c.t.Helper()
         c.routePattern = p
         return c
@@ -4021,14 +4012,14 @@ func (c *EchoTestClient) RoutePattern(p string) *EchoTestClient <span class="cov
 // (パスパラメータやクエリパラメータを含めて指定することができます。)
 //
 // 例: /users/123?limit=10, /products/456?sort=asc
-func (c *EchoTestClient) RequestURL(u string) *EchoTestClient <span class="cov6" title="6">{
+func (c *EchoTestClient) RequestURL(u string) *EchoTestClient <span class="cov8" title="1">{
         c.t.Helper()
         c.requestURL = u
         return c
 }</span>
 
 // JSONBody はJSON形式のリクエストボディを設定します。
-func (c *EchoTestClient) JSONBody(v any) *EchoTestClient <span class="cov1" title="1">{
+func (c *EchoTestClient) JSONBody(v any) *EchoTestClient <span class="cov8" title="1">{
         c.t.Helper()
         data, err := json.Marshal(v)
         require.NoError(c.t, err)
@@ -4040,37 +4031,37 @@ func (c *EchoTestClient) JSONBody(v any) *EchoTestClient <span class="cov1" titl
 // RawBody は生のリクエストボディを設定します。
 //
 // JSON形式は、 JSONBody() を使用してください。
-func (c *EchoTestClient) RawBody(r io.Reader, contentType string) *EchoTestClient <span class="cov3" title="2">{
+func (c *EchoTestClient) RawBody(r io.Reader, contentType string) *EchoTestClient <span class="cov8" title="1">{
         c.t.Helper()
         c.body = r
-        if contentType != "" </span><span class="cov1" title="1">{
+        if contentType != "" </span><span class="cov8" title="1">{
                 c.Header(echo.HeaderContentType, contentType)
         }</span>
-        <span class="cov3" title="2">return c</span>
+        <span class="cov8" title="1">return c</span>
 }
 
 // Header はリクエストヘッダーを設定します。
-func (c *EchoTestClient) Header(k, v string) *EchoTestClient <span class="cov5" title="4">{
+func (c *EchoTestClient) Header(k, v string) *EchoTestClient <span class="cov8" title="1">{
         c.t.Helper()
         c.headers.Set(k, v)
         return c
 }</span>
 
 // AuthBearer はBearerトークンを設定します。
-func (c *EchoTestClient) AuthBearer(token string) *EchoTestClient <span class="cov1" title="1">{
+func (c *EchoTestClient) AuthBearer(token string) *EchoTestClient <span class="cov8" title="1">{
         c.t.Helper()
         return c.Header(echo.HeaderAuthorization, "Bearer "+token)
 }</span>
 
 // PathParams はパスパラメータを設定します。
-func (c *EchoTestClient) PathParams(params []EchoTestParam) *EchoTestClient <span class="cov3" title="2">{
+func (c *EchoTestClient) PathParams(params []EchoTestParam) *EchoTestClient <span class="cov8" title="1">{
         c.t.Helper()
         c.pathParams = params
         return c
 }</span>
 
 // QueryParams はクエリパラメータを設定します。
-func (c *EchoTestClient) QueryParams(params []EchoTestParam) *EchoTestClient <span class="cov1" title="1">{
+func (c *EchoTestClient) QueryParams(params []EchoTestParam) *EchoTestClient <span class="cov8" title="1">{
         c.t.Helper()
         c.queryParams = params
         return c
@@ -4079,33 +4070,33 @@ func (c *EchoTestClient) QueryParams(params []EchoTestParam) *EchoTestClient <sp
 // Build はテスト用のHTTPリクエストとレスポンスレコーダー、echo.Contextを構築します。
 //
 // requestURL モードではルータ解決により echo.Context のパスが設定されます。
-func (c *EchoTestClient) Build() (*http.Request, *httptest.ResponseRecorder, echo.Context) <span class="cov7" title="8">{
+func (c *EchoTestClient) Build() (*http.Request, *httptest.ResponseRecorder, echo.Context) <span class="cov8" title="1">{
         c.t.Helper()
 
         req, rec := c.buildRequest()
         ec := c.e.NewContext(req, rec)
 
-        if c.requestURL != "" </span><span class="cov1" title="1">{
+        if c.requestURL != "" </span><span class="cov8" title="1">{
                 c.e.Router().Find(c.method, req.URL.Path, ec)
                 return req, rec, ec
         }</span>
 
-        <span class="cov7" title="7">ec.SetPath(c.routePattern)
-        if len(c.pathParams) &gt; 0 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">ec.SetPath(c.routePattern)
+        if len(c.pathParams) &gt; 0 </span><span class="cov8" title="1">{
                 names := make([]string, len(c.pathParams))
                 values := make([]string, len(c.pathParams))
-                for i, p := range c.pathParams </span><span class="cov1" title="1">{
+                for i, p := range c.pathParams </span><span class="cov8" title="1">{
                         names[i], values[i] = p.Name, p.Value
                 }</span>
-                <span class="cov1" title="1">ec.SetParamNames(names...)
+                <span class="cov8" title="1">ec.SetParamNames(names...)
                 ec.SetParamValues(values...)</span>
         }
 
-        <span class="cov7" title="7">return req, rec, ec</span>
+        <span class="cov8" title="1">return req, rec, ec</span>
 }
 
 // Serve は、結合テスト用に起動したEchoインスタンスに対してリクエストを送信し、レスポンスを取得します。
-func (c *EchoTestClient) Serve() *httptest.ResponseRecorder <span class="cov3" title="2">{
+func (c *EchoTestClient) Serve() *httptest.ResponseRecorder <span class="cov8" title="1">{
         c.t.Helper()
         req, rec := c.buildRequest()
         c.e.ServeHTTP(rec, req)
@@ -4115,22 +4106,22 @@ func (c *EchoTestClient) Serve() *httptest.ResponseRecorder <span class="cov3" t
 // resolveTarget はリクエスト先URLを決定し、モードの排他違反を検出します。
 //
 // requestURL モード(ルータ登録済みの Echo 前提)と routePattern/pathParams モードは排他です。
-func (c *EchoTestClient) resolveTarget() (string, error) <span class="cov10" title="15">{
+func (c *EchoTestClient) resolveTarget() (string, error) <span class="cov8" title="1">{
         switch </span>{
-        case c.requestURL != "":<span class="cov6" title="6">
-                if c.routePattern != "" || len(c.pathParams) &gt; 0 </span><span class="cov3" title="2">{
+        case c.requestURL != "":<span class="cov8" title="1">
+                if c.routePattern != "" || len(c.pathParams) &gt; 0 </span><span class="cov8" title="1">{
                         return "", errModeConflict
                 }</span>
-                <span class="cov5" title="4">return c.requestURL, nil</span>
-        case c.routePattern != "":<span class="cov7" title="8">
+                <span class="cov8" title="1">return c.requestURL, nil</span>
+        case c.routePattern != "":<span class="cov8" title="1">
                 return c.routePattern, nil</span>
-        default:<span class="cov1" title="1">
+        default:<span class="cov8" title="1">
                 return "", errTargetUnset</span>
         }
 }
 
 // buildRequest はリクエストとレスポンスレコーダーを構築します。
-func (c *EchoTestClient) buildRequest() (*http.Request, *httptest.ResponseRecorder) <span class="cov8" title="10">{
+func (c *EchoTestClient) buildRequest() (*http.Request, *httptest.ResponseRecorder) <span class="cov8" title="1">{
         c.t.Helper()
 
         target, err := c.resolveTarget()
@@ -4138,19 +4129,19 @@ func (c *EchoTestClient) buildRequest() (*http.Request, *httptest.ResponseRecord
                 c.t.Fatal(err)
         }</span>
 
-        <span class="cov8" title="10">ctx := context.Background()
+        <span class="cov8" title="1">ctx := context.Background()
         req := httptest.NewRequestWithContext(ctx, c.method, target, c.body)
-        for k, vv := range c.headers </span><span class="cov5" title="4">{
-                for _, v := range vv </span><span class="cov5" title="4">{
+        for k, vv := range c.headers </span><span class="cov8" title="1">{
+                for _, v := range vv </span><span class="cov8" title="1">{
                         req.Header.Add(k, v)
                 }</span>
         }
 
-        <span class="cov8" title="10">q := req.URL.Query()
-        for _, p := range c.queryParams </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">q := req.URL.Query()
+        for _, p := range c.queryParams </span><span class="cov8" title="1">{
                 q.Add(p.Name, p.Value)
         }</span>
-        <span class="cov8" title="10">req.URL.RawQuery = q.Encode()
+        <span class="cov8" title="1">req.URL.RawQuery = q.Encode()
 
         return req, httptest.NewRecorder()</span>
 }
@@ -4171,7 +4162,7 @@ import (
 func StartTestSpanForEcho(
         t *testing.T,
         c echo.Context,
-) (echo.Context, func()) <span class="cov10" title="9">{
+) (echo.Context, func()) <span class="cov8" title="1">{
         t.Helper()
 
         req := c.Request()
@@ -4197,7 +4188,7 @@ import (
 )
 
 // RequestUUID は、リクエスト用の openapi UUID（生成型）を1件生成します。
-func RequestUUID(t *testing.T) types.UUID <span class="cov10" title="16">{
+func RequestUUID(t *testing.T) types.UUID <span class="cov8" title="1">{
         t.Helper()
 
         id, err := uuid.New()
@@ -4229,7 +4220,7 @@ type server struct {
 }
 
 // BindHandler は、為替換算エンドポイントのハンドラを Echo に登録します。
-func BindHandler(e *echo.Echo, tf observability.TracerFactory, uc exchangerateuc.Usecase) <span class="cov10" title="4">{
+func BindHandler(e *echo.Echo, tf observability.TracerFactory, uc exchangerateuc.Usecase) <span class="cov8" title="1">{
         gen.RegisterHandlers(e, gen.NewStrictHandler(&amp;server{
                 tracer: tf.Controller(),
                 uc:     uc,
@@ -4239,16 +4230,16 @@ func BindHandler(e *echo.Echo, tf observability.TracerFactory, uc exchangerateuc
 // GetExchangeRates は、為替レートで amount を換算した結果を返します。
 func (s *server) GetExchangeRates(
         ctx context.Context, request gen.GetExchangeRatesRequestObject,
-) (gen.GetExchangeRatesResponseObject, error) <span class="cov10" title="4">{
+) (gen.GetExchangeRatesResponseObject, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         converted, err := s.uc.Convert(ctx, request.Params.Base, request.Params.Quote, request.Params.Amount)
-        if err != nil </span><span class="cov5" title="2">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov5" title="2">return gen.GetExchangeRates200JSONResponse(gen.ExchangeRateResponse{
+        <span class="cov8" title="1">return gen.GetExchangeRates200JSONResponse(gen.ExchangeRateResponse{
                 Base:      request.Params.Base,
                 Quote:     request.Params.Quote,
                 Amount:    request.Params.Amount,
@@ -4287,7 +4278,7 @@ type server struct {
 }
 
 // BindHandler は、ユーザー詳細のハンドラを Echo に登録します。
-func BindHandler(e *echo.Echo, tf observability.TracerFactory, uc user.Usecase) <span class="cov10" title="9">{
+func BindHandler(e *echo.Echo, tf observability.TracerFactory, uc user.Usecase) <span class="cov8" title="1">{
         gen.RegisterHandlers(e, gen.NewStrictHandler(&amp;server{
                 tracer: tf.Controller(),
                 uc:     uc,
@@ -4295,36 +4286,36 @@ func BindHandler(e *echo.Echo, tf observability.TracerFactory, uc user.Usecase) 
 }</span>
 
 // GetUsersDetail は、指定されたUUIDに該当するユーザーの詳細情報を取得します。
-func (s *server) GetUsersDetail(ctx context.Context, request gen.GetUsersDetailRequestObject) (gen.GetUsersDetailResponseObject, error) <span class="cov8" title="6">{
+func (s *server) GetUsersDetail(ctx context.Context, request gen.GetUsersDetailRequestObject) (gen.GetUsersDetailResponseObject, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         authn, ok := ctxhelper.GetAuthn(ctx)
-        if !ok </span><span class="cov1" title="1">{
+        if !ok </span><span class="cov8" title="1">{
                 return nil, ErrUnauthenticatedUser
         }</span>
 
-        <span class="cov7" title="5">id := conv.UUID(request.UserId)
+        <span class="cov8" title="1">id := conv.UUID(request.UserId)
 
         dto, err := s.uc.GetUser(ctx, &amp;authn, id)
-        if err != nil </span><span class="cov5" title="3">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov3" title="2">return gen.GetUsersDetail200JSONResponse(toUserResponse(dto)), nil</span>
+        <span class="cov8" title="1">return gen.GetUsersDetail200JSONResponse(toUserResponse(dto)), nil</span>
 }
 
 // PutUsersDetail は、指定されたUUIDに該当するユーザーのプロフィールを全て更新します（パスワードは含みません）。
-func (s *server) PutUsersDetail(ctx context.Context, request gen.PutUsersDetailRequestObject) (gen.PutUsersDetailResponseObject, error) <span class="cov6" title="4">{
+func (s *server) PutUsersDetail(ctx context.Context, request gen.PutUsersDetailRequestObject) (gen.PutUsersDetailResponseObject, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         authn, ok := ctxhelper.GetAuthn(ctx)
-        if !ok </span><span class="cov1" title="1">{
+        if !ok </span><span class="cov8" title="1">{
                 return nil, ErrUnauthenticatedUser
         }</span>
 
-        <span class="cov5" title="3">id := conv.UUID(request.UserId)
+        <span class="cov8" title="1">id := conv.UUID(request.UserId)
 
         dto := &amp;user.UpdateProfileParams{
                 FirstName:      request.Body.FirstName,
@@ -4339,24 +4330,24 @@ func (s *server) PutUsersDetail(ctx context.Context, request gen.PutUsersDetailR
         }
 
         res, err := s.uc.UpdateUser(ctx, &amp;authn, id, dto)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov3" title="2">return gen.PutUsersDetail200JSONResponse(toUserResponse(res)), nil</span>
+        <span class="cov8" title="1">return gen.PutUsersDetail200JSONResponse(toUserResponse(res)), nil</span>
 }
 
 // PatchUsersDetail は、指定されたUUIDに該当するユーザーの情報を部分的に更新します（パスワードは更新しません）。
-func (s *server) PatchUsersDetail(ctx context.Context, request gen.PatchUsersDetailRequestObject) (gen.PatchUsersDetailResponseObject, error) <span class="cov7" title="5">{
+func (s *server) PatchUsersDetail(ctx context.Context, request gen.PatchUsersDetailRequestObject) (gen.PatchUsersDetailResponseObject, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         authn, ok := ctxhelper.GetAuthn(ctx)
-        if !ok </span><span class="cov1" title="1">{
+        if !ok </span><span class="cov8" title="1">{
                 return nil, ErrUnauthenticatedUser
         }</span>
 
-        <span class="cov6" title="4">id := conv.UUID(request.UserId)
+        <span class="cov8" title="1">id := conv.UUID(request.UserId)
 
         dto := &amp;user.PatchParamsDTO{
                 FirstName:      request.Body.FirstName,
@@ -4371,55 +4362,55 @@ func (s *server) PatchUsersDetail(ctx context.Context, request gen.PatchUsersDet
         }
 
         res, err := s.uc.UpdateUserPartially(ctx, &amp;authn, id, dto)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov5" title="3">return gen.PatchUsersDetail200JSONResponse(toUserResponse(res)), nil</span>
+        <span class="cov8" title="1">return gen.PatchUsersDetail200JSONResponse(toUserResponse(res)), nil</span>
 }
 
 // PutUsersMePassword は、認証ユーザー自身のパスワードを変更します（現パスワード照合あり）。
-func (s *server) PutUsersMePassword(ctx context.Context, request gen.PutUsersMePasswordRequestObject) (gen.PutUsersMePasswordResponseObject, error) <span class="cov7" title="5">{
+func (s *server) PutUsersMePassword(ctx context.Context, request gen.PutUsersMePasswordRequestObject) (gen.PutUsersMePasswordResponseObject, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         authn, ok := ctxhelper.GetAuthn(ctx)
-        if !ok </span><span class="cov1" title="1">{
+        if !ok </span><span class="cov8" title="1">{
                 return nil, ErrUnauthenticatedUser
         }</span>
-        <span class="cov6" title="4">id, err := authn.ID()
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">id, err := authn.ID()
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(err, "failed to get user ID from authenticator")
         }</span>
 
-        <span class="cov5" title="3">if err := s.uc.ChangePassword(ctx, id, request.Body.CurrentPassword, request.Body.NewPassword); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err := s.uc.ChangePassword(ctx, id, request.Body.CurrentPassword, request.Body.NewPassword); err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov3" title="2">return gen.PutUsersMePassword204Response{}, nil</span>
+        <span class="cov8" title="1">return gen.PutUsersMePassword204Response{}, nil</span>
 }
 
 // DeleteUsersDetail は、指定されたUUIDに該当するユーザーを論理削除します。
-func (s *server) DeleteUsersDetail(ctx context.Context, request gen.DeleteUsersDetailRequestObject) (gen.DeleteUsersDetailResponseObject, error) <span class="cov6" title="4">{
+func (s *server) DeleteUsersDetail(ctx context.Context, request gen.DeleteUsersDetailRequestObject) (gen.DeleteUsersDetailResponseObject, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         authn, ok := ctxhelper.GetAuthn(ctx)
-        if !ok </span><span class="cov1" title="1">{
+        if !ok </span><span class="cov8" title="1">{
                 return nil, ErrUnauthenticatedUser
         }</span>
 
-        <span class="cov5" title="3">id := conv.UUID(request.UserId)
+        <span class="cov8" title="1">id := conv.UUID(request.UserId)
 
-        if err := s.uc.DeleteUser(ctx, &amp;authn, id); err != nil </span><span class="cov1" title="1">{
+        if err := s.uc.DeleteUser(ctx, &amp;authn, id); err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov3" title="2">return gen.DeleteUsersDetail204Response{}, nil</span>
+        <span class="cov8" title="1">return gen.DeleteUsersDetail204Response{}, nil</span>
 }
 
 // toUserResponse は、ユースケースのDTOをHTTPレスポンスへ変換します。
-func toUserResponse(dto user.UserView) gen.UserResponse <span class="cov8" title="7">{
+func toUserResponse(dto user.UserView) gen.UserResponse <span class="cov8" title="1">{
         return gen.UserResponse{
                 FirstName:  dto.FirstName,
                 LastName:   dto.LastName,
@@ -4459,7 +4450,7 @@ type server struct {
 }
 
 // BindHandler は、ユーザーフィードのハンドラを Echo に登録します。
-func BindHandler(e *echo.Echo, tf observability.TracerFactory, uc user.Usecase) <span class="cov8" title="5">{
+func BindHandler(e *echo.Echo, tf observability.TracerFactory, uc user.Usecase) <span class="cov8" title="1">{
         gen.RegisterHandlers(e, gen.NewStrictHandler(&amp;server{
                 tracer: tf.Controller(),
                 uc:     uc,
@@ -4467,27 +4458,27 @@ func BindHandler(e *echo.Echo, tf observability.TracerFactory, uc user.Usecase) 
 }</span>
 
 // GetUsersFeed は、未削除ユーザーを作成日時の降順（cursor ページネーション）で取得します。
-func (s *server) GetUsersFeed(ctx context.Context, request gen.GetUsersFeedRequestObject) (gen.GetUsersFeedResponseObject, error) <span class="cov10" title="7">{
+func (s *server) GetUsersFeed(ctx context.Context, request gen.GetUsersFeedRequestObject) (gen.GetUsersFeedResponseObject, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         // WARN: このエンドポイントは認可チェックを実施していません。
         cursor, err := paging.NewCursor(request.Params.After, request.Params.First)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov9" title="6">feed, err := s.uc.ListUsersFeed(ctx, cursor)
-        if err != nil </span><span class="cov4" title="2">{
+        <span class="cov8" title="1">feed, err := s.uc.ListUsersFeed(ctx, cursor)
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov7" title="4">users := make([]gen.UserResponse, len(feed.Items))
-        for i, dto := range feed.Items </span><span class="cov8" title="5">{
+        <span class="cov8" title="1">users := make([]gen.UserResponse, len(feed.Items))
+        for i, dto := range feed.Items </span><span class="cov8" title="1">{
                 users[i] = toUserResponse(dto)
         }</span>
 
-        <span class="cov7" title="4">res := gen.UsersFeedResponse{
+        <span class="cov8" title="1">res := gen.UsersFeedResponse{
                 Users:      users,
                 NextCursor: feed.NextCursor,
                 HasNext:    feed.NextCursor != nil,
@@ -4497,7 +4488,7 @@ func (s *server) GetUsersFeed(ctx context.Context, request gen.GetUsersFeedReque
 }
 
 // toUserResponse は、ユースケースのDTOをHTTPレスポンスへ変換します。
-func toUserResponse(dto user.UserView) gen.UserResponse <span class="cov8" title="5">{
+func toUserResponse(dto user.UserView) gen.UserResponse <span class="cov8" title="1">{
         return gen.UserResponse{
                 FirstName:  dto.FirstName,
                 LastName:   dto.LastName,
@@ -4537,7 +4528,7 @@ type server struct {
 }
 
 // BindHandler は、ユーザー検索エンドポイントのハンドラーをEchoに登録します。
-func BindHandler(e *echo.Echo, tf observability.TracerFactory, us search.Usecase) <span class="cov7" title="4">{
+func BindHandler(e *echo.Echo, tf observability.TracerFactory, us search.Usecase) <span class="cov8" title="1">{
         gen.RegisterHandlers(e, gen.NewStrictHandler(&amp;server{
                 tracer: tf.Controller(),
                 uc:     us,
@@ -4545,26 +4536,26 @@ func BindHandler(e *echo.Echo, tf observability.TracerFactory, us search.Usecase
 }</span>
 
 // GetUsersSearch は、検索条件に基づいてユーザーの一覧を取得します。
-func (s *server) GetUsersSearch(ctx context.Context, request gen.GetUsersSearchRequestObject) (gen.GetUsersSearchResponseObject, error) <span class="cov10" title="7">{
+func (s *server) GetUsersSearch(ctx context.Context, request gen.GetUsersSearchRequestObject) (gen.GetUsersSearchResponseObject, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         page, err := paging.NewPageFrom1Based(request.Params.Page, request.Params.PerPage)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov9" title="6">filter := &amp;search.SearchParams{
+        <span class="cov8" title="1">filter := &amp;search.SearchParams{
                 Keyword: request.Params.Keyword,
                 Active:  request.Params.Active,
         }
         list, err := s.uc.ListUsersByKeywordWithTotal(ctx, filter, page)
-        if err != nil </span><span class="cov4" title="2">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov7" title="4">users := make([]gen.UsersSearchResponseItem, len(list.Items))
-        for i, dto := range list.Items </span><span class="cov6" title="3">{
+        <span class="cov8" title="1">users := make([]gen.UsersSearchResponseItem, len(list.Items))
+        for i, dto := range list.Items </span><span class="cov8" title="1">{
                 users[i] = gen.UsersSearchResponseItem{
                         FirstName:    dto.FirstName,
                         LastName:     dto.LastName,
@@ -4580,7 +4571,7 @@ func (s *server) GetUsersSearch(ctx context.Context, request gen.GetUsersSearchR
                 }
         }</span>
 
-        <span class="cov7" title="4">return gen.GetUsersSearch200JSONResponse(gen.UsersSearchResponse{
+        <span class="cov8" title="1">return gen.GetUsersSearch200JSONResponse(gen.UsersSearchResponse{
                 Users:  users,
                 Total:  list.Total,
                 Limit:  page.Limit(),
@@ -4624,7 +4615,7 @@ type server struct {
 }
 
 // BindHandler は、ユーザー一覧のハンドラを Echo に登録します。
-func BindHandler(e *echo.Echo, tf observability.TracerFactory, uc user.Usecase, idem idempotency.Deps) <span class="cov9" title="6">{
+func BindHandler(e *echo.Echo, tf observability.TracerFactory, uc user.Usecase, idem idempotency.Deps) <span class="cov8" title="1">{
         gen.RegisterHandlers(e, gen.NewStrictHandler(&amp;server{
                 tracer: tf.Controller(),
                 uc:     uc,
@@ -4633,27 +4624,27 @@ func BindHandler(e *echo.Echo, tf observability.TracerFactory, uc user.Usecase, 
 }</span>
 
 // GetUsers は、ユーザー一覧を取得します。
-func (s *server) GetUsers(ctx context.Context, request gen.GetUsersRequestObject) (gen.GetUsersResponseObject, error) <span class="cov10" title="7">{
+func (s *server) GetUsers(ctx context.Context, request gen.GetUsersRequestObject) (gen.GetUsersResponseObject, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         // WARN: 本来はここで認可を行うべきですが、今回は省略します。
         page, err := paging.NewPageFrom1Based(request.Params.Page, request.Params.PerPage)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov9" title="6">list, err := s.uc.ListUsersWithTotal(ctx, request.Params.Active, page)
-        if err != nil </span><span class="cov4" title="2">{
+        <span class="cov8" title="1">list, err := s.uc.ListUsersWithTotal(ctx, request.Params.Active, page)
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov7" title="4">users := make([]gen.UserResponse, len(list.Items))
-        for i, dto := range list.Items </span><span class="cov7" title="4">{
+        <span class="cov8" title="1">users := make([]gen.UserResponse, len(list.Items))
+        for i, dto := range list.Items </span><span class="cov8" title="1">{
                 users[i] = toUserResponse(dto)
         }</span>
 
-        <span class="cov7" title="4">res := gen.UsersResponse{
+        <span class="cov8" title="1">res := gen.UsersResponse{
                 Users:  users,
                 Total:  list.Total,
                 Limit:  page.Limit(),
@@ -4664,20 +4655,20 @@ func (s *server) GetUsers(ctx context.Context, request gen.GetUsersRequestObject
 }
 
 // PostUsers は、ユーザーを作成します。
-func (s *server) PostUsers(ctx context.Context, request gen.PostUsersRequestObject) (gen.PostUsersResponseObject, error) <span class="cov9" title="6">{
+func (s *server) PostUsers(ctx context.Context, request gen.PostUsersRequestObject) (gen.PostUsersResponseObject, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         authn, ok := ctxhelper.GetAuthn(ctx)
-        if !ok </span><span class="cov1" title="1">{
+        if !ok </span><span class="cov8" title="1">{
                 return nil, ErrUnauthenticatedUser
         }</span>
-        <span class="cov8" title="5">userID, err := authn.ID()
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">userID, err := authn.ID()
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(err, "failed to get user ID from authenticator")
         }</span>
 
-        <span class="cov7" title="4">createParams := &amp;user.CreateParamsDTO{
+        <span class="cov8" title="1">createParams := &amp;user.CreateParamsDTO{
                 UserID:      userID,
                 RawPassword: request.Body.Password,
                 UpdateProfileParams: user.UpdateProfileParams{
@@ -4693,18 +4684,18 @@ func (s *server) PostUsers(ctx context.Context, request gen.PostUsersRequestObje
                 },
         }
 
-        dto, _, err := idempotency.Run(ctx, s.idem, http.StatusCreated, func(ctx context.Context) (user.UserView, error) </span><span class="cov7" title="4">{
+        dto, _, err := idempotency.Run(ctx, s.idem, http.StatusCreated, func(ctx context.Context) (user.UserView, error) </span><span class="cov8" title="1">{
                 return s.uc.CreateUser(ctx, createParams)
         }</span>)
-        <span class="cov7" title="4">if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov6" title="3">return gen.PostUsers201JSONResponse(toUserResponse(dto)), nil</span>
+        <span class="cov8" title="1">return gen.PostUsers201JSONResponse(toUserResponse(dto)), nil</span>
 }
 
 // toUserResponse は、ユースケースのDTOをHTTPレスポンスへ変換します。
-func toUserResponse(dto user.UserView) gen.UserResponse <span class="cov10" title="7">{
+func toUserResponse(dto user.UserView) gen.UserResponse <span class="cov8" title="1">{
         return gen.UserResponse{
                 FirstName:  dto.FirstName,
                 LastName:   dto.LastName,
@@ -4757,7 +4748,7 @@ func BindHandler(
         loc *time.Location,
         bi system.BuildInfo,
         ac *config.ApplicationConfig,
-) <span class="cov10" title="3">{
+) <span class="cov8" title="1">{
         gen.RegisterHandlers(e, gen.NewStrictHandler(&amp;server{
                 buildInfo: bi,
                 appCfg:    ac,
@@ -4767,16 +4758,16 @@ func BindHandler(
 }</span>
 
 // GetVersion は、アプリケーションのバージョン情報を取得します。
-func (s *server) GetVersion(ctx context.Context, _ gen.GetVersionRequestObject) (gen.GetVersionResponseObject, error) <span class="cov10" title="3">{
+func (s *server) GetVersion(ctx context.Context, _ gen.GetVersionRequestObject) (gen.GetVersionResponseObject, error) <span class="cov8" title="1">{
         _, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         buildDate, err := datetime.ParseRFC3339UTCToLocation(s.buildInfo.BuildDate(), s.loc)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Join(errInvalidBuildDate, err)
         }</span>
 
-        <span class="cov6" title="2">return gen.GetVersion200JSONResponse(gen.VersionResponse{
+        <span class="cov8" title="1">return gen.GetVersion200JSONResponse(gen.VersionResponse{
                 Version:     s.buildInfo.Version(),
                 Revision:    s.buildInfo.Revision(),
                 BuildDate:   buildDate,
@@ -4799,8 +4790,8 @@ import (
 )
 
 // NewBasicAuthValidator は、MetricsConfig のユーザ名・パスワードを用いる Basic 認証バリデータを返します。タイミング攻撃を防ぐために定数時間比較（subtle.ConstantTimeCompare）を用います。
-func NewBasicAuthValidator(mtcCfg *config.MetricsConfig) echomw.BasicAuthValidator <span class="cov10" title="7">{
-        return func(username, password string, _ echo.Context) (bool, error) </span><span class="cov9" title="6">{
+func NewBasicAuthValidator(mtcCfg *config.MetricsConfig) echomw.BasicAuthValidator <span class="cov8" title="1">{
+        return func(username, password string, _ echo.Context) (bool, error) </span><span class="cov8" title="1">{
                 userOK := subtle.ConstantTimeCompare([]byte(username), []byte(mtcCfg.UserName())) == 1
                 passOK := subtle.ConstantTimeCompare([]byte(password), []byte(mtcCfg.Password())) == 1
                 return userOK &amp;&amp; passOK, nil
@@ -4825,11 +4816,11 @@ import (
 // Pre ミドルウェアとして登録すること。Use 層の OpenAPI validator が requestBody を
 // 読む前に上限を適用するために必要です。Use 以降に置くと validator が無制限ボディを
 // 読み切り、上限がサイレントに無効化されます。
-func Middleware(limitMB int) echo.MiddlewareFunc <span class="cov10" title="10">{
-        if limitMB &lt;= 0 </span><span class="cov3" title="2">{
+func Middleware(limitMB int) echo.MiddlewareFunc <span class="cov8" title="1">{
+        if limitMB &lt;= 0 </span><span class="cov8" title="1">{
                 panic(fmt.Sprintf("bodylimit: limitMB must be positive, got %d", limitMB))</span>
         }
-        <span class="cov9" title="8">return middleware.BodyLimit(fmt.Sprintf("%dM", limitMB))</span>
+        <span class="cov8" title="1">return middleware.BodyLimit(fmt.Sprintf("%dM", limitMB))</span>
 }
 </pre>
 		
@@ -4850,122 +4841,122 @@ type cookieAttrs struct {
 
 // parseSetCookie は Set-Cookie ヘッダ値を解析します。
 // 失敗時は ok == false を返します。
-func parseSetCookie(raw string) (string, string, *cookieAttrs, bool) <span class="cov8" title="44">{
+func parseSetCookie(raw string) (string, string, *cookieAttrs, bool) <span class="cov8" title="1">{
         parts := strings.Split(raw, ";")
         first := strings.TrimSpace(parts[0])
         eq := strings.Index(first, keyValueAttrSep)
-        if eq &lt;= 0 </span><span class="cov4" title="6">{
+        if eq &lt;= 0 </span><span class="cov8" title="1">{
                 return "", "", nil, false
         }</span>
 
-        <span class="cov8" title="38">name := strings.TrimSpace(first[:eq])
+        <span class="cov8" title="1">name := strings.TrimSpace(first[:eq])
         value := strings.TrimSpace(first[eq+1:]) // value はそのまま（quoted/encoded を壊さない）
 
         attrs := &amp;cookieAttrs{order: make([]string, 0, len(parts)-1), kv: make(map[string]*string, len(parts)-1)}
-        for _, p := range parts[1:] </span><span class="cov8" title="51">{
-                if strings.TrimSpace(p) == "" </span><span class="cov1" title="1">{
+        for _, p := range parts[1:] </span><span class="cov8" title="1">{
+                if strings.TrimSpace(p) == "" </span><span class="cov8" title="1">{
                         continue</span>
                 }
-                <span class="cov8" title="50">k, v, isKV := splitAttr(p)
-                if isKV </span><span class="cov7" title="31">{
+                <span class="cov8" title="1">k, v, isKV := splitAttr(p)
+                if isKV </span><span class="cov8" title="1">{
                         upsertAttr(attrs, k, new(v))
-                }</span> else<span class="cov6" title="19"> {
+                }</span> else<span class="cov8" title="1"> {
                         upsertAttr(attrs, k, nil)
                 }</span>
         }
-        <span class="cov8" title="38">return name, value, attrs, true</span>
+        <span class="cov8" title="1">return name, value, attrs, true</span>
 }
 
 // splitAttr は 属性文字列を key/value に分割します（`=` 前後の空白は除去）。
-func splitAttr(s string) (string, string, bool) <span class="cov8" title="53">{
+func splitAttr(s string) (string, string, bool) <span class="cov8" title="1">{
         before, after, ok := strings.Cut(s, keyValueAttrSep)
-        if !ok </span><span class="cov7" title="20">{
+        if !ok </span><span class="cov8" title="1">{
                 return strings.TrimSpace(s), "", false
         }</span>
-        <span class="cov8" title="33">return strings.TrimSpace(before), strings.TrimSpace(after), true</span>
+        <span class="cov8" title="1">return strings.TrimSpace(before), strings.TrimSpace(after), true</span>
 }
 
 // upsertAttr は 属性を追加/更新します（order と kv のキー集合を一致させる単一経路）。
-func upsertAttr(attrs *cookieAttrs, key string, val *string) <span class="cov10" title="88">{
+func upsertAttr(attrs *cookieAttrs, key string, val *string) <span class="cov8" title="1">{
         key = strings.ToLower(key)
-        if _, exists := attrs.kv[key]; !exists </span><span class="cov9" title="82">{
+        if _, exists := attrs.kv[key]; !exists </span><span class="cov8" title="1">{
                 attrs.order = append(attrs.order, key)
         }</span>
-        <span class="cov10" title="88">attrs.kv[key] = val</span>
+        <span class="cov8" title="1">attrs.kv[key] = val</span>
 }
 
 // setBoolAttr は ブール属性を設定/削除します。
-func setBoolAttr(attrs *cookieAttrs, key string, on bool) <span class="cov7" title="22">{
-        if on </span><span class="cov6" title="19">{
+func setBoolAttr(attrs *cookieAttrs, key string, on bool) <span class="cov8" title="1">{
+        if on </span><span class="cov8" title="1">{
                 upsertAttr(attrs, key, nil)
                 return
         }</span>
-        <span class="cov3" title="3">delAttr(attrs, key)</span>
+        <span class="cov8" title="1">delAttr(attrs, key)</span>
 }
 
 // setKVAttr は key/value 属性を設定します。
-func setKVAttr(attrs *cookieAttrs, key, val string) <span class="cov6" title="19">{
+func setKVAttr(attrs *cookieAttrs, key, val string) <span class="cov8" title="1">{
         upsertAttr(attrs, key, new(val))
 }</span>
 
 // delAttr は 属性を削除します。
-func delAttr(attrs *cookieAttrs, key string) <span class="cov4" title="6">{
+func delAttr(attrs *cookieAttrs, key string) <span class="cov8" title="1">{
         key = strings.ToLower(key)
-        if _, exists := attrs.kv[key]; !exists </span><span class="cov1" title="1">{
+        if _, exists := attrs.kv[key]; !exists </span><span class="cov8" title="1">{
                 return
         }</span>
-        <span class="cov4" title="5">delete(attrs.kv, key)
+        <span class="cov8" title="1">delete(attrs.kv, key)
         // order からも消す
         out := attrs.order[:0]
-        for _, k := range attrs.order </span><span class="cov5" title="9">{
-                if k != key </span><span class="cov3" title="4">{
+        for _, k := range attrs.order </span><span class="cov8" title="1">{
+                if k != key </span><span class="cov8" title="1">{
                         out = append(out, k)
                 }</span>
         }
-        <span class="cov4" title="5">attrs.order = out</span>
+        <span class="cov8" title="1">attrs.order = out</span>
 }
 
 // buildSetCookie は Set-Cookie ヘッダ値を構築します。
-func buildSetCookie(name, value string, attrs *cookieAttrs) string <span class="cov7" title="21">{
+func buildSetCookie(name, value string, attrs *cookieAttrs) string <span class="cov8" title="1">{
         var b strings.Builder
         b.WriteString(name)
         b.WriteString(keyValueAttrSep)
         b.WriteString(value)
 
         // 既存の順序を尊重しつつ出力
-        for _, k := range attrs.order </span><span class="cov8" title="45">{
+        for _, k := range attrs.order </span><span class="cov8" title="1">{
                 v, ok := attrs.kv[k]
-                if !ok </span><span class="cov1" title="1">{
+                if !ok </span><span class="cov8" title="1">{
                         continue</span>
                 }
-                <span class="cov8" title="44">b.WriteString("; ")
+                <span class="cov8" title="1">b.WriteString("; ")
                 b.WriteString(canonicalAttrKey(k))
-                if v != nil </span><span class="cov7" title="25">{
+                if v != nil </span><span class="cov8" title="1">{
                         b.WriteString(keyValueAttrSep)
                         b.WriteString(*v)
                 }</span>
         }
-        <span class="cov7" title="21">return b.String()</span>
+        <span class="cov8" title="1">return b.String()</span>
 }
 
 // canonicalAttrKey は 属性キーの正規化を行います（order のキーは小文字前提）。
-func canonicalAttrKey(k string) string <span class="cov8" title="52">{
+func canonicalAttrKey(k string) string <span class="cov8" title="1">{
         switch k </span>{
-        case "httponly":<span class="cov5" title="9">
+        case "httponly":<span class="cov8" title="1">
                 return "HttpOnly"</span>
-        case "samesite":<span class="cov4" title="7">
+        case "samesite":<span class="cov8" title="1">
                 return "SameSite"</span>
-        case "max-age":<span class="cov2" title="2">
+        case "max-age":<span class="cov8" title="1">
                 return "Max-Age"</span>
-        case "secure":<span class="cov5" title="11">
+        case "secure":<span class="cov8" title="1">
                 return "Secure"</span>
-        case "domain":<span class="cov4" title="6">
+        case "domain":<span class="cov8" title="1">
                 return "Domain"</span>
-        case "path":<span class="cov5" title="11">
+        case "path":<span class="cov8" title="1">
                 return "Path"</span>
-        case "expires":<span class="cov1" title="1">
+        case "expires":<span class="cov8" title="1">
                 return "Expires"</span>
-        default:<span class="cov4" title="5">
+        default:<span class="cov8" title="1">
                 // それ以外はそのまま（先頭だけ大文字等は揃えない）
                 return k</span>
         }
@@ -4993,7 +4984,7 @@ type cookieRewriteWriter struct {
 }
 
 // newCookieRewriteWriter は cookieRewriteWriter を構築します。
-func newCookieRewriteWriter(orig http.ResponseWriter, cfg *SecurityCookie) *cookieRewriteWriter <span class="cov10" title="20">{
+func newCookieRewriteWriter(orig http.ResponseWriter, cfg *SecurityCookie) *cookieRewriteWriter <span class="cov8" title="1">{
         return &amp;cookieRewriteWriter{
                 orig: orig,
                 cfg:  cfg,
@@ -5002,16 +4993,16 @@ func newCookieRewriteWriter(orig http.ResponseWriter, cfg *SecurityCookie) *cook
 }</span>
 
 // Header はヘッダを返します。
-func (w *cookieRewriteWriter) Header() http.Header <span class="cov5" title="5">{
+func (w *cookieRewriteWriter) Header() http.Header <span class="cov8" title="1">{
         return w.hdr
 }</span>
 
 // WriteHeader はステータスコードを設定します。
-func (w *cookieRewriteWriter) WriteHeader(code int) <span class="cov6" title="7">{
-        if w.wroteHdr </span><span class="cov1" title="1">{
+func (w *cookieRewriteWriter) WriteHeader(code int) <span class="cov8" title="1">{
+        if w.wroteHdr </span><span class="cov8" title="1">{
                 return
         }</span>
-        <span class="cov6" title="6">w.wroteHdr = true
+        <span class="cov8" title="1">w.wroteHdr = true
 
         // Set-Cookie を書き換え
         w.flushHeadersWithRewrite()
@@ -5020,99 +5011,99 @@ func (w *cookieRewriteWriter) WriteHeader(code int) <span class="cov6" title="7"
 }
 
 // Write はボディを書き込みます。
-func (w *cookieRewriteWriter) Write(p []byte) (int, error) <span class="cov4" title="3">{
-        if !w.wroteHdr </span><span class="cov1" title="1">{
+func (w *cookieRewriteWriter) Write(p []byte) (int, error) <span class="cov8" title="1">{
+        if !w.wroteHdr </span><span class="cov8" title="1">{
                 w.WriteHeader(http.StatusOK)
         }</span>
-        <span class="cov4" title="3">return w.orig.Write(p)</span>
+        <span class="cov8" title="1">return w.orig.Write(p)</span>
 }
 
 // Flush はフラッシュを行います。
-func (w *cookieRewriteWriter) Flush() <span class="cov3" title="2">{
-        if f, ok := w.orig.(http.Flusher); ok </span><span class="cov1" title="1">{
-                if !w.wroteHdr </span><span class="cov1" title="1">{
+func (w *cookieRewriteWriter) Flush() <span class="cov8" title="1">{
+        if f, ok := w.orig.(http.Flusher); ok </span><span class="cov8" title="1">{
+                if !w.wroteHdr </span><span class="cov8" title="1">{
                         w.WriteHeader(http.StatusOK)
                 }</span>
-                <span class="cov1" title="1">f.Flush()</span>
+                <span class="cov8" title="1">f.Flush()</span>
         }
 }
 
 // Hijack はコネクションをハイジャックします。
-func (w *cookieRewriteWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) <span class="cov5" title="4">{
+func (w *cookieRewriteWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) <span class="cov8" title="1">{
         // WebSocket 等は WriteHeader を経由せずに Hijack されることがあるため、w.hdr 上で
         // Set-Cookie rewrite を確定させる。これは w.Header() を参照するタイプの Upgrade 実装にのみ
         // 効く防御であり、生バッファへ直書きする通常の hijack 経路では配線に出ない。
-        if !w.wroteHdr </span><span class="cov4" title="3">{
+        if !w.wroteHdr </span><span class="cov8" title="1">{
                 w.wroteHdr = true
 
                 rawCookies := w.hdr.Values(headerSetCookie)
-                if len(rawCookies) &gt; 0 </span><span class="cov3" title="2">{
+                if len(rawCookies) &gt; 0 </span><span class="cov8" title="1">{
                         w.hdr.Del(headerSetCookie)
-                        for _, raw := range rawCookies </span><span class="cov3" title="2">{
+                        for _, raw := range rawCookies </span><span class="cov8" title="1">{
                                 w.hdr.Add(headerSetCookie, w.rewriteOrKeep(raw))
                         }</span>
                 }
         }
 
         // WebSocket などで http.Hijacker を透過する
-        <span class="cov5" title="4">h, ok := w.orig.(http.Hijacker)
-        if !ok </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">h, ok := w.orig.(http.Hijacker)
+        if !ok </span><span class="cov8" title="1">{
                 return nil, nil, http.ErrNotSupported
         }</span>
-        <span class="cov4" title="3">return h.Hijack()</span>
+        <span class="cov8" title="1">return h.Hijack()</span>
 }
 
 // Push は HTTP/2 Server Push を透過します。
-func (w *cookieRewriteWriter) Push(target string, opts *http.PushOptions) error <span class="cov3" title="2">{
+func (w *cookieRewriteWriter) Push(target string, opts *http.PushOptions) error <span class="cov8" title="1">{
         p, ok := w.orig.(http.Pusher)
-        if !ok </span><span class="cov1" title="1">{
+        if !ok </span><span class="cov8" title="1">{
                 return http.ErrNotSupported
         }</span>
-        <span class="cov1" title="1">return p.Push(target, opts)</span>
+        <span class="cov8" title="1">return p.Push(target, opts)</span>
 }
 
 // ReadFrom は io.Copy の最適化経路を透過します。
 // wrapper 側でヘッダ書き換えを確定させてから orig に委譲します。
-func (w *cookieRewriteWriter) ReadFrom(r io.Reader) (int64, error) <span class="cov3" title="2">{
-        if !w.wroteHdr </span><span class="cov3" title="2">{
+func (w *cookieRewriteWriter) ReadFrom(r io.Reader) (int64, error) <span class="cov8" title="1">{
+        if !w.wroteHdr </span><span class="cov8" title="1">{
                 w.WriteHeader(http.StatusOK)
         }</span>
 
-        <span class="cov3" title="2">if rf, ok := w.orig.(io.ReaderFrom); ok </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if rf, ok := w.orig.(io.ReaderFrom); ok </span><span class="cov8" title="1">{
                 return rf.ReadFrom(r)
         }</span>
         // orig が ReaderFrom を持たない場合は素直にコピー（w には書かない：再帰回避）
-        <span class="cov1" title="1">return io.Copy(w.orig, r)</span>
+        <span class="cov8" title="1">return io.Copy(w.orig, r)</span>
 }
 
 // Unwrap は内側の ResponseWriter を返します。
 // 他のミドルウェアや標準ライブラリが内側へアクセスしたい場合に役立ちます。
-func (w *cookieRewriteWriter) Unwrap() http.ResponseWriter <span class="cov1" title="1">{
+func (w *cookieRewriteWriter) Unwrap() http.ResponseWriter <span class="cov8" title="1">{
         return w.orig
 }</span>
 
 // rewriteOrKeep は Set-Cookie を書き換え、失敗（空文字）時は元の raw を残します。
 // 失敗時に消すと Cookie 消失になるため、この不変条件を1箇所に集約します。
-func (w *cookieRewriteWriter) rewriteOrKeep(raw string) string <span class="cov6" title="6">{
-        if r := w.cfg.RewriteSetCookie(raw); r != "" </span><span class="cov5" title="4">{
+func (w *cookieRewriteWriter) rewriteOrKeep(raw string) string <span class="cov8" title="1">{
+        if r := w.cfg.RewriteSetCookie(raw); r != "" </span><span class="cov8" title="1">{
                 return r
         }</span>
-        <span class="cov3" title="2">return raw</span>
+        <span class="cov8" title="1">return raw</span>
 }
 
 // flushHeadersWithRewrite はヘッダを書き込みます（Set-Cookie を書き換え）。
-func (w *cookieRewriteWriter) flushHeadersWithRewrite() <span class="cov7" title="8">{
-        for k, vv := range w.hdr </span><span class="cov6" title="7">{
-                if strings.EqualFold(k, headerSetCookie) </span><span class="cov5" title="4">{
+func (w *cookieRewriteWriter) flushHeadersWithRewrite() <span class="cov8" title="1">{
+        for k, vv := range w.hdr </span><span class="cov8" title="1">{
+                if strings.EqualFold(k, headerSetCookie) </span><span class="cov8" title="1">{
                         continue</span>
                 }
-                <span class="cov4" title="3">for _, v := range vv </span><span class="cov4" title="3">{
+                <span class="cov8" title="1">for _, v := range vv </span><span class="cov8" title="1">{
                         w.orig.Header().Add(k, v)
                 }</span>
         }
 
         // Set-Cookie を rewrite してから追加
-        <span class="cov7" title="8">for _, raw := range w.hdr.Values(headerSetCookie) </span><span class="cov5" title="4">{
+        <span class="cov8" title="1">for _, raw := range w.hdr.Values(headerSetCookie) </span><span class="cov8" title="1">{
                 w.orig.Header().Add(headerSetCookie, w.rewriteOrKeep(raw))
         }</span>
 }
@@ -5125,14 +5116,14 @@ import (
 )
 
 // Middleware は、SecurityCookie 設定に従い Set-Cookie ヘッダのセキュリティ属性（Secure / HttpOnly / SameSite / Path / Domain など）を上書きする Echo ミドルウェアを返します。
-func Middleware(cfg *SecurityCookie) echo.MiddlewareFunc <span class="cov7" title="4">{
+func Middleware(cfg *SecurityCookie) echo.MiddlewareFunc <span class="cov8" title="1">{
         return secureCookieMiddleware(cfg)
 }</span>
 
 // secureCookieMiddleware は、SecurityCookie 設定に基づいてクッキーを書き換える Echo 用の middleware を生成します。
-func secureCookieMiddleware(cfg *SecurityCookie) echo.MiddlewareFunc <span class="cov10" title="6">{
-        return func(next echo.HandlerFunc) echo.HandlerFunc </span><span class="cov4" title="2">{
-                return func(c echo.Context) error </span><span class="cov4" title="2">{
+func secureCookieMiddleware(cfg *SecurityCookie) echo.MiddlewareFunc <span class="cov8" title="1">{
+        return func(next echo.HandlerFunc) echo.HandlerFunc </span><span class="cov8" title="1">{
+                return func(c echo.Context) error </span><span class="cov8" title="1">{
                         res := c.Response()
 
                         // next 後に Writer を復元しない（エラー経路の Set-Cookie も書き換え対象にするため。後始末は echo の Context Reset が担う）。
@@ -5191,7 +5182,7 @@ type SecurityCookie struct {
 // NewSecurityCookie は、設定から SecurityCookie を構築します。
 func NewSecurityCookie(
         p *config.SecureCookieConfig,
-) *SecurityCookie <span class="cov6" title="8">{
+) *SecurityCookie <span class="cov8" title="1">{
         cfg := &amp;SecurityCookie{
                 // デフォルト（boilerplate 推奨値）
                 applyToAll: true,
@@ -5212,90 +5203,90 @@ func NewSecurityCookie(
 
         cfg.forceSecure = p.Secure()
         // SameSite: 空なら上書きしない、許容値（Lax/Strict/None）へ正規化し非許容値は無視
-        if s := normalizeSameSite(p.SameSite()); s != "" </span><span class="cov6" title="7">{
+        if s := normalizeSameSite(p.SameSite()); s != "" </span><span class="cov8" title="1">{
                 cfg.forceSameSite = s
         }</span>
         // Domain: 空なら上書きしない
         // （__Host- を使う場合は Rewrite 内で Domain が落とされる）
-        <span class="cov6" title="8">if d := strings.TrimSpace(p.Domain()); d != "" </span><span class="cov6" title="7">{
+        <span class="cov8" title="1">if d := strings.TrimSpace(p.Domain()); d != "" </span><span class="cov8" title="1">{
                 cfg.forceDomain = d
         }</span>
 
-        <span class="cov6" title="8">return cfg</span>
+        <span class="cov8" title="1">return cfg</span>
 }
 
 // RewriteSetCookie は Set-Cookie ヘッダ値（1本）を cfg に基づいて上書きします。
 // 失敗時は空文字を返します（呼び出し側で元の raw を使う想定）。
-func (cfg *SecurityCookie) RewriteSetCookie(raw string) string <span class="cov10" title="24">{
+func (cfg *SecurityCookie) RewriteSetCookie(raw string) string <span class="cov8" title="1">{
         name, value, attrs, ok := parseSetCookie(raw)
-        if !ok || name == "" </span><span class="cov4" title="4">{
+        if !ok || name == "" </span><span class="cov8" title="1">{
                 return ""
         }</span>
-        <span class="cov9" title="20">if !cfg.targets(name) </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if !cfg.targets(name) </span><span class="cov8" title="1">{
                 return raw
         }</span>
 
-        <span class="cov9" title="18">if cfg.forceSecure != nil </span><span class="cov6" title="7">{
+        <span class="cov8" title="1">if cfg.forceSecure != nil </span><span class="cov8" title="1">{
                 setBoolAttr(attrs, "secure", *cfg.forceSecure)
         }</span>
-        <span class="cov9" title="18">if cfg.forceHTTPOnly != nil </span><span class="cov6" title="8">{
+        <span class="cov8" title="1">if cfg.forceHTTPOnly != nil </span><span class="cov8" title="1">{
                 setBoolAttr(attrs, "httponly", *cfg.forceHTTPOnly)
         }</span>
-        <span class="cov9" title="18">cfg.applySameSite(attrs)
-        if cfg.forcePath != "" </span><span class="cov6" title="6">{
+        <span class="cov8" title="1">cfg.applySameSite(attrs)
+        if cfg.forcePath != "" </span><span class="cov8" title="1">{
                 setKVAttr(attrs, "path", cfg.forcePath)
         }</span>
-        <span class="cov9" title="18">if cfg.forceDomain != "" </span><span class="cov4" title="4">{
+        <span class="cov8" title="1">if cfg.forceDomain != "" </span><span class="cov8" title="1">{
                 setKVAttr(attrs, "domain", cfg.forceDomain)
         }</span>
-        <span class="cov9" title="18">if cfg.forceMaxAge != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if cfg.forceMaxAge != nil </span><span class="cov8" title="1">{
                 setKVAttr(attrs, "max-age", strconv.Itoa(*cfg.forceMaxAge))
         }</span>
         // expires は Secure 属性との整合性を保つのが困難なため、Max-Age と並行して操作しない。
-        <span class="cov9" title="18">cfg.applyNamePrefix(name, attrs)
+        <span class="cov8" title="1">cfg.applyNamePrefix(name, attrs)
 
         return buildSetCookie(name, value, attrs)</span>
 }
 
 // targets は、name を書き換え対象とするか判定します。
-func (cfg *SecurityCookie) targets(name string) bool <span class="cov9" title="20">{
-        if !cfg.applyToAll </span><span class="cov2" title="2">{
-                if _, ok := cfg.cookieNames[name]; !ok </span><span class="cov1" title="1">{
+func (cfg *SecurityCookie) targets(name string) bool <span class="cov8" title="1">{
+        if !cfg.applyToAll </span><span class="cov8" title="1">{
+                if _, ok := cfg.cookieNames[name]; !ok </span><span class="cov8" title="1">{
                         return false
                 }</span>
         }
-        <span class="cov9" title="19">_, skip := cfg.skipCookieNames[name]
+        <span class="cov8" title="1">_, skip := cfg.skipCookieNames[name]
         return !skip</span>
 }
 
 // applySameSite は SameSite 上書きと、実効 SameSite=None 時の Secure 強制を適用します。
-func (cfg *SecurityCookie) applySameSite(attrs *cookieAttrs) <span class="cov9" title="18">{
-        if cfg.forceSameSite != "" </span><span class="cov5" title="5">{
+func (cfg *SecurityCookie) applySameSite(attrs *cookieAttrs) <span class="cov8" title="1">{
+        if cfg.forceSameSite != "" </span><span class="cov8" title="1">{
                 setKVAttr(attrs, "samesite", cfg.forceSameSite)
         }</span>
-        <span class="cov9" title="18">if !cfg.enforceSecureWhenSameSiteNone </span><span class="cov8" title="12">{
+        <span class="cov8" title="1">if !cfg.enforceSecureWhenSameSiteNone </span><span class="cov8" title="1">{
                 return
         }</span>
         // 実効 SameSite（強制値優先、無ければ入力値）が None なら Secure を強制する
-        <span class="cov6" title="6">effective := cfg.forceSameSite
-        if effective == "" </span><span class="cov2" title="2">{
-                if p := attrs.kv["samesite"]; p != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">effective := cfg.forceSameSite
+        if effective == "" </span><span class="cov8" title="1">{
+                if p := attrs.kv["samesite"]; p != nil </span><span class="cov8" title="1">{
                         effective = *p
                 }</span>
         }
-        <span class="cov6" title="6">if strings.EqualFold(effective, "None") </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if strings.EqualFold(effective, "None") </span><span class="cov8" title="1">{
                 setBoolAttr(attrs, "secure", true)
         }</span>
 }
 
 // applyNamePrefix は __Secure-/__Host- prefix の安全要件を適用します。
-func (cfg *SecurityCookie) applyNamePrefix(name string, attrs *cookieAttrs) <span class="cov9" title="18">{
+func (cfg *SecurityCookie) applyNamePrefix(name string, attrs *cookieAttrs) <span class="cov8" title="1">{
         hostPrefix := strings.HasPrefix(name, "__Host-")
         securePrefix := strings.HasPrefix(name, "__Secure-") || hostPrefix
-        if securePrefix </span><span class="cov2" title="2">{
+        if securePrefix </span><span class="cov8" title="1">{
                 setBoolAttr(attrs, "secure", true)
         }</span>
-        <span class="cov9" title="18">if hostPrefix </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if hostPrefix </span><span class="cov8" title="1">{
                 // __Host- は Secure（securePrefix で付与済み）+ Path=/ + Domain無し
                 setKVAttr(attrs, "path", "/")
                 delAttr(attrs, "domain")
@@ -5303,15 +5294,15 @@ func (cfg *SecurityCookie) applyNamePrefix(name string, attrs *cookieAttrs) <spa
 }
 
 // normalizeSameSite は SameSite 値を許容値（Lax/Strict/None）へ正規化します。非許容値・空は "" を返します。
-func normalizeSameSite(s string) string <span class="cov8" title="14">{
+func normalizeSameSite(s string) string <span class="cov8" title="1">{
         switch strings.ToLower(strings.TrimSpace(s)) </span>{
-        case "lax":<span class="cov1" title="1">
+        case "lax":<span class="cov8" title="1">
                 return "Lax"</span>
-        case "strict":<span class="cov6" title="8">
+        case "strict":<span class="cov8" title="1">
                 return "Strict"</span>
-        case "none":<span class="cov2" title="2">
+        case "none":<span class="cov8" title="1">
                 return "None"</span>
-        default:<span class="cov4" title="3">
+        default:<span class="cov8" title="1">
                 return ""</span>
         }
 }
@@ -5331,12 +5322,12 @@ import (
 const corsMaxAgeSeconds = 600
 
 // Middleware は、CORSミドルウェアを設定して返します。
-func Middleware(secCfg *config.SecurityConfig) echo.MiddlewareFunc <span class="cov7" title="5">{
+func Middleware(secCfg *config.SecurityConfig) echo.MiddlewareFunc <span class="cov8" title="1">{
         return middleware.CORSWithConfig(buildCORSConfig(secCfg.AllowedOrigins()))
 }</span>
 
 // buildCORSConfig は、CORSミドルウェアの設定を構築します。
-func buildCORSConfig(allowedOrigins []string) middleware.CORSConfig <span class="cov10" title="8">{
+func buildCORSConfig(allowedOrigins []string) middleware.CORSConfig <span class="cov8" title="1">{
         return middleware.CORSConfig{
                 AllowOrigins: allowedOrigins,
                 AllowMethods: []string{
@@ -5375,7 +5366,7 @@ import (
 )
 
 // New は、開発モード向けのデバッグ支援機能を設定します。
-func New(e *echo.Echo, appCfg *config.ApplicationConfig) <span class="cov10" title="5">{
+func New(e *echo.Echo, appCfg *config.ApplicationConfig) <span class="cov8" title="1">{
         e.Debug = appCfg.IsDevelopmentMode()
 }</span>
 </pre>
@@ -5390,14 +5381,14 @@ import (
 )
 
 // normalizeEchoHTTPError は、EchoのHTTPエラーを正規化し、エラーレスポンスを生成します。
-func normalizeEchoHTTPError(err error, details ...string) *response.HTTPErrorResponse <span class="cov10" title="7">{
+func normalizeEchoHTTPError(err error, details ...string) *response.HTTPErrorResponse <span class="cov8" title="1">{
         var ehe *echo.HTTPError
-        if !xerrors.As(err, &amp;ehe) || !isErrorStatus(ehe.Code) </span><span class="cov6" title="3">{
+        if !xerrors.As(err, &amp;ehe) || !isErrorStatus(ehe.Code) </span><span class="cov8" title="1">{
                 return nil
         }</span>
 
         // ehe.Internal は nil になり得る（Wrap(nil)=nil で文脈喪失）ため、常に非 nil の err をラップする。
-        <span class="cov7" title="4">internal := xerrors.Wrap(err, "echo HTTP error")
+        <span class="cov8" title="1">internal := xerrors.Wrap(err, "echo HTTP error")
         return response.NewHTTPErrorFromStatus(ehe.Code, internal, details...)</span>
 }
 </pre>
@@ -5426,28 +5417,28 @@ const (
 )
 
 // New は、NewHTTPErrorHandler で生成したハンドラを Echo の HTTPErrorHandler として登録します。
-func New(e *echo.Echo, log logging.Logger, lf logging.LogFieldBuilder, obsCfg *config.ObservabilityConfig) <span class="cov7" title="11">{
+func New(e *echo.Echo, log logging.Logger, lf logging.LogFieldBuilder, obsCfg *config.ObservabilityConfig) <span class="cov8" title="1">{
         e.HTTPErrorHandler = NewHTTPErrorHandler(log, lf, obsCfg)
 }</span>
 
 // NewHTTPErrorHandler は、echo.HTTPErrorHandler を生成して返します。
-func NewHTTPErrorHandler(logger logging.Logger, lf logging.LogFieldBuilder, obsCfg *config.ObservabilityConfig) echo.HTTPErrorHandler <span class="cov8" title="12">{
-        return func(err error, c echo.Context) </span><span class="cov7" title="9">{
+func NewHTTPErrorHandler(logger logging.Logger, lf logging.LogFieldBuilder, obsCfg *config.ObservabilityConfig) echo.HTTPErrorHandler <span class="cov8" title="1">{
+        return func(err error, c echo.Context) </span><span class="cov8" title="1">{
                 handleHTTPError(c, logger, lf, obsCfg, err)
         }</span>
 }
 
 // handleHTTPError は、HTTPエラーを処理し、適切なレスポンスをクライアントに返します。
-func handleHTTPError(c echo.Context, logger logging.Logger, lf logging.LogFieldBuilder, obsCfg *config.ObservabilityConfig, err error) <span class="cov8" title="13">{
-        if handled, _ := ctxhelper.GetErrorHandledFromEcho(c); handled </span><span class="cov1" title="1">{
+func handleHTTPError(c echo.Context, logger logging.Logger, lf logging.LogFieldBuilder, obsCfg *config.ObservabilityConfig, err error) <span class="cov8" title="1">{
+        if handled, _ := ctxhelper.GetErrorHandledFromEcho(c); handled </span><span class="cov8" title="1">{
                 return
         }</span>
-        <span class="cov8" title="12">ctxhelper.SetErrorHandledToEcho(c, true)
+        <span class="cov8" title="1">ctxhelper.SetErrorHandledToEcho(c, true)
 
         resp := normalizeHTTPError(err, requestid.GetRequestIDFromResponse(c))
 
-        if !c.Response().Committed </span><span class="cov8" title="12">{
-                if writeErr := writeErrorResponse(c, resp); writeErr != nil </span><span class="cov1" title="1">{
+        if !c.Response().Committed </span><span class="cov8" title="1">{
+                if writeErr := writeErrorResponse(c, resp); writeErr != nil </span><span class="cov8" title="1">{
                         reqIn := server.BuildHTTPRequestLogInput(c, logging.EventTypeError)
                         writeErrFields := []*logging.Field{logging.String(logging.InternalErrorKey, writeErr.Error())}
                         fields := append(lf.BuildHTTPRequestFields(reqIn), writeErrFields...)
@@ -5456,18 +5447,18 @@ func handleHTTPError(c echo.Context, logger logging.Logger, lf logging.LogFieldB
                         if !c.Response().Committed </span><span class="cov0" title="0">{
                                 c.Response().WriteHeader(http.StatusInternalServerError)
                         }</span>
-                        <span class="cov1" title="1">return</span>
+                        <span class="cov8" title="1">return</span>
                 }
         }
 
         // リカバリ済みのパニックは middleware.recover が既にログ済みのため、二重ログを抑止する（500 応答は返す）。
-        <span class="cov7" title="11">if recovered, _ := ctxhelper.GetRecoveredFromEcho(c); !recovered </span><span class="cov7" title="10">{
+        <span class="cov8" title="1">if recovered, _ := ctxhelper.GetRecoveredFromEcho(c); !recovered </span><span class="cov8" title="1">{
                 logHTTPError(c, logger, lf, obsCfg, resp)
         }</span>
 }
 
 // writeErrorResponse は、エラーレスポンスをクライアントに書き込みます。
-func writeErrorResponse(c echo.Context, resp *response.HTTPErrorResponse) error <span class="cov8" title="13">{
+func writeErrorResponse(c echo.Context, resp *response.HTTPErrorResponse) error <span class="cov8" title="1">{
         return c.JSON(resp.HTTPStatus, resp.ErrorResponse)
 }</span>
 
@@ -5476,35 +5467,35 @@ func writeErrorResponse(c echo.Context, resp *response.HTTPErrorResponse) error 
 func normalizeHTTPError(
         err error,
         requestID string,
-) *response.HTTPErrorResponse <span class="cov10" title="23">{
+) *response.HTTPErrorResponse <span class="cov8" title="1">{
         var he *response.HTTPErrorResponse
-        if xerrors.As(err, &amp;he) </span><span class="cov2" title="2">{
+        if xerrors.As(err, &amp;he) </span><span class="cov8" title="1">{
                 // ステータスがエラー域外(400〜599 外)の不正な HTTPErrorResponse は、Internal を真とみなして 500 系へ矯正する。
-                if !isErrorStatus(he.HTTPStatus) </span><span class="cov1" title="1">{
+                if !isErrorStatus(he.HTTPStatus) </span><span class="cov8" title="1">{
                         res := response.NewHTTPErrorFromAppError(he.Internal)
-                        if he.Details != nil </span><span class="cov1" title="1">{
+                        if he.Details != nil </span><span class="cov8" title="1">{
                                 res.Details = he.Details
                         }</span>
-                        <span class="cov1" title="1">res.RequestId = requestID
+                        <span class="cov8" title="1">res.RequestId = requestID
                         return res</span>
                 }
-                <span class="cov1" title="1">he.RequestId = requestID
+                <span class="cov8" title="1">he.RequestId = requestID
                 return he</span>
         }
 
-        <span class="cov9" title="21">var ehe *echo.HTTPError
-        if xerrors.As(err, &amp;ehe) </span><span class="cov6" title="6">{
-                if res := normalizeOpenAPIError(ehe); res != nil </span><span class="cov4" title="3">{
+        <span class="cov8" title="1">var ehe *echo.HTTPError
+        if xerrors.As(err, &amp;ehe) </span><span class="cov8" title="1">{
+                if res := normalizeOpenAPIError(ehe); res != nil </span><span class="cov8" title="1">{
                         res.RequestId = requestID
                         return res
                 }</span>
-                <span class="cov4" title="3">if res := normalizeEchoHTTPError(ehe); res != nil </span><span class="cov2" title="2">{
+                <span class="cov8" title="1">if res := normalizeEchoHTTPError(ehe); res != nil </span><span class="cov8" title="1">{
                         res.RequestId = requestID
                         return res
                 }</span>
         }
 
-        <span class="cov8" title="16">res := response.NewHTTPErrorFromAppError(err)
+        <span class="cov8" title="1">res := response.NewHTTPErrorFromAppError(err)
         res.RequestId = requestID
         return res</span>
 }
@@ -5514,7 +5505,7 @@ func httpErrorField(
         c echo.Context,
         lf logging.LogFieldBuilder,
         he *response.HTTPErrorResponse,
-) []*logging.Field <span class="cov8" title="14">{
+) []*logging.Field <span class="cov8" title="1">{
         fields := []*logging.Field{
                 logging.Int(logging.StatusKey, he.HTTPStatus),
                 logging.String(logging.ErrorCodeKey, he.Code),
@@ -5522,17 +5513,17 @@ func httpErrorField(
                 logging.String(logging.RequestIDKey, he.RequestId),
         }
         fields = append(fields, lf.BuildHTTPRequestFields(server.BuildHTTPRequestLogInput(c, logging.EventTypeError))...)
-        if he.Details != nil </span><span class="cov1" title="1">{
+        if he.Details != nil </span><span class="cov8" title="1">{
                 fields = append(fields, logging.Strings(logging.ErrorDetailsKey, *he.Details))
         }</span>
-        <span class="cov8" title="14">if he.Internal != nil </span><span class="cov7" title="11">{
+        <span class="cov8" title="1">if he.Internal != nil </span><span class="cov8" title="1">{
                 additionalFields := []*logging.Field{
                         logging.String(logging.InternalErrorKey, he.Internal.Error()),
                         logging.Stacktrace(logging.InternalStackTraceKey, he.Internal),
                 }
                 fields = append(fields, additionalFields...)
         }</span>
-        <span class="cov8" title="14">return fields</span>
+        <span class="cov8" title="1">return fields</span>
 }
 
 // logHTTPError は、HTTPエラーをログに記録します。
@@ -5542,15 +5533,15 @@ func logHTTPError(
         lf logging.LogFieldBuilder,
         obsCfg *config.ObservabilityConfig,
         he *response.HTTPErrorResponse,
-) <span class="cov8" title="13">{
-        if !obsCfg.TargetStatusCodeSet()[he.HTTPStatus] </span><span class="cov1" title="1">{
+) <span class="cov8" title="1">{
+        if !obsCfg.TargetStatusCodeSet()[he.HTTPStatus] </span><span class="cov8" title="1">{
                 return
         }</span>
-        <span class="cov8" title="12">fields := httpErrorField(c, lf, he)
+        <span class="cov8" title="1">fields := httpErrorField(c, lf, he)
         switch </span>{
-        case he.HTTPStatus &gt;= errorLevelBoundHTTPStatus:<span class="cov7" title="9">
+        case he.HTTPStatus &gt;= errorLevelBoundHTTPStatus:<span class="cov8" title="1">
                 logger.Error("errorhandler.server_error", fields...)</span>
-        default:<span class="cov4" title="3">
+        default:<span class="cov8" title="1">
                 logger.Warn("errorhandler.client_error", fields...)</span>
         }
 }
@@ -5558,7 +5549,7 @@ func logHTTPError(
 // isErrorStatus は、HTTPステータスコードがエラー範囲（400〜599）にあるかをチェックします。
 func isErrorStatus(
         s int,
-) bool <span class="cov8" title="12">{
+) bool <span class="cov8" title="1">{
         return lowerBoundHTTPStatus &lt;= s &amp;&amp; s &lt; upperBoundHTTPStatus
 }</span>
 </pre>
@@ -5575,7 +5566,7 @@ import (
 )
 
 // normalizeOpenAPIError は、OpenAPI関連のエラーを正規化し、エラーレスポンスを生成します。
-func normalizeOpenAPIError(err error, details ...string) *response.HTTPErrorResponse <span class="cov10" title="12">{
+func normalizeOpenAPIError(err error, details ...string) *response.HTTPErrorResponse <span class="cov8" title="1">{
         var (
                 reqErr  *openapi3filter.RequestError
                 secErr  *openapi3filter.SecurityRequirementsError
@@ -5585,17 +5576,17 @@ func normalizeOpenAPIError(err error, details ...string) *response.HTTPErrorResp
         )
 
         switch </span>{
-        case xerrors.As(err, &amp;reqErr):<span class="cov4" title="3">
+        case xerrors.As(err, &amp;reqErr):<span class="cov8" title="1">
                 resErr = response.NewHTTPErrorFromStatus(http.StatusBadRequest, err, details...)</span>
-        case xerrors.As(err, &amp;secErr):<span class="cov3" title="2">
+        case xerrors.As(err, &amp;secErr):<span class="cov8" title="1">
                 resErr = response.NewHTTPErrorFromStatus(http.StatusUnauthorized, err, details...)</span>
-        case xerrors.As(err, &amp;respErr):<span class="cov3" title="2">
+        case xerrors.As(err, &amp;respErr):<span class="cov8" title="1">
                 resErr = response.NewHTTPErrorFromStatus(http.StatusInternalServerError, err, details...)</span>
-        default:<span class="cov6" title="5">
+        default:<span class="cov8" title="1">
                 return nil</span>
         }
 
-        <span class="cov8" title="7">return resErr</span>
+        <span class="cov8" title="1">return resErr</span>
 }
 </pre>
 		
@@ -5610,28 +5601,28 @@ import (
 
 // Middleware は、Content-Type が未設定または text/html の場合に
 // application/json へ強制するミドルウェアを返します。
-func Middleware() echo.MiddlewareFunc <span class="cov7" title="7">{
-        return func(next echo.HandlerFunc) echo.HandlerFunc </span><span class="cov5" title="4">{
-                return func(c echo.Context) error </span><span class="cov5" title="4">{
+func Middleware() echo.MiddlewareFunc <span class="cov8" title="1">{
+        return func(next echo.HandlerFunc) echo.HandlerFunc </span><span class="cov8" title="1">{
+                return func(c echo.Context) error </span><span class="cov8" title="1">{
                         // next 後では commit 済みで反映されないため、WriteHeader 直前(Before)に補正する。
-                        c.Response().Before(func() </span><span class="cov5" title="4">{
+                        c.Response().Before(func() </span><span class="cov8" title="1">{
                                 ensureJSONContentType(c)
                         }</span>)
-                        <span class="cov5" title="4">return next(c)</span>
+                        <span class="cov8" title="1">return next(c)</span>
                 }
         }
 }
 
 // ensureJSONContentType は、Content-Type が未設定または text/html の場合に application/json へ強制します。
-func ensureJSONContentType(c echo.Context) <span class="cov7" title="7">{
+func ensureJSONContentType(c echo.Context) <span class="cov8" title="1">{
         h := c.Response().Header()
-        if shouldForceJSON(h.Get(echo.HeaderContentType)) </span><span class="cov5" title="4">{
+        if shouldForceJSON(h.Get(echo.HeaderContentType)) </span><span class="cov8" title="1">{
                 h.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
         }</span>
 }
 
 // shouldForceJSON は、Content-Type が未設定または text/html の場合に true を返します。
-func shouldForceJSON(ct string) bool <span class="cov10" title="13">{
+func shouldForceJSON(ct string) bool <span class="cov8" title="1">{
         return ct == "" || strings.HasPrefix(ct, echo.MIMETextHTML)
 }</span>
 </pre>
@@ -5662,9 +5653,9 @@ const maxKeyLength = 255
 type NextFunc func(ctx echo.Context, request any) (any, error)
 
 // Middleware は、冪等性入り口を StrictMiddleware の構造的シグネチャで返します。
-func Middleware() func(next NextFunc, operationID string) NextFunc <span class="cov5" title="14">{
-        return func(next NextFunc, operationID string) NextFunc </span><span class="cov4" title="12">{
-                return func(ec echo.Context, request any) (any, error) </span><span class="cov4" title="12">{
+func Middleware() func(next NextFunc, operationID string) NextFunc <span class="cov8" title="1">{
+        return func(next NextFunc, operationID string) NextFunc </span><span class="cov8" title="1">{
+                return func(ec echo.Context, request any) (any, error) </span><span class="cov8" title="1">{
                         return handle(ec, request, operationID, next)
                 }</span>
         }
@@ -5672,36 +5663,36 @@ func Middleware() func(next NextFunc, operationID string) NextFunc <span class="
 
 // StrictMiddleware は、Middleware() を oapi-codegen のパッケージ固有 StrictMiddlewareFunc 形へ
 // 適合させたアダプタを返します。
-func StrictMiddleware[H ~func(ec echo.Context, request any) (any, error)]() func(f H, operationID string) H <span class="cov4" title="7">{
+func StrictMiddleware[H ~func(ec echo.Context, request any) (any, error)]() func(f H, operationID string) H <span class="cov8" title="1">{
         core := Middleware()
-        return func(f H, operationID string) H </span><span class="cov3" title="5">{
+        return func(f H, operationID string) H </span><span class="cov8" title="1">{
                 return H(core(NextFunc(f), operationID))
         }</span>
 }
 
-func handle(ec echo.Context, request any, operationID string, next NextFunc) (any, error) <span class="cov4" title="12">{
+func handle(ec echo.Context, request any, operationID string, next NextFunc) (any, error) <span class="cov8" title="1">{
         r := ec.Request()
         key := strings.TrimSpace(r.Header.Get(headerName))
-        if key == "" </span><span class="cov3" title="6">{
+        if key == "" </span><span class="cov8" title="1">{
                 // ヘッダ無し = 非冪等（既存挙動のまま素通し）。
                 return next(ec, request)
         }</span>
-        <span class="cov3" title="6">if err := validateKey(key); err != nil </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if err := validateKey(key); err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
         // 認証プリンシパルが取れなければ冪等性は発動しない（スコープキーに Subject を使うため、認証済みリクエストのみ対象とする）。
-        <span class="cov3" title="4">authn, ok := ctxhelper.GetAuthn(r.Context())
-        if !ok </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">authn, ok := ctxhelper.GetAuthn(r.Context())
+        if !ok </span><span class="cov8" title="1">{
                 return next(ec, request)
         }</span>
 
-        <span class="cov2" title="3">fp, err := fingerprint(r.Method, r.URL.Path, request)
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">fp, err := fingerprint(r.Method, r.URL.Path, request)
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Join(apperror.ErrInternal, xerrors.Wrap(err, "failed to fingerprint idempotent request"))
         }</span>
 
-        <span class="cov2" title="2">reqCtx := idempotencyuc.WithRequest(r.Context(), idempotencyuc.Request{
+        <span class="cov8" title="1">reqCtx := idempotencyuc.WithRequest(r.Context(), idempotencyuc.Request{
                 Scope:       authn.Subject(),
                 Key:         key,
                 Fingerprint: fp,
@@ -5715,26 +5706,26 @@ func handle(ec echo.Context, request any, operationID string, next NextFunc) (an
 }
 
 // validateKey は、Idempotency-Key の健全性を検証します（非空 / ≤255 / 印字可能 ASCII）。違反は 400。
-func validateKey(key string) error <span class="cov5" title="13">{
-        if len(key) &gt; maxKeyLength </span><span class="cov2" title="2">{
+func validateKey(key string) error <span class="cov8" title="1">{
+        if len(key) &gt; maxKeyLength </span><span class="cov8" title="1">{
                 return xerrors.Wrap(apperror.ErrInvalidArgument, "Idempotency-Key must be 255 characters or fewer")
         }</span>
-        <span class="cov4" title="11">for _, c := range []byte(key) </span><span class="cov10" title="314">{
-                if c &lt; 0x21 || c &gt; 0x7E </span><span class="cov3" title="5">{
+        <span class="cov8" title="1">for _, c := range []byte(key) </span><span class="cov8" title="1">{
+                if c &lt; 0x21 || c &gt; 0x7E </span><span class="cov8" title="1">{
                         return xerrors.Wrap(apperror.ErrInvalidArgument, "Idempotency-Key must contain only printable ASCII characters")
                 }</span>
         }
-        <span class="cov3" title="6">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // fingerprint は、method + path + typed request の決定的 marshal を SHA-256 した指紋を返します。
 // request の marshal に失敗した場合は弱い指紋を作らずエラーを返します（fail-closed）。
-func fingerprint(method, path string, request any) ([]byte, error) <span class="cov4" title="9">{
+func fingerprint(method, path string, request any) ([]byte, error) <span class="cov8" title="1">{
         b, err := json.Marshal(request)
-        if err != nil </span><span class="cov2" title="2">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov4" title="7">h := sha256.New()
+        <span class="cov8" title="1">h := sha256.New()
         h.Write([]byte(method))
         h.Write([]byte{'\n'})
         h.Write([]byte(path))
@@ -5754,18 +5745,18 @@ import (
 )
 
 // New は、アプリケーション設定とセキュリティ設定をもとに Echo の IP アドレス抽出ポリシーを設定します。
-func New(e *echo.Echo, appCfg *config.ApplicationConfig, secCfg *config.SecurityConfig) <span class="cov7" title="4">{
+func New(e *echo.Echo, appCfg *config.ApplicationConfig, secCfg *config.SecurityConfig) <span class="cov8" title="1">{
         e.IPExtractor = NewIPExtractor(appCfg, secCfg)
 }</span>
 
 // NewIPExtractor は、EchoでクライアントのIPアドレスを抽出するためのインスタンスを生成します。
 //
 // 開発環境では直接抽出し、それ以外（本番・未知環境）ではX-Forwarded-Forヘッダーから抽出します。
-func NewIPExtractor(appCfg *config.ApplicationConfig, secCfg *config.SecurityConfig) echo.IPExtractor <span class="cov10" title="7">{
-        if appCfg.IsDevelopmentMode() </span><span class="cov7" title="4">{
+func NewIPExtractor(appCfg *config.ApplicationConfig, secCfg *config.SecurityConfig) echo.IPExtractor <span class="cov8" title="1">{
+        if appCfg.IsDevelopmentMode() </span><span class="cov8" title="1">{
                 return echo.ExtractIPDirect()
         }</span>
-        <span class="cov6" title="3">return echo.ExtractIPFromXFFHeader(
+        <span class="cov8" title="1">return echo.ExtractIPFromXFFHeader(
                 echo.TrustIPRange(secCfg.CIDR()),
         )</span>
 }
@@ -5794,19 +5785,19 @@ type requestLog struct {
 
 // Middleware は、Echoフレームワークのミドルウェアで、リクエストのログを出力します。
 // ただし /health, /metrics 等の運用系エンドポイントはログ出力をスキップします。
-func Middleware(logger logging.Logger, lf logging.LogFieldBuilder) echo.MiddlewareFunc <span class="cov7" title="4">{
+func Middleware(logger logging.Logger, lf logging.LogFieldBuilder) echo.MiddlewareFunc <span class="cov8" title="1">{
         return loggingMiddleware(logger, lf)
 }</span>
 
 // loggingMiddleware は、リクエストのログを出力するミドルウェアを返します。
-func loggingMiddleware(logger logging.Logger, lf logging.LogFieldBuilder) echo.MiddlewareFunc <span class="cov10" title="7">{
-        return func(next echo.HandlerFunc) echo.HandlerFunc </span><span class="cov6" title="3">{
-                return func(c echo.Context) error </span><span class="cov6" title="3">{
-                        if ops.IsOpsPath(c.Request().URL.Path) </span><span class="cov1" title="1">{
+func loggingMiddleware(logger logging.Logger, lf logging.LogFieldBuilder) echo.MiddlewareFunc <span class="cov8" title="1">{
+        return func(next echo.HandlerFunc) echo.HandlerFunc </span><span class="cov8" title="1">{
+                return func(c echo.Context) error </span><span class="cov8" title="1">{
+                        if ops.IsOpsPath(c.Request().URL.Path) </span><span class="cov8" title="1">{
                                 return next(c)
                         }</span>
 
-                        <span class="cov4" title="2">start := time.Now()
+                        <span class="cov8" title="1">start := time.Now()
 
                         l := requestLog{
                                 c:        c,
@@ -5817,25 +5808,25 @@ func loggingMiddleware(logger logging.Logger, lf logging.LogFieldBuilder) echo.M
                         reqFields := l.buildRequestLogFields(start)
                         logger.Named("http.request").Info("request received", reqFields...)
 
-                        c.Response().After(func() </span><span class="cov4" title="2">{
+                        c.Response().After(func() </span><span class="cov8" title="1">{
                                 latency := time.Since(start)
 
                                 fields := l.buildResponseLogFields(latency)
                                 resLogger := logger.Named("http.response")
-                                if c.Response().Status &gt;= MinStatusError </span><span class="cov1" title="1">{
+                                if c.Response().Status &gt;= MinStatusError </span><span class="cov8" title="1">{
                                         resLogger.Error("request handled", fields...)
-                                }</span> else<span class="cov1" title="1"> {
+                                }</span> else<span class="cov8" title="1"> {
                                         resLogger.Info("request handled", fields...)
                                 }</span>
                         })
 
-                        <span class="cov4" title="2">return next(c)</span>
+                        <span class="cov8" title="1">return next(c)</span>
                 }
         }
 }
 
 // buildRequestLogFields は、リクエストの情報を含むFieldのスライスを生成します。
-func (l requestLog) buildRequestLogFields(start time.Time) []*logging.Field <span class="cov6" title="3">{
+func (l requestLog) buildRequestLogFields(start time.Time) []*logging.Field <span class="cov8" title="1">{
         req := l.c.Request()
         reqIn := logging.HTTPRequestLogInput{
                 EventType:     logging.EventTypeStart,
@@ -5860,7 +5851,7 @@ func (l requestLog) buildRequestLogFields(start time.Time) []*logging.Field <spa
 }</span>
 
 // buildResponseLogFields は、レスポンスの情報を含むFieldのスライスを生成します。
-func (l requestLog) buildResponseLogFields(latency time.Duration) []*logging.Field <span class="cov7" title="4">{
+func (l requestLog) buildResponseLogFields(latency time.Duration) []*logging.Field <span class="cov8" title="1">{
         req := l.c.Request()
         res := l.c.Response()
         resIn := logging.HTTPResponseLogInput{
@@ -5900,24 +5891,24 @@ const prefixBearer = "Bearer "
 func NewAuthenticator(
         authCfg *config.AuthConfig,
         authenticator authbd.Authenticator,
-) openapi3filter.AuthenticationFunc <span class="cov6" title="6">{
-        return func(ctx context.Context, input *openapi3filter.AuthenticationInput) error </span><span class="cov6" title="5">{
+) openapi3filter.AuthenticationFunc <span class="cov8" title="1">{
+        return func(ctx context.Context, input *openapi3filter.AuthenticationInput) error </span><span class="cov8" title="1">{
                 req := input.RequestValidationInput.Request
 
                 // エラー変換は authExtractor に一本化。
                 authn, err := authExtractor(ctx, req, authCfg, authenticator)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
-                <span class="cov5" title="4">if authn == nil </span><span class="cov3" title="2">{
+                <span class="cov8" title="1">if authn == nil </span><span class="cov8" title="1">{
                         return ErrUnauthorizedTokenNotProvided
                 }</span>
 
                 //nolint:contextcheck // input が内包する request の context のスロットへ書き戻すため
-                <span class="cov3" title="2">if !ctxhelper.SetAuthn(req.Context(), *authn) </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">if !ctxhelper.SetAuthn(req.Context(), *authn) </span><span class="cov8" title="1">{
                         return ErrAuthnSlotNotFound
                 }</span>
-                <span class="cov1" title="1">return nil</span>
+                <span class="cov8" title="1">return nil</span>
         }
 }
 
@@ -5927,53 +5918,53 @@ func authExtractor(
         req *http.Request,
         authCfg *config.AuthConfig,
         authenticator authbd.Authenticator,
-) (*authbd.Authn, error) <span class="cov7" title="8">{
+) (*authbd.Authn, error) <span class="cov8" title="1">{
         token := extractToken(req, authCfg)
-        if token == "" </span><span class="cov3" title="2">{
+        if token == "" </span><span class="cov8" title="1">{
                 //nolint:nilnil // トークン未提供を表す。呼び出し側で authn==nil を判定し未提供エラーへ変換するため意図的にnil,nilを返す
                 return nil, nil
         }</span>
 
-        <span class="cov6" title="6">cred, err := authbd.NewCredential(token)
+        <span class="cov8" title="1">cred, err := authbd.NewCredential(token)
         if err != nil </span><span class="cov0" title="0">{
                 return nil, err
         }</span>
 
-        <span class="cov6" title="6">authn, err := authenticator.Authenticate(ctx, cred)
-        if err != nil </span><span class="cov3" title="2">{
+        <span class="cov8" title="1">authn, err := authenticator.Authenticate(ctx, cred)
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, ErrUnauthorizedInvalidToken
         }</span>
 
-        <span class="cov5" title="4">return authn, nil</span>
+        <span class="cov8" title="1">return authn, nil</span>
 }
 
 // extractToken は、認証トークンを抽出します。
-func extractToken(r *http.Request, authCfg *config.AuthConfig) string <span class="cov10" title="16">{
+func extractToken(r *http.Request, authCfg *config.AuthConfig) string <span class="cov8" title="1">{
         // extract from Cookie
-        if authCfg.CookieName() != "" </span><span class="cov10" title="16">{
-                if ck, err := r.Cookie(authCfg.CookieName()); err == nil &amp;&amp; ck != nil </span><span class="cov7" title="8">{
-                        if v := strings.TrimSpace(ck.Value); v != "" </span><span class="cov7" title="8">{
+        if authCfg.CookieName() != "" </span><span class="cov8" title="1">{
+                if ck, err := r.Cookie(authCfg.CookieName()); err == nil &amp;&amp; ck != nil </span><span class="cov8" title="1">{
+                        if v := strings.TrimSpace(ck.Value); v != "" </span><span class="cov8" title="1">{
                                 return v
                         }</span>
                 }
         }
 
         // extract from Header
-        <span class="cov7" title="8">if authCfg.HeaderName() == "" </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if authCfg.HeaderName() == "" </span><span class="cov8" title="1">{
                 return ""
         }</span>
 
-        <span class="cov7" title="7">raw := strings.TrimSpace(r.Header.Get(authCfg.HeaderName()))
-        if raw == "" </span><span class="cov4" title="3">{
+        <span class="cov8" title="1">raw := strings.TrimSpace(r.Header.Get(authCfg.HeaderName()))
+        if raw == "" </span><span class="cov8" title="1">{
                 return ""
         }</span>
-        <span class="cov5" title="4">if authCfg.AllowedHeaderBearer() &amp;&amp; strings.EqualFold(authCfg.HeaderName(), echo.HeaderAuthorization) </span><span class="cov3" title="2">{
-                if after, ok := strings.CutPrefix(raw, prefixBearer); ok </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if authCfg.AllowedHeaderBearer() &amp;&amp; strings.EqualFold(authCfg.HeaderName(), echo.HeaderAuthorization) </span><span class="cov8" title="1">{
+                if after, ok := strings.CutPrefix(raw, prefixBearer); ok </span><span class="cov8" title="1">{
                         return strings.TrimSpace(after)
                 }</span>
-                <span class="cov1" title="1">return ""</span>
+                <span class="cov8" title="1">return ""</span>
         }
-        <span class="cov3" title="2">return raw</span>
+        <span class="cov8" title="1">return raw</span>
 }
 </pre>
 		
@@ -5997,7 +5988,7 @@ func Middleware(
         spec *openapi3.T,
         skipper echomw.Skipper,
         authFunc openapi3filter.AuthenticationFunc,
-) echo.MiddlewareFunc <span class="cov10" title="4">{
+) echo.MiddlewareFunc <span class="cov8" title="1">{
         oapiValidator := oapimw.OapiRequestValidatorWithOptions(spec, &amp;oapimw.Options{
                 SilenceServersWarning: true,
                 Skipper:               skipper,
@@ -6006,8 +5997,8 @@ func Middleware(
                 },
         })
 
-        return func(next echo.HandlerFunc) echo.HandlerFunc </span><span class="cov1" title="1">{
-                return func(c echo.Context) error </span><span class="cov1" title="1">{
+        return func(next echo.HandlerFunc) echo.HandlerFunc </span><span class="cov8" title="1">{
+                return func(c echo.Context) error </span><span class="cov8" title="1">{
                         req := c.Request()
                         req = req.WithContext(ctxhelper.WithAuthn(req.Context()))
                         c.SetRequest(req)
@@ -6029,8 +6020,8 @@ import (
 )
 
 // New は、運用系エンドポイント（/health, /metrics 等）へのリクエストを OpenAPI バリデーションからスキップする Skipper 関数を返します。
-func New() echomw.Skipper <span class="cov10" title="3">{
-        return func(c echo.Context) bool </span><span class="cov6" title="2">{
+func New() echomw.Skipper <span class="cov8" title="1">{
+        return func(c echo.Context) bool </span><span class="cov8" title="1">{
                 return ops.IsOpsPath(c.Request().URL.Path)
         }</span>
 }
@@ -6048,7 +6039,7 @@ import (
 )
 
 // GetValidator は、OpenAPI仕様(spec)を返します。
-func GetValidator() (*openapi3.T, error) <span class="cov10" title="3">{
+func GetValidator() (*openapi3.T, error) <span class="cov8" title="1">{
         return gen.GetSwagger()
 }</span>
 </pre>
@@ -6062,13 +6053,13 @@ import (
 )
 
 // Middleware は、指定したサービス名で Echo 用の OTel ミドルウェアを返します。
-func Middleware(serviceName string) echo.MiddlewareFunc <span class="cov8" title="4">{
+func Middleware(serviceName string) echo.MiddlewareFunc <span class="cov8" title="1">{
         return otelecho.Middleware(serviceName)
 }</span>
 
 // PassthroughMiddleware は、リクエストを次のハンドラへそのまま渡す素通しミドルウェアを返します。
-func PassthroughMiddleware() echo.MiddlewareFunc <span class="cov10" title="5">{
-        return func(next echo.HandlerFunc) echo.HandlerFunc </span><span class="cov4" title="2">{
+func PassthroughMiddleware() echo.MiddlewareFunc <span class="cov8" title="1">{
+        return func(next echo.HandlerFunc) echo.HandlerFunc </span><span class="cov8" title="1">{
                 return next
         }</span>
 }
@@ -6080,7 +6071,7 @@ package ops
 import "strings"
 
 // IsOpsPath は /metrics, /health, /healthz, /ready, /version のいずれかを運用系エンドポイントとして判定し true を返します。末尾スラッシュは無視されます。
-func IsOpsPath(path string) bool <span class="cov10" title="24">{
+func IsOpsPath(path string) bool <span class="cov8" title="1">{
         path = strings.TrimRight(path, "/")
 
         switch path </span>{
@@ -6088,9 +6079,9 @@ func IsOpsPath(path string) bool <span class="cov10" title="24">{
                 "/health",
                 "/healthz",
                 "/ready",
-                "/version":<span class="cov8" title="13">
+                "/version":<span class="cov8" title="1">
                 return true</span>
-        default:<span class="cov7" title="11">
+        default:<span class="cov8" title="1">
                 return false</span>
         }
 }
@@ -6117,7 +6108,7 @@ const (
 )
 
 // Middleware は、Echoフレームワークのミドルウェアで、パニックからのリカバリを行います。
-func Middleware(z logging.Logger, lf logging.LogFieldBuilder, appCfg *config.ApplicationConfig) echo.MiddlewareFunc <span class="cov8" title="7">{
+func Middleware(z logging.Logger, lf logging.LogFieldBuilder, appCfg *config.ApplicationConfig) echo.MiddlewareFunc <span class="cov8" title="1">{
         cnf := newRecoverConfig(z, appCfg)
         cnf.LogErrorFunc = newRecoverLogErrorFunc(z, lf)
 
@@ -6125,13 +6116,13 @@ func Middleware(z logging.Logger, lf logging.LogFieldBuilder, appCfg *config.App
 }</span>
 
 // newRecoverConfig は、環境設定に基づいてリカバリミドルウェアの設定を生成します。
-func newRecoverConfig(logger logging.Logger, appCfg *config.ApplicationConfig) middleware.RecoverConfig <span class="cov10" title="10">{
+func newRecoverConfig(logger logging.Logger, appCfg *config.ApplicationConfig) middleware.RecoverConfig <span class="cov8" title="1">{
         switch </span>{
-        case appCfg.IsDevelopmentMode():<span class="cov9" title="8">
+        case appCfg.IsDevelopmentMode():<span class="cov8" title="1">
                 return developmentConfig()</span>
-        case appCfg.IsProductionMode():<span class="cov1" title="1">
+        case appCfg.IsProductionMode():<span class="cov8" title="1">
                 return productionConfig()</span>
-        default:<span class="cov1" title="1">
+        default:<span class="cov8" title="1">
                 logger.Named("middleware.recover").Warn(
                         "Unknown environment, using production config for recover middleware",
                         logging.String("env", appCfg.Mode()),
@@ -6141,8 +6132,8 @@ func newRecoverConfig(logger logging.Logger, appCfg *config.ApplicationConfig) m
 }
 
 // newRecoverLogErrorFunc は、リカバリミドルウェアのログ出力関数を生成します。
-func newRecoverLogErrorFunc(logger logging.Logger, lf logging.LogFieldBuilder) func(c echo.Context, err error, stack []byte) error <span class="cov10" title="10">{
-        return func(c echo.Context, err error, stack []byte) error </span><span class="cov7" title="5">{
+func newRecoverLogErrorFunc(logger logging.Logger, lf logging.LogFieldBuilder) func(c echo.Context, err error, stack []byte) error <span class="cov8" title="1">{
+        return func(c echo.Context, err error, stack []byte) error </span><span class="cov8" title="1">{
                 reqIn := server.BuildHTTPRequestLogInput(c, logging.EventTypePanic)
                 recoverFields := []*logging.Field{
                         logging.String(logging.InternalErrorKey, err.Error()),
@@ -6157,7 +6148,7 @@ func newRecoverLogErrorFunc(logger logging.Logger, lf logging.LogFieldBuilder) f
 }
 
 // developmentConfig は、開発環境用のリカバリミドルウェアの設定を返します。
-func developmentConfig() middleware.RecoverConfig <span class="cov10" title="10">{
+func developmentConfig() middleware.RecoverConfig <span class="cov8" title="1">{
         return middleware.RecoverConfig{
                 StackSize:         developmentStackSize,
                 DisableStackAll:   false,
@@ -6166,7 +6157,7 @@ func developmentConfig() middleware.RecoverConfig <span class="cov10" title="10"
 }</span>
 
 // productionConfig は、本番環境用のリカバリミドルウェアの設定を返します。
-func productionConfig() middleware.RecoverConfig <span class="cov8" title="6">{
+func productionConfig() middleware.RecoverConfig <span class="cov8" title="1">{
         return middleware.RecoverConfig{
                 StackSize: productionStackSize,
                 // DisableStackAll=true で他 goroutine は除外しつつ、当該 goroutine のスタックは捕捉する
@@ -6202,25 +6193,25 @@ import (
 //
 // これは status を確定後に安全に観測するための After フック採用とのトレードオフであり、
 // 現時点では仕様として許容する。
-func Middleware(rec Recorder) echo.MiddlewareFunc <span class="cov10" title="14">{
-        return func(next echo.HandlerFunc) echo.HandlerFunc </span><span class="cov9" title="11">{
-                return func(c echo.Context) error </span><span class="cov9" title="11">{
-                        if ops.IsOpsPath(c.Request().URL.Path) </span><span class="cov6" title="5">{
+func Middleware(rec Recorder) echo.MiddlewareFunc <span class="cov8" title="1">{
+        return func(next echo.HandlerFunc) echo.HandlerFunc </span><span class="cov8" title="1">{
+                return func(c echo.Context) error </span><span class="cov8" title="1">{
+                        if ops.IsOpsPath(c.Request().URL.Path) </span><span class="cov8" title="1">{
                                 return next(c)
                         }</span>
 
-                        <span class="cov7" title="6">start := time.Now()
+                        <span class="cov8" title="1">start := time.Now()
                         method := c.Request().Method
 
                         var once sync.Once
-                        c.Response().After(func() </span><span class="cov7" title="7">{
-                                once.Do(func() </span><span class="cov6" title="5">{
+                        c.Response().After(func() </span><span class="cov8" title="1">{
+                                once.Do(func() </span><span class="cov8" title="1">{
                                         status := normalizeStatus(c.Response().Status)
                                         rec.Observe(method, routeOf(c), status, statusClass(status), time.Since(start))
                                 }</span>)
                         })
 
-                        <span class="cov7" title="6">return next(c)</span>
+                        <span class="cov8" title="1">return next(c)</span>
                 }
         }
 }
@@ -6266,7 +6257,7 @@ type PrometheusRecorder struct {
 
 // NewPrometheusRecorder は、PrometheusRecorder を初期化して返します。
 // 副作用は持たず、registry への登録は RegisterRecorder で別途行います。
-func NewPrometheusRecorder() *PrometheusRecorder <span class="cov10" title="13">{
+func NewPrometheusRecorder() *PrometheusRecorder <span class="cov8" title="1">{
         return &amp;PrometheusRecorder{
                 requests: prometheus.NewCounterVec(prometheus.CounterOpts{
                         Namespace: namespace,
@@ -6285,7 +6276,7 @@ func NewPrometheusRecorder() *PrometheusRecorder <span class="cov10" title="13">
 }</span>
 
 // Observe は、request count を increment し、duration を histogram に記録します。
-func (r *PrometheusRecorder) Observe(method, route string, statusCode int, statusClass string, duration time.Duration) <span class="cov4" title="3">{
+func (r *PrometheusRecorder) Observe(method, route string, statusCode int, statusClass string, duration time.Duration) <span class="cov8" title="1">{
         labels := prometheus.Labels{
                 "method":       method,
                 "route":        route,
@@ -6297,34 +6288,34 @@ func (r *PrometheusRecorder) Observe(method, route string, statusCode int, statu
 }</span>
 
 // Describe は、PrometheusRecorder のメトリクスの説明を Prometheus に提供します。
-func (r *PrometheusRecorder) Describe(ch chan&lt;- *prometheus.Desc) <span class="cov7" title="7">{
+func (r *PrometheusRecorder) Describe(ch chan&lt;- *prometheus.Desc) <span class="cov8" title="1">{
         r.requests.Describe(ch)
         r.duration.Describe(ch)
 }</span>
 
 // Collect は、PrometheusRecorder のメトリクスを収集して Prometheus に提供します。
-func (r *PrometheusRecorder) Collect(ch chan&lt;- prometheus.Metric) <span class="cov3" title="2">{
+func (r *PrometheusRecorder) Collect(ch chan&lt;- prometheus.Metric) <span class="cov8" title="1">{
         r.requests.Collect(ch)
         r.duration.Collect(ch)
 }</span>
 
 // RegisterRecorder は、PrometheusRecorder を指定レジストリに登録します。
 // 既に登録済みの場合はエラーを返さず無視します。
-func RegisterRecorder(reg prometheus.Registerer, r *PrometheusRecorder) error <span class="cov6" title="5">{
+func RegisterRecorder(reg prometheus.Registerer, r *PrometheusRecorder) error <span class="cov8" title="1">{
         return ignoreAlreadyRegistered(reg.Register(r))
 }</span>
 
 // ignoreAlreadyRegistered は、AlreadyRegisteredError を無視し、それ以外のエラーはそのまま返します。
-func ignoreAlreadyRegistered(err error) error <span class="cov8" title="8">{
-        if err == nil </span><span class="cov6" title="5">{
+func ignoreAlreadyRegistered(err error) error <span class="cov8" title="1">{
+        if err == nil </span><span class="cov8" title="1">{
                 return nil
         }</span>
 
-        <span class="cov4" title="3">var alreadyRegisteredErr prometheus.AlreadyRegisteredError
-        if xerrors.As(err, &amp;alreadyRegisteredErr) </span><span class="cov3" title="2">{
+        <span class="cov8" title="1">var alreadyRegisteredErr prometheus.AlreadyRegisteredError
+        if xerrors.As(err, &amp;alreadyRegisteredErr) </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov1" title="1">return err</span>
+        <span class="cov8" title="1">return err</span>
 }
 </pre>
 		
@@ -6337,12 +6328,12 @@ const routeUnknown = "unknown"
 
 // routeOf は、raw path / query を含まない Echo の route pattern（例: /users/:id）を返します。
 // 取得できない場合は unknown に丸めます。
-func routeOf(c echo.Context) string <span class="cov10" title="7">{
+func routeOf(c echo.Context) string <span class="cov8" title="1">{
         route := c.Path()
-        if route == "" </span><span class="cov4" title="2">{
+        if route == "" </span><span class="cov8" title="1">{
                 return routeUnknown
         }</span>
-        <span class="cov8" title="5">return route</span>
+        <span class="cov8" title="1">return route</span>
 }
 </pre>
 		
@@ -6361,39 +6352,39 @@ const statusCodeUnknown = "unknown"
 
 // normalizeStatus は、未確定（0）の status code を 500 に補正します。
 // error handler / recovery 後でも status が確定しないケースのフォールバックです。
-func normalizeStatus(code int) int <span class="cov7" title="7">{
-        if code == 0 </span><span class="cov1" title="1">{
+func normalizeStatus(code int) int <span class="cov8" title="1">{
+        if code == 0 </span><span class="cov8" title="1">{
                 return http.StatusInternalServerError
         }</span>
-        <span class="cov6" title="6">return code</span>
+        <span class="cov8" title="1">return code</span>
 }
 
 // statusClass は、status code を 1xx〜5xx の固定 enum に分類します。
 // 範囲外の値は unknown に丸めます。
-func statusClass(code int) string <span class="cov10" title="18">{
+func statusClass(code int) string <span class="cov8" title="1">{
         switch </span>{
-        case code &gt;= 100 &amp;&amp; code &lt; 200:<span class="cov3" title="2">
+        case code &gt;= 100 &amp;&amp; code &lt; 200:<span class="cov8" title="1">
                 return "1xx"</span>
-        case code &gt;= 200 &amp;&amp; code &lt; 300:<span class="cov6" title="5">
+        case code &gt;= 200 &amp;&amp; code &lt; 300:<span class="cov8" title="1">
                 return "2xx"</span>
-        case code &gt;= 300 &amp;&amp; code &lt; 400:<span class="cov3" title="2">
+        case code &gt;= 300 &amp;&amp; code &lt; 400:<span class="cov8" title="1">
                 return "3xx"</span>
-        case code &gt;= 400 &amp;&amp; code &lt; 500:<span class="cov5" title="4">
+        case code &gt;= 400 &amp;&amp; code &lt; 500:<span class="cov8" title="1">
                 return "4xx"</span>
-        case code &gt;= 500 &amp;&amp; code &lt; 600:<span class="cov4" title="3">
+        case code &gt;= 500 &amp;&amp; code &lt; 600:<span class="cov8" title="1">
                 return "5xx"</span>
-        default:<span class="cov3" title="2">
+        default:<span class="cov8" title="1">
                 return statusClassUnknown</span>
         }
 }
 
 // statusCodeLabel は、status code を label 用の文字列に変換します。
 // 0 以下は unknown に丸めます。
-func statusCodeLabel(code int) string <span class="cov6" title="5">{
-        if code &lt;= 0 </span><span class="cov1" title="1">{
+func statusCodeLabel(code int) string <span class="cov8" title="1">{
+        if code &lt;= 0 </span><span class="cov8" title="1">{
                 return statusCodeUnknown
         }</span>
-        <span class="cov5" title="4">return strconv.Itoa(code)</span>
+        <span class="cov8" title="1">return strconv.Itoa(code)</span>
 }
 </pre>
 		
@@ -6406,14 +6397,14 @@ import (
 )
 
 // Middleware は、リクエストIDを生成するミドルウェアを返します。
-func Middleware() echo.MiddlewareFunc <span class="cov5" title="4">{
+func Middleware() echo.MiddlewareFunc <span class="cov8" title="1">{
         return middleware.RequestID()
 }</span>
 
 // GetRequestIDFromResponse は、レスポンスヘッダ X-Request-ID からリクエストIDを取得します（Middleware が設定した値を読み出す）。
 func GetRequestIDFromResponse(
         c echo.Context,
-) string <span class="cov10" title="18">{
+) string <span class="cov8" title="1">{
         return c.Response().Header().Get(echo.HeaderXRequestID)
 }</span>
 </pre>
@@ -6429,12 +6420,12 @@ import (
 )
 
 // Middleware は、Content-Type-Options / Referrer-Policy / X-Frame-Options / HSTS を設定する Echo セキュリティミドルウェアを返します。各値は SecurityConfig から取得します。
-func Middleware(secCfg *config.SecurityConfig) echo.MiddlewareFunc <span class="cov8" title="4">{
+func Middleware(secCfg *config.SecurityConfig) echo.MiddlewareFunc <span class="cov8" title="1">{
         return middleware.SecureWithConfig(buildSecureConfig(secCfg))
 }</span>
 
 // buildSecureConfig は、セキュリティ設定を構築します。
-func buildSecureConfig(secCfg *config.SecurityConfig) middleware.SecureConfig <span class="cov10" title="5">{
+func buildSecureConfig(secCfg *config.SecurityConfig) middleware.SecureConfig <span class="cov8" title="1">{
         return middleware.SecureConfig{
                 ContentTypeNosniff:    secCfg.ContentTypeNosniff(),
                 ReferrerPolicy:        secCfg.ReferrerPolicy(),
@@ -6466,14 +6457,14 @@ import (
 // response writer のデータ競合を避けるため race-free な ContextTimeout を基底とします
 // （deprecated な Timeout は競合を抱える）。deadline 超過は apperror.ErrUnavailable(503) へ、
 // それ以外のエラーはそのまま伝播します。
-func Middleware(timeout time.Duration) echo.MiddlewareFunc <span class="cov10" title="6">{
+func Middleware(timeout time.Duration) echo.MiddlewareFunc <span class="cov8" title="1">{
         return middleware.ContextTimeoutWithConfig(middleware.ContextTimeoutConfig{
                 Timeout: timeout,
-                ErrorHandler: func(err error, _ echo.Context) error </span><span class="cov4" title="2">{
-                        if xerrors.Is(err, context.DeadlineExceeded) </span><span class="cov1" title="1">{
+                ErrorHandler: func(err error, _ echo.Context) error </span><span class="cov8" title="1">{
+                        if xerrors.Is(err, context.DeadlineExceeded) </span><span class="cov8" title="1">{
                                 return xerrors.Wrap(apperror.ErrUnavailable, "request deadline exceeded")
                         }</span>
-                        <span class="cov1" title="1">return err</span>
+                        <span class="cov8" title="1">return err</span>
                 },
         })
 }
@@ -6488,7 +6479,7 @@ import (
 )
 
 // Middleware は、URIの末尾のスラッシュを削除するミドルウェアを返します。
-func Middleware() echo.MiddlewareFunc <span class="cov10" title="5">{
+func Middleware() echo.MiddlewareFunc <span class="cov8" title="1">{
         return middleware.RemoveTrailingSlash()
 }</span>
 </pre>
@@ -6524,7 +6515,7 @@ func New(
         logging logging.Logger,
         tf observability.TracerFactory,
         gc idempotency.GCUsecase,
-) job.Job <span class="cov7" title="6">{
+) job.Job <span class="cov8" title="1">{
         return &amp;jobImpl{
                 logging: logging,
                 tracer:  tf.Controller(),
@@ -6533,26 +6524,26 @@ func New(
 }</span>
 
 // Name は、このジョブの名前を返します。
-func (j *jobImpl) Name() string <span class="cov7" title="6">{
+func (j *jobImpl) Name() string <span class="cov8" title="1">{
         return jobName
 }</span>
 
 // Execute は、失効した冪等性キーをバッチ削除します。--batch-size=N で 1 バッチの件数を指定できます。
-func (j *jobImpl) Execute(ctx context.Context, args []string) error <span class="cov6" title="4">{
+func (j *jobImpl) Execute(ctx context.Context, args []string) error <span class="cov8" title="1">{
         ctx, endSpan := j.tracer.Start(ctx)
         defer endSpan()
 
         batchSize, err := parseBatchSize(args)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov5" title="3">deleted, err := j.gc.SweepExpired(ctx, batchSize)
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">deleted, err := j.gc.SweepExpired(ctx, batchSize)
+        if err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov3" title="2">j.logging.Named(jobName).Info(
+        <span class="cov8" title="1">j.logging.Named(jobName).Info(
                 "Result: expired idempotency keys deleted",
                 logging.Int64(logging.JobResultKey, deleted),
         )
@@ -6560,25 +6551,25 @@ func (j *jobImpl) Execute(ctx context.Context, args []string) error <span class=
 }
 
 // parseBatchSize は、--batch-size=N フラグを解釈します。未指定なら 0（usecase 側で既定値）。
-func parseBatchSize(args []string) (int32, error) <span class="cov10" title="11">{
+func parseBatchSize(args []string) (int32, error) <span class="cov8" title="1">{
         var batchSize int32
         seen := false
-        for _, a := range args </span><span class="cov9" title="9">{
-                if !strings.HasPrefix(a, batchSizeFlagPrefix) </span><span class="cov3" title="2">{
+        for _, a := range args </span><span class="cov8" title="1">{
+                if !strings.HasPrefix(a, batchSizeFlagPrefix) </span><span class="cov8" title="1">{
                         return 0, xerrors.New("unknown flag: " + a)
                 }</span>
-                <span class="cov8" title="7">if seen </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">if seen </span><span class="cov8" title="1">{
                         return 0, xerrors.New("duplicate flag: " + batchSizeFlagPrefix)
                 }</span>
-                <span class="cov7" title="6">seen = true
+                <span class="cov8" title="1">seen = true
 
                 n, err := strconv.ParseInt(strings.TrimPrefix(a, batchSizeFlagPrefix), 10, 32)
-                if err != nil || n &lt;= 0 </span><span class="cov5" title="3">{
+                if err != nil || n &lt;= 0 </span><span class="cov8" title="1">{
                         return 0, xerrors.New("invalid batch size: " + a)
                 }</span>
-                <span class="cov5" title="3">batchSize = int32(n)</span>
+                <span class="cov8" title="1">batchSize = int32(n)</span>
         }
-        <span class="cov7" title="5">return batchSize, nil</span>
+        <span class="cov8" title="1">return batchSize, nil</span>
 }
 </pre>
 		
@@ -6613,7 +6604,7 @@ func New(
         logging logging.Logger,
         tf observability.TracerFactory,
         gc outbox.GCUsecase,
-) job.Job <span class="cov7" title="6">{
+) job.Job <span class="cov8" title="1">{
         return &amp;jobImpl{
                 logging: logging,
                 tracer:  tf.Controller(),
@@ -6622,26 +6613,26 @@ func New(
 }</span>
 
 // Name は、このジョブの名前を返します。
-func (j *jobImpl) Name() string <span class="cov7" title="6">{
+func (j *jobImpl) Name() string <span class="cov8" title="1">{
         return jobName
 }</span>
 
 // Execute は、retention を超えた published 行をバッチ削除します。--batch-size=N で 1 バッチの件数を指定できます。
-func (j *jobImpl) Execute(ctx context.Context, args []string) error <span class="cov6" title="4">{
+func (j *jobImpl) Execute(ctx context.Context, args []string) error <span class="cov8" title="1">{
         ctx, endSpan := j.tracer.Start(ctx)
         defer endSpan()
 
         batchSize, err := parseBatchSize(args)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov5" title="3">deleted, err := j.gc.SweepPublished(ctx, batchSize)
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">deleted, err := j.gc.SweepPublished(ctx, batchSize)
+        if err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov3" title="2">j.logging.Named(jobName).Info(
+        <span class="cov8" title="1">j.logging.Named(jobName).Info(
                 "Result: published outbox rows deleted",
                 logging.Int64(logging.JobResultKey, deleted),
         )
@@ -6649,25 +6640,25 @@ func (j *jobImpl) Execute(ctx context.Context, args []string) error <span class=
 }
 
 // parseBatchSize は、--batch-size=N フラグを解釈します。未指定なら 0（usecase 側で既定値）。
-func parseBatchSize(args []string) (int32, error) <span class="cov10" title="11">{
+func parseBatchSize(args []string) (int32, error) <span class="cov8" title="1">{
         var batchSize int32
         seen := false
-        for _, a := range args </span><span class="cov9" title="9">{
-                if !strings.HasPrefix(a, batchSizeFlagPrefix) </span><span class="cov3" title="2">{
+        for _, a := range args </span><span class="cov8" title="1">{
+                if !strings.HasPrefix(a, batchSizeFlagPrefix) </span><span class="cov8" title="1">{
                         return 0, xerrors.New("unknown flag: " + a)
                 }</span>
-                <span class="cov8" title="7">if seen </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">if seen </span><span class="cov8" title="1">{
                         return 0, xerrors.New("duplicate flag: " + batchSizeFlagPrefix)
                 }</span>
-                <span class="cov7" title="6">seen = true
+                <span class="cov8" title="1">seen = true
 
                 n, err := strconv.ParseInt(strings.TrimPrefix(a, batchSizeFlagPrefix), 10, 32)
-                if err != nil || n &lt;= 0 </span><span class="cov5" title="3">{
+                if err != nil || n &lt;= 0 </span><span class="cov8" title="1">{
                         return 0, xerrors.New("invalid batch size: " + a)
                 }</span>
-                <span class="cov5" title="3">batchSize = int32(n)</span>
+                <span class="cov8" title="1">batchSize = int32(n)</span>
         }
-        <span class="cov7" title="5">return batchSize, nil</span>
+        <span class="cov8" title="1">return batchSize, nil</span>
 }
 </pre>
 		
@@ -6696,34 +6687,34 @@ type runner struct {
 }
 
 // NewRunner は、Runner を生成します。jobs に同名のエントリが含まれる場合は ErrDuplicateJob を返します。
-func NewRunner(jobs []job.Job) (job.Runner, error) <span class="cov8" title="16">{
+func NewRunner(jobs []job.Job) (job.Runner, error) <span class="cov8" title="1">{
         m := make(map[string]job.Job, len(jobs))
-        for _, j := range jobs </span><span class="cov10" title="29">{
+        for _, j := range jobs </span><span class="cov8" title="1">{
                 name := j.Name()
-                if _, exists := m[name]; exists </span><span class="cov2" title="2">{
+                if _, exists := m[name]; exists </span><span class="cov8" title="1">{
                         return nil, xerrors.Wrap(ErrDuplicateJob, name)
                 }</span>
-                <span class="cov9" title="27">m[name] = j</span>
+                <span class="cov8" title="1">m[name] = j</span>
         }
-        <span class="cov8" title="14">return &amp;runner{registry: m}, nil</span>
+        <span class="cov8" title="1">return &amp;runner{registry: m}, nil</span>
 }
 
 // Run は、指定されたジョブを実行します。jobName が未登録の場合は ErrUnknownJob（利用可能名一覧付き）を返します。
-func (r *runner) Run(ctx context.Context, jobName string, args []string) error <span class="cov4" title="4">{
+func (r *runner) Run(ctx context.Context, jobName string, args []string) error <span class="cov8" title="1">{
         j, ok := r.registry[jobName]
-        if !ok </span><span class="cov2" title="2">{
+        if !ok </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrUnknownJob, fmt.Sprintf("%s (available: %v)", jobName, r.Names()))
         }</span>
-        <span class="cov2" title="2">return j.Execute(ctx, args)</span>
+        <span class="cov8" title="1">return j.Execute(ctx, args)</span>
 }
 
 // Names は、登録されているジョブの名前一覧を返します。
-func (r *runner) Names() []string <span class="cov6" title="8">{
+func (r *runner) Names() []string <span class="cov8" title="1">{
         out := make([]string, 0, len(r.registry))
-        for k := range r.registry </span><span class="cov7" title="11">{
+        for k := range r.registry </span><span class="cov8" title="1">{
                 out = append(out, k)
         }</span>
-        <span class="cov6" title="8">sort.Strings(out)
+        <span class="cov8" title="1">sort.Strings(out)
         return out</span>
 }
 </pre>
@@ -6745,12 +6736,12 @@ type state struct {
 }
 
 // NewState は、新しい State インスタンスを生成します。
-func NewState() job.State <span class="cov10" title="10">{
+func NewState() job.State <span class="cov8" title="1">{
         return &amp;state{}
 }</span>
 
 // Set は、ジョブの状態を設定します。
-func (s *state) Set(name string, args []string, done chan error) <span class="cov8" title="6">{
+func (s *state) Set(name string, args []string, done chan error) <span class="cov8" title="1">{
         s.mu.Lock()
         defer s.mu.Unlock()
         s.name = name
@@ -6759,7 +6750,7 @@ func (s *state) Set(name string, args []string, done chan error) <span class="co
 }</span>
 
 // Snapshot は、現在のジョブの状態をスナップショットとして取得します。
-func (s *state) Snapshot() (string, []string, chan error) <span class="cov8" title="7">{
+func (s *state) Snapshot() (string, []string, chan error) <span class="cov8" title="1">{
         s.mu.Lock()
         defer s.mu.Unlock()
         return s.name, s.args, s.done
@@ -6792,7 +6783,7 @@ func New(
         logging logging.Logger,
         tf observability.TracerFactory,
         usecase user.Usecase,
-) job.Job <span class="cov9" title="6">{
+) job.Job <span class="cov8" title="1">{
         return &amp;jobImpl{
                 logging: logging,
                 tracer:  tf.Controller(),
@@ -6801,42 +6792,42 @@ func New(
 }</span>
 
 // Name は、このジョブの名前を返します。
-func (u *jobImpl) Name() string <span class="cov10" title="7">{
+func (u *jobImpl) Name() string <span class="cov8" title="1">{
         return jobName
 }</span>
 
 // Execute は、ユーザ件数を集計してログに出力します。
 // --active-only / --inactive-only でカウント対象を絞り込めます。両フラグの併用はエラーです。
-func (u *jobImpl) Execute(ctx context.Context, args []string) error <span class="cov10" title="7">{
+func (u *jobImpl) Execute(ctx context.Context, args []string) error <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
         var active *bool
         filter := "all"
-        for _, a := range args </span><span class="cov10" title="7">{
+        for _, a := range args </span><span class="cov8" title="1">{
                 // 相反・重複するフィルタ指定は、後勝ちで黙殺せずエラーにする。
                 switch a </span>{
-                case "--active-only":<span class="cov7" title="4">
-                        if active != nil </span><span class="cov1" title="1">{
+                case "--active-only":<span class="cov8" title="1">
+                        if active != nil </span><span class="cov8" title="1">{
                                 return xerrors.New("conflicting filter flag: " + a)
                         }</span>
-                        <span class="cov6" title="3">active = new(true)
+                        <span class="cov8" title="1">active = new(true)
                         filter = "active"</span>
-                case "--inactive-only":<span class="cov4" title="2">
-                        if active != nil </span><span class="cov1" title="1">{
+                case "--inactive-only":<span class="cov8" title="1">
+                        if active != nil </span><span class="cov8" title="1">{
                                 return xerrors.New("conflicting filter flag: " + a)
                         }</span>
-                        <span class="cov1" title="1">active = new(false)
+                        <span class="cov8" title="1">active = new(false)
                         filter = "inactive"</span>
-                default:<span class="cov1" title="1">
+                default:<span class="cov8" title="1">
                         return xerrors.New("unknown flag: " + a)</span>
                 }
         }
-        <span class="cov7" title="4">count, err := u.usecase.CountUsers(ctx, active)
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">count, err := u.usecase.CountUsers(ctx, active)
+        if err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov6" title="3">u.logging.Named(jobName).Info(
+        <span class="cov8" title="1">u.logging.Named(jobName).Info(
                 "Result: total user count",
                 logging.Int64(logging.JobResultKey, count),
                 logging.String(logging.FilterKey, filter),
@@ -6887,7 +6878,7 @@ func NewEngine(
         log logging.Logger,
         tf observability.TracerFactory,
         set Settings,
-) *Engine <span class="cov9" title="13">{
+) *Engine <span class="cov8" title="1">{
         return &amp;Engine{
                 uc:      uc,
                 sleeper: sleeper,
@@ -6904,53 +6895,53 @@ func NewEngine(
 //     全件 publish 失敗の満杯バッチを待機ゼロで再 claim すると、下流停止時にホットループして即時 dead 化
 //     するため、進捗が無い満杯バッチは必ず待機へ落とします。
 //   - 待機は clock.Sleeper 経由で行い、ctx 完了で即座に抜けます。
-func (e *Engine) Run(ctx context.Context) error <span class="cov9" title="11">{
+func (e *Engine) Run(ctx context.Context) error <span class="cov8" title="1">{
         ctx, endSpan := e.tracer.Start(ctx)
         defer endSpan()
 
         log := e.logging.Named(relayLoggerName)
-        for </span><span class="cov10" title="14">{
-                if ctx.Err() != nil </span><span class="cov3" title="2">{
+        for </span><span class="cov8" title="1">{
+                if ctx.Err() != nil </span><span class="cov8" title="1">{
                         return nil
                 }</span>
 
-                <span class="cov9" title="12">res, err := e.uc.RelayBatch(ctx, e.set.BatchSize)
-                if err != nil </span><span class="cov5" title="4">{
-                        if ctx.Err() != nil </span><span class="cov3" title="2">{
+                <span class="cov8" title="1">res, err := e.uc.RelayBatch(ctx, e.set.BatchSize)
+                if err != nil </span><span class="cov8" title="1">{
+                        if ctx.Err() != nil </span><span class="cov8" title="1">{
                                 return nil
                         }</span>
-                        <span class="cov3" title="2">log.Error("outbox relay batch failed", logging.Error(logging.JobErrorKey, err))
-                        if e.waitDone(ctx, e.set.ErrorBackoff) </span><span class="cov1" title="1">{
+                        <span class="cov8" title="1">log.Error("outbox relay batch failed", logging.Error(logging.JobErrorKey, err))
+                        if e.waitDone(ctx, e.set.ErrorBackoff) </span><span class="cov8" title="1">{
                                 return nil
                         }</span>
-                        <span class="cov1" title="1">continue</span>
+                        <span class="cov8" title="1">continue</span>
                 }
 
                 // lag 記録はバッチ成功時のみ行う。エラー時は同一原因（DB 障害等）で二重にエラーログが出るのを避ける。
-                <span class="cov8" title="8">e.observeLag(ctx, log)
+                <span class="cov8" title="1">e.observeLag(ctx, log)
 
-                if res.Claimed &gt;= int(e.set.BatchSize) &amp;&amp; res.Published &gt; 0 </span><span class="cov1" title="1">{
+                if res.Claimed &gt;= int(e.set.BatchSize) &amp;&amp; res.Published &gt; 0 </span><span class="cov8" title="1">{
                         // 満杯かつ進捗あり。まだ pending が残る可能性が高いため待機せず次 poll を即実行する。
                         continue</span>
                 }
-                <span class="cov7" title="7">if e.waitDone(ctx, e.set.PollInterval) </span><span class="cov7" title="6">{
+                <span class="cov8" title="1">if e.waitDone(ctx, e.set.PollInterval) </span><span class="cov8" title="1">{
                         return nil
                 }</span>
         }
 }
 
 // waitDone は、d 待機します。ctx 完了で待機が中断された場合に true を返します。
-func (e *Engine) waitDone(ctx context.Context, d time.Duration) bool <span class="cov8" title="9">{
+func (e *Engine) waitDone(ctx context.Context, d time.Duration) bool <span class="cov8" title="1">{
         return e.sleeper.Sleep(ctx, d) != nil
 }</span>
 
 // observeLag は、outbox lag(SLI) をベストエフォートで記録します。
 // ctx 完了時は記録をスキップし、記録失敗はループを止めずログのみ行います。
-func (e *Engine) observeLag(ctx context.Context, log logging.Logger) <span class="cov8" title="8">{
-        if ctx.Err() != nil </span><span class="cov3" title="2">{
+func (e *Engine) observeLag(ctx context.Context, log logging.Logger) <span class="cov8" title="1">{
+        if ctx.Err() != nil </span><span class="cov8" title="1">{
                 return
         }</span>
-        <span class="cov7" title="6">if err := e.uc.RecordLag(ctx); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err := e.uc.RecordLag(ctx); err != nil </span><span class="cov8" title="1">{
                 log.Error("failed to record outbox lag", logging.Error(logging.JobErrorKey, err))
         }</span>
 }
@@ -6966,7 +6957,7 @@ import (
 )
 
 // NewAppServer は、サーバーインスタンスを作成します。
-func NewAppServer(srvCfg *config.ServerConfig) *echo.Echo <span class="cov10" title="9">{
+func NewAppServer(srvCfg *config.ServerConfig) *echo.Echo <span class="cov8" title="1">{
         e := echo.New()
         e.HideBanner = true
         e.HidePort = true
@@ -6991,7 +6982,7 @@ import (
 
 // BuildHTTPRequestLogInput は、Echo コンテキストから HTTP リクエストのログ入力を組み立てます（エラー/リカバリ経路の共通生成点）。
 // eventType には呼び出し経路に応じたイベント種別（logging.EventTypeError / EventTypePanic 等）を渡す。
-func BuildHTTPRequestLogInput(c echo.Context, eventType string) logging.HTTPRequestLogInput <span class="cov9" title="21">{
+func BuildHTTPRequestLogInput(c echo.Context, eventType string) logging.HTTPRequestLogInput <span class="cov8" title="1">{
         req := c.Request()
         traceCtx := observability.ExtractTraceContext(req.Context())
         return logging.HTTPRequestLogInput{
@@ -7015,16 +7006,16 @@ func BuildHTTPRequestLogInput(c echo.Context, eventType string) logging.HTTPRequ
 }</span>
 
 // ExtractPathParams は、Echoコンテキストからパスパラメータを抽出します。
-func ExtractPathParams(c echo.Context) map[string]string <span class="cov10" title="26">{
+func ExtractPathParams(c echo.Context) map[string]string <span class="cov8" title="1">{
         m := make(map[string]string, len(c.ParamNames()))
-        for _, name := range c.ParamNames() </span><span class="cov5" title="5">{
+        for _, name := range c.ParamNames() </span><span class="cov8" title="1">{
                 m[name] = c.Param(name)
         }</span>
-        <span class="cov10" title="26">return m</span>
+        <span class="cov8" title="1">return m</span>
 }
 
 // ExtractQueryParams は、Echoコンテキストからクエリパラメータを抽出します。
-func ExtractQueryParams(c echo.Context) map[string][]string <span class="cov10" title="26">{
+func ExtractQueryParams(c echo.Context) map[string][]string <span class="cov8" title="1">{
         // URL.Query() は呼び出し毎に新規 map を返すため、防御的コピーは不要。
         return c.Request().URL.Query()
 }</span>
@@ -7065,66 +7056,66 @@ type circuit struct {
 }
 
 // newCircuit は、サーキットブレーカを生成します。threshold が 0 以下なら常に Closed のままです。
-func newCircuit(threshold int, bo backoff.Exponential) *circuit <span class="cov6" title="31">{
+func newCircuit(threshold int, bo backoff.Exponential) *circuit <span class="cov8" title="1">{
         return &amp;circuit{threshold: threshold, backoff: bo}
 }</span>
 
 // phaseNow は、現在の状態を返します。
-func (c *circuit) phaseNow() circuitPhase <span class="cov10" title="386">{
+func (c *circuit) phaseNow() circuitPhase <span class="cov8" title="1">{
         c.mu.Lock()
         defer c.mu.Unlock()
         return c.phase
 }</span>
 
 // cooldown は、現在の Open エピソードの cooldown を返します。
-func (c *circuit) cooldown() time.Duration <span class="cov3" title="4">{
+func (c *circuit) cooldown() time.Duration <span class="cov8" title="1">{
         c.mu.Lock()
         defer c.mu.Unlock()
         return c.curCooldown
 }</span>
 
 // toHalfOpen は、Open から Half-open へ遷移します（cooldown 経過後に poll loop が呼ぶ）。
-func (c *circuit) toHalfOpen() <span class="cov2" title="2">{
+func (c *circuit) toHalfOpen() <span class="cov8" title="1">{
         c.mu.Lock()
         defer c.mu.Unlock()
-        if c.phase == phaseOpen </span><span class="cov2" title="2">{
+        if c.phase == phaseOpen </span><span class="cov8" title="1">{
                 c.phase = phaseHalfOpen
         }</span>
 }
 
 // onSuccess は、成功（または Permanent 退避完了）を記録します。Half-open なら Closed へ復帰します。
-func (c *circuit) onSuccess() <span class="cov5" title="19">{
+func (c *circuit) onSuccess() <span class="cov8" title="1">{
         c.mu.Lock()
         defer c.mu.Unlock()
         c.failures = 0
-        if c.phase == phaseHalfOpen </span><span class="cov1" title="1">{
+        if c.phase == phaseHalfOpen </span><span class="cov8" title="1">{
                 c.phase = phaseClosed
                 c.openCount = 0
         }</span>
 }
 
 // onFailure は、Retryable 失敗または poll エラーを記録します。閾値超過 or Half-open 失敗で Open へ遷移します。
-func (c *circuit) onFailure() <span class="cov8" title="169">{
+func (c *circuit) onFailure() <span class="cov8" title="1">{
         c.mu.Lock()
         defer c.mu.Unlock()
-        if c.threshold &lt;= 0 </span><span class="cov8" title="159">{
+        if c.threshold &lt;= 0 </span><span class="cov8" title="1">{
                 return
         }</span>
-        <span class="cov4" title="10">c.failures++
+        <span class="cov8" title="1">c.failures++
         switch c.phase </span>{
-        case phaseHalfOpen:<span class="cov1" title="1">
+        case phaseHalfOpen:<span class="cov8" title="1">
                 c.trip()</span>
-        case phaseClosed:<span class="cov4" title="8">
-                if c.failures &gt;= c.threshold </span><span class="cov3" title="6">{
+        case phaseClosed:<span class="cov8" title="1">
+                if c.failures &gt;= c.threshold </span><span class="cov8" title="1">{
                         c.trip()
                 }</span>
-        case phaseOpen:<span class="cov1" title="1"></span>
+        case phaseOpen:<span class="cov8" title="1"></span>
                 // Open 中は Receive しないため通常は到達しない。
         }
 }
 
 // trip は、Open へ遷移し cooldown を確定します（mu ロック下で呼ぶこと）。
-func (c *circuit) trip() <span class="cov3" title="7">{
+func (c *circuit) trip() <span class="cov8" title="1">{
         c.phase = phaseOpen
         c.curCooldown = c.backoff.Duration(c.openCount)
         c.openCount++
@@ -7152,13 +7143,13 @@ type category int
 
 // classify は、非 nil の err を重大度順（Fatal &gt; Permanent &gt; Retryable）で分類します。
 // いずれの分類センチネルにも該当しない error は Retryable として扱います。
-func classify(err error) category <span class="cov10" title="161">{
+func classify(err error) category <span class="cov8" title="1">{
         switch </span>{
-        case xerrors.Is(err, apperror.ErrFatal):<span class="cov2" title="2">
+        case xerrors.Is(err, apperror.ErrFatal):<span class="cov8" title="1">
                 return catFatal</span>
-        case xerrors.Is(err, apperror.ErrPermanent):<span class="cov2" title="2">
+        case xerrors.Is(err, apperror.ErrPermanent):<span class="cov8" title="1">
                 return catPermanent</span>
-        default:<span class="cov9" title="157">
+        default:<span class="cov8" title="1">
                 return catRetryable</span>
         }
 }
@@ -7191,7 +7182,7 @@ type keyRunner struct {
 }
 
 // newKeyedDispatcher は、keyedDispatcher を生成します。buffer は key ごとのキュー長です。
-func newKeyedDispatcher(buffer int, proc func(ctx context.Context, m worker.Message)) *keyedDispatcher <span class="cov6" title="27">{
+func newKeyedDispatcher(buffer int, proc func(ctx context.Context, m worker.Message)) *keyedDispatcher <span class="cov8" title="1">{
         return &amp;keyedDispatcher{
                 runners: make(map[string]*keyRunner),
                 buffer:  buffer,
@@ -7200,39 +7191,39 @@ func newKeyedDispatcher(buffer int, proc func(ctx context.Context, m worker.Mess
 }</span>
 
 // dispatch は、メッセージを並列 or key 直列で処理へ回します。
-func (kd *keyedDispatcher) dispatch(ctx context.Context, m worker.Message) <span class="cov10" title="181">{
-        if m.PartitionKey == "" </span><span class="cov9" title="178">{
+func (kd *keyedDispatcher) dispatch(ctx context.Context, m worker.Message) <span class="cov8" title="1">{
+        if m.PartitionKey == "" </span><span class="cov8" title="1">{
                 go kd.proc(ctx, m)
                 return
         }</span>
 
-        <span class="cov2" title="3">kd.mu.Lock()
+        <span class="cov8" title="1">kd.mu.Lock()
         r, ok := kd.runners[m.PartitionKey]
-        if !ok </span><span class="cov1" title="1">{
+        if !ok </span><span class="cov8" title="1">{
                 r = &amp;keyRunner{ch: make(chan worker.Message, kd.buffer)}
                 kd.runners[m.PartitionKey] = r
                 go kd.runKey(ctx, m.PartitionKey, r)
         }</span>
-        <span class="cov2" title="3">r.pending++
+        <span class="cov8" title="1">r.pending++
         kd.mu.Unlock()
 
         r.ch &lt;- m</span>
 }
 
 // runKey は、特定 key のメッセージを FIFO で順次処理し、滞留が無くなれば自身を破棄します。
-func (kd *keyedDispatcher) runKey(ctx context.Context, key string, r *keyRunner) <span class="cov1" title="1">{
-        for </span><span class="cov2" title="3">{
+func (kd *keyedDispatcher) runKey(ctx context.Context, key string, r *keyRunner) <span class="cov8" title="1">{
+        for </span><span class="cov8" title="1">{
                 m := &lt;-r.ch
                 kd.proc(ctx, m)
 
                 kd.mu.Lock()
                 r.pending--
-                if r.pending == 0 </span><span class="cov1" title="1">{
+                if r.pending == 0 </span><span class="cov8" title="1">{
                         delete(kd.runners, key)
                         kd.mu.Unlock()
                         return
                 }</span>
-                <span class="cov2" title="2">kd.mu.Unlock()</span>
+                <span class="cov8" title="1">kd.mu.Unlock()</span>
         }
 }
 </pre>
@@ -7276,7 +7267,7 @@ type run struct {
         fatal   error
 }
 
-func newRun(e *Engine, w worker.Worker) *run <span class="cov6" title="27">{
+func newRun(e *Engine, w worker.Worker) *run <span class="cov8" title="1">{
         set := e.set
         r := &amp;run{
                 e:         e,
@@ -7294,94 +7285,94 @@ func newRun(e *Engine, w worker.Worker) *run <span class="cov6" title="27">{
 }</span>
 
 // loop は、poll loop 本体です。ctx 完了 or Fatal で抜け、drain して返ります。
-func (r *run) loop(parent context.Context) error <span class="cov5" title="17">{
+func (r *run) loop(parent context.Context) error <span class="cov8" title="1">{
         ctx, cancel := context.WithCancel(parent)
         r.cancel = cancel
         defer cancel()
         defer r.drain()
 
-        for </span><span class="cov9" title="188">{
+        for </span><span class="cov8" title="1">{
                 r.e.markProgress() // stuck 検出用に進捗時刻を更新
                 n, ok := r.acquire(ctx)
-                if !ok </span><span class="cov2" title="2">{
+                if !ok </span><span class="cov8" title="1">{
                         return r.fatalErr()
                 }</span>
-                <span class="cov9" title="186">msgs, err := r.consumer.Receive(ctx, n)
-                if err != nil </span><span class="cov5" title="16">{
-                        if ctx.Err() != nil </span><span class="cov5" title="15">{
+                <span class="cov8" title="1">msgs, err := r.consumer.Receive(ctx, n)
+                if err != nil </span><span class="cov8" title="1">{
+                        if ctx.Err() != nil </span><span class="cov8" title="1">{
                                 return r.fatalErr()
                         }</span>
-                        <span class="cov1" title="1">r.onPollError(ctx, err)
+                        <span class="cov8" title="1">r.onPollError(ctx, err)
                         continue</span>
                 }
-                <span class="cov9" title="170">r.dispatchAll(ctx, msgs)</span>
+                <span class="cov8" title="1">r.dispatchAll(ctx, msgs)</span>
         }
 }
 
 // acquire は、Receive を許可できる状態になるまで待ち、取得件数を返します。
 // サーキットが Open なら cooldown を待ち、in-flight に空きが出るまで待つ二段ゲートです。
 // スロット待ちの間に Open へ遷移しうるため、待機後に状態を再確認します。
-func (r *run) acquire(ctx context.Context) (int, bool) <span class="cov9" title="189">{
-        for </span><span class="cov10" title="191">{
-                if ctx.Err() != nil </span><span class="cov1" title="1">{
+func (r *run) acquire(ctx context.Context) (int, bool) <span class="cov8" title="1">{
+        for </span><span class="cov8" title="1">{
+                if ctx.Err() != nil </span><span class="cov8" title="1">{
                         return 0, false
                 }</span>
-                <span class="cov9" title="190">if r.cb.phaseNow() == phaseOpen </span><span class="cov2" title="2">{
-                        if !r.waitCooldown(ctx) </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">if r.cb.phaseNow() == phaseOpen </span><span class="cov8" title="1">{
+                        if !r.waitCooldown(ctx) </span><span class="cov8" title="1">{
                                 return 0, false
                         }</span>
-                        <span class="cov1" title="1">continue</span>
+                        <span class="cov8" title="1">continue</span>
                 }
-                <span class="cov9" title="188">free, ok := r.waitForSlot(ctx)
-                if !ok </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">free, ok := r.waitForSlot(ctx)
+                if !ok </span><span class="cov8" title="1">{
                         return 0, false
                 }</span>
                 // phase は 1 度だけ snapshot して判定する（複数回 phaseNow() すると
                 // その間の trip() 割り込みで Open なのに BatchSize 件 Receive しうる TOCTOU を防ぐ）。
-                <span class="cov9" title="187">switch r.cb.phaseNow() </span>{
-                case phaseOpen:<span class="cov1" title="1">
+                <span class="cov8" title="1">switch r.cb.phaseNow() </span>{
+                case phaseOpen:<span class="cov8" title="1">
                         continue</span> // スロット待ちの間に Open へ遷移したので Receive せず再評価
-                case phaseHalfOpen:<span class="cov1" title="1">
+                case phaseHalfOpen:<span class="cov8" title="1">
                         return min(r.e.set.CircuitHalfOpenProbe, free), true</span>
-                default:<span class="cov9" title="185">
+                default:<span class="cov8" title="1">
                         return min(r.e.set.BatchSize, free), true</span>
                 }
         }
 }
 
 // waitForSlot は、in-flight に空きが出るまで待ち、空き数を返します（B2 のゲート）。
-func (r *run) waitForSlot(ctx context.Context) (int, bool) <span class="cov9" title="188">{
-        for </span><span class="cov10" title="191">{
+func (r *run) waitForSlot(ctx context.Context) (int, bool) <span class="cov8" title="1">{
+        for </span><span class="cov8" title="1">{
                 free := cap(r.inflight) - len(r.inflight)
-                if free &gt; 0 </span><span class="cov9" title="187">{
+                if free &gt; 0 </span><span class="cov8" title="1">{
                         return free, true
                 }</span>
-                <span class="cov3" title="4">select </span>{
-                case &lt;-ctx.Done():<span class="cov1" title="1">
+                <span class="cov8" title="1">select </span>{
+                case &lt;-ctx.Done():<span class="cov8" title="1">
                         return 0, false</span>
-                case &lt;-r.slotFreed:<span class="cov2" title="3"></span>
+                case &lt;-r.slotFreed:<span class="cov8" title="1"></span>
                 }
         }
 }
 
 // waitCooldown は、Open の cooldown を待って Half-open へ遷移します。
-func (r *run) waitCooldown(ctx context.Context) bool <span class="cov2" title="2">{
+func (r *run) waitCooldown(ctx context.Context) bool <span class="cov8" title="1">{
         select </span>{
-        case &lt;-ctx.Done():<span class="cov1" title="1">
+        case &lt;-ctx.Done():<span class="cov8" title="1">
                 return false</span>
-        case &lt;-time.After(r.cb.cooldown()):<span class="cov1" title="1">
+        case &lt;-time.After(r.cb.cooldown()):<span class="cov8" title="1">
                 r.cb.toHalfOpen()
                 return true</span>
         }
 }
 
 // dispatchAll は、受信メッセージを in-flight 計上のうえ dispatch へ回します。
-func (r *run) dispatchAll(ctx context.Context, msgs []worker.Message) <span class="cov9" title="171">{
-        if len(msgs) == 0 </span><span class="cov1" title="1">{
+func (r *run) dispatchAll(ctx context.Context, msgs []worker.Message) <span class="cov8" title="1">{
+        if len(msgs) == 0 </span><span class="cov8" title="1">{
                 return
         }</span>
-        <span class="cov9" title="170">r.e.met.Received(ctx, int64(len(msgs)))
-        for _, m := range msgs </span><span class="cov9" title="181">{
+        <span class="cov8" title="1">r.e.met.Received(ctx, int64(len(msgs)))
+        for _, m := range msgs </span><span class="cov8" title="1">{
                 r.inflight &lt;- struct{}{}
                 r.e.met.InFlightAdd(ctx, 1)
                 r.wg.Add(1)
@@ -7390,7 +7381,7 @@ func (r *run) dispatchAll(ctx context.Context, msgs []worker.Message) <span clas
 }
 
 // process は、1 メッセージの処理単位です（B1 の同時数制御・span・分類処理）。
-func (r *run) process(ctx context.Context, m worker.Message) <span class="cov9" title="181">{
+func (r *run) process(ctx context.Context, m worker.Message) <span class="cov8" title="1">{
         defer r.finishMessage(ctx)
 
         ctx = r.withTrace(ctx, m) // D1: traceparent から trace 継続
@@ -7398,13 +7389,13 @@ func (r *run) process(ctx context.Context, m worker.Message) <span class="cov9" 
         defer endSpan()
 
         select </span>{
-        case r.conc &lt;- struct{}{}:<span class="cov9" title="175"></span>
-        case &lt;-ctx.Done():<span class="cov4" title="6">
+        case r.conc &lt;- struct{}{}:<span class="cov8" title="1"></span>
+        case &lt;-ctx.Done():<span class="cov8" title="1">
                 return</span> // 停止中は未処理のまま離脱（Ack/Nack せず再配送へ）。in-flight は finishMessage が解放
         }
-        <span class="cov9" title="175">defer func() </span><span class="cov9" title="175">{ &lt;-r.conc }</span>()
+        <span class="cov8" title="1">defer func() </span><span class="cov8" title="1">{ &lt;-r.conc }</span>()
 
-        <span class="cov9" title="175">r.warnIfPoison(ctx, m)
+        <span class="cov8" title="1">r.warnIfPoison(ctx, m)
         start := time.Now()
         err := r.safeHandle(ctx, m)
         r.e.met.RecordLatencyMs(ctx, msSince(start))
@@ -7412,25 +7403,25 @@ func (r *run) process(ctx context.Context, m worker.Message) <span class="cov9" 
 }
 
 // finishMessage は、in-flight トークンを解放し poll loop を起床させます。
-func (r *run) finishMessage(ctx context.Context) <span class="cov9" title="181">{
+func (r *run) finishMessage(ctx context.Context) <span class="cov8" title="1">{
         &lt;-r.inflight
         r.e.met.InFlightAdd(ctx, -1)
         select </span>{
-        case r.slotFreed &lt;- struct{}{}:<span class="cov5" title="18"></span>
-        default:<span class="cov9" title="163"></span>
+        case r.slotFreed &lt;- struct{}{}:<span class="cov8" title="1"></span>
+        default:<span class="cov8" title="1"></span>
         }
-        <span class="cov9" title="181">r.wg.Done()</span>
+        <span class="cov8" title="1">r.wg.Done()</span>
 }
 
 // msSince は、start からの経過時間をミリ秒（小数）で返します。
-func msSince(start time.Time) float64 <span class="cov9" title="175">{
+func msSince(start time.Time) float64 <span class="cov8" title="1">{
         return float64(time.Since(start)) / float64(time.Millisecond)
 }</span>
 
 // safeHandle は、per-message recover（A6）と Extend ハートビート（A3）付きで Handle を実行します。
-func (r *run) safeHandle(ctx context.Context, m worker.Message) (err error) <span class="cov9" title="175">{
-        defer func() </span><span class="cov9" title="175">{
-                if rec := recover(); rec != nil </span><span class="cov6" title="28">{
+func (r *run) safeHandle(ctx context.Context, m worker.Message) (err error) <span class="cov8" title="1">{
+        defer func() </span><span class="cov8" title="1">{
+                if rec := recover(); rec != nil </span><span class="cov8" title="1">{
                         // panic 値はログにのみ残し、伝播するエラーには含めない（秘密情報の漏洩防止）。
                         r.e.log.Named("worker.recover").Error(
                                 "panic recovered in handler",
@@ -7440,35 +7431,35 @@ func (r *run) safeHandle(ctx context.Context, m worker.Message) (err error) <spa
                 }</span>
         }()
 
-        <span class="cov9" title="175">stop := r.startHeartbeat(ctx, m)
+        <span class="cov8" title="1">stop := r.startHeartbeat(ctx, m)
         defer stop()
 
         return r.handler.Handle(ctx, m)</span>
 }
 
 // startHeartbeat は、ExtendInterval ごとに Extend を呼ぶハートビートを開始し、停止関数を返します。
-func (r *run) startHeartbeat(ctx context.Context, m worker.Message) func() <span class="cov9" title="177">{
+func (r *run) startHeartbeat(ctx context.Context, m worker.Message) func() <span class="cov8" title="1">{
         interval := r.e.set.ExtendInterval
-        if interval &lt;= 0 </span><span class="cov9" title="174">{
-                return func() </span>{<span class="cov9" title="174">}</span>
+        if interval &lt;= 0 </span><span class="cov8" title="1">{
+                return func() </span>{<span class="cov8" title="1">}</span>
         }
 
-        <span class="cov2" title="3">ticker := time.NewTicker(interval)
+        <span class="cov8" title="1">ticker := time.NewTicker(interval)
         done := make(chan struct{})
-        go func() </span><span class="cov2" title="3">{
-                for </span><span class="cov4" title="7">{
+        go func() </span><span class="cov8" title="1">{
+                for </span><span class="cov8" title="1">{
                         select </span>{
-                        case &lt;-done:<span class="cov1" title="1">
+                        case &lt;-done:<span class="cov8" title="1">
                                 return</span>
-                        case &lt;-ctx.Done():<span class="cov1" title="1">
+                        case &lt;-ctx.Done():<span class="cov8" title="1">
                                 return</span>
-                        case &lt;-ticker.C:<span class="cov3" title="5">
-                                if err := r.consumer.Extend(ctx, m, interval*extendVisibilityFactor); err != nil </span><span class="cov2" title="3">{
-                                        if ctx.Err() != nil </span><span class="cov1" title="1">{
+                        case &lt;-ticker.C:<span class="cov8" title="1">
+                                if err := r.consumer.Extend(ctx, m, interval*extendVisibilityFactor); err != nil </span><span class="cov8" title="1">{
+                                        if ctx.Err() != nil </span><span class="cov8" title="1">{
                                                 return // 停止中の Extend 失敗は握り潰してよい（未 Ack なので再配送される）
                                         }</span>
                                         // 握り潰さず可視化する。lease 延長失敗は早期再配送→重複処理の予兆。
-                                        <span class="cov2" title="2">r.e.met.ExtendError(ctx)
+                                        <span class="cov8" title="1">r.e.met.ExtendError(ctx)
                                         r.e.log.Named("worker.extend").Warn(
                                                 "extend failed",
                                                 append(msgFields(ctx, r.name, m), logging.Error(logging.ErrorKey, err))...,
@@ -7478,7 +7469,7 @@ func (r *run) startHeartbeat(ctx context.Context, m worker.Message) func() <span
                 }
         }()
 
-        <span class="cov2" title="3">return func() </span><span class="cov2" title="3">{
+        <span class="cov8" title="1">return func() </span><span class="cov8" title="1">{
                 ticker.Stop()
                 close(done)
         }</span>
@@ -7486,8 +7477,8 @@ func (r *run) startHeartbeat(ctx context.Context, m worker.Message) func() <span
 
 // handleResult は、Handle の結果を分類して Ack / Nack / FailureHandler / engine 停止に振り分けます。
 // 併せて engine 所有 metric の更新（D2）と構造化ログ（D3）を行います。
-func (r *run) handleResult(ctx context.Context, m worker.Message, err error) <span class="cov9" title="175">{
-        if err == nil </span><span class="cov5" title="18">{
+func (r *run) handleResult(ctx context.Context, m worker.Message, err error) <span class="cov8" title="1">{
+        if err == nil </span><span class="cov8" title="1">{
                 r.ack(ctx, m) // A1: 成功時のみ Ack
                 r.cb.onSuccess()
                 r.e.met.Processed(ctx)
@@ -7495,107 +7486,107 @@ func (r *run) handleResult(ctx context.Context, m worker.Message, err error) <sp
                 return
         }</span>
 
-        <span class="cov9" title="157">r.e.met.Failed(ctx)
+        <span class="cov8" title="1">r.e.met.Failed(ctx)
         fields := append(msgFields(ctx, r.name, m), logging.Error(logging.ErrorKey, err))
 
         switch classify(err) </span>{
-        case catRetryable:<span class="cov9" title="155">
+        case catRetryable:<span class="cov8" title="1">
                 r.nack(ctx, m) // A2
                 r.cb.onFailure()
                 r.e.met.Retried(ctx)
                 r.e.log.Named("worker.process").Warn("retryable failure, nacked", fields...)</span>
-        case catPermanent:<span class="cov1" title="1">
+        case catPermanent:<span class="cov8" title="1">
                 r.routePermanent(ctx, m, err) // A5
                 r.cb.onSuccess()
                 r.e.met.DLQ(ctx)
                 r.e.log.Named("worker.process").Warn("permanent failure, routed to dead-letter", fields...)</span>
-        case catFatal:<span class="cov1" title="1">
+        case catFatal:<span class="cov8" title="1">
                 r.e.log.Named("worker.process").Error("fatal failure, stopping engine", fields...)
                 r.triggerFatal(err)</span> // A5（Fatal）
         }
 }
 
 // routePermanent は、Permanent を FailureHandler へ退避してから Ack します（退避失敗時は Ack しない）。
-func (r *run) routePermanent(ctx context.Context, m worker.Message, cause error) <span class="cov2" title="3">{
-        if r.failure != nil </span><span class="cov2" title="2">{
-                if err := r.failure.Fail(ctx, m, cause); err != nil </span><span class="cov1" title="1">{
+func (r *run) routePermanent(ctx context.Context, m worker.Message, cause error) <span class="cov8" title="1">{
+        if r.failure != nil </span><span class="cov8" title="1">{
+                if err := r.failure.Fail(ctx, m, cause); err != nil </span><span class="cov8" title="1">{
                         r.logErr("worker.failure", "failure handler error", err)
                         return
                 }</span>
         }
-        <span class="cov2" title="2">r.ack(ctx, m)</span>
+        <span class="cov8" title="1">r.ack(ctx, m)</span>
 }
 
-func (r *run) ack(ctx context.Context, m worker.Message) <span class="cov6" title="21">{
-        if err := r.consumer.Ack(ctx, m); err != nil </span><span class="cov1" title="1">{
+func (r *run) ack(ctx context.Context, m worker.Message) <span class="cov8" title="1">{
+        if err := r.consumer.Ack(ctx, m); err != nil </span><span class="cov8" title="1">{
                 r.logErr("worker.ack", "ack error", err)
         }</span>
 }
 
 // nack は、retryable 失敗時に per-message 再配送 backoff（指数 + full jitter）を計算し、
 // その遅延つきで再配送します。policy は engine が持ち、adapter が native 機構で honor します。
-func (r *run) nack(ctx context.Context, m worker.Message) <span class="cov9" title="156">{
+func (r *run) nack(ctx context.Context, m worker.Message) <span class="cov8" title="1">{
         d := r.nackBackoff(m.ReceiveCount)
-        if err := r.consumer.NackWithBackoff(ctx, m, d); err != nil </span><span class="cov1" title="1">{
+        if err := r.consumer.NackWithBackoff(ctx, m, d); err != nil </span><span class="cov8" title="1">{
                 r.logErr("worker.nack", "nack error", err)
         }</span>
 }
 
 // nackBackoff は、ReceiveCount（1 起算）に対する再配送遅延を返します。
 // 指数 backoff を full jitter で散らし、同時失敗の thundering herd を避けます。
-func (r *run) nackBackoff(receiveCount int) time.Duration <span class="cov9" title="156">{
+func (r *run) nackBackoff(receiveCount int) time.Duration <span class="cov8" title="1">{
         // ReceiveCount は 1 起算、backoff.Duration は 0 起算。
         attempt := max(0, receiveCount-1)
         return retry.Full(r.e.set.nackBackoff().Duration(attempt))
 }</span>
 
 // onPollError は、Receive の失敗をサーキットへ反映します（broker 到達不能など）。
-func (r *run) onPollError(ctx context.Context, err error) <span class="cov2" title="2">{
+func (r *run) onPollError(ctx context.Context, err error) <span class="cov8" title="1">{
         r.e.met.PollError(ctx)
         r.logErr("worker.poll", "receive error", err)
         r.cb.onFailure()
 }</span>
 
 // warnIfPoison は、再配送回数が閾値以上のとき warn します（A7。無限ループは IaC の DLQ で打ち切る）。
-func (r *run) warnIfPoison(ctx context.Context, m worker.Message) <span class="cov9" title="175">{
+func (r *run) warnIfPoison(ctx context.Context, m worker.Message) <span class="cov8" title="1">{
         th := r.e.set.ReceiveCountWarnThreshold
-        if th &lt;= 0 || m.ReceiveCount &lt; th </span><span class="cov9" title="174">{
+        if th &lt;= 0 || m.ReceiveCount &lt; th </span><span class="cov8" title="1">{
                 return
         }</span>
-        <span class="cov1" title="1">r.e.log.Named("worker.poison").Warn("receive count threshold reached", msgFields(ctx, r.name, m)...)</span>
+        <span class="cov8" title="1">r.e.log.Named("worker.poison").Warn("receive count threshold reached", msgFields(ctx, r.name, m)...)</span>
 }
 
 // triggerFatal は、Fatal を記録して engine を停止（ctx キャンセル）します。ログは handleResult が出します。
-func (r *run) triggerFatal(err error) <span class="cov1" title="1">{
+func (r *run) triggerFatal(err error) <span class="cov8" title="1">{
         r.fatalMu.Lock()
-        if r.fatal == nil </span><span class="cov1" title="1">{
+        if r.fatal == nil </span><span class="cov8" title="1">{
                 r.fatal = err
         }</span>
-        <span class="cov1" title="1">r.fatalMu.Unlock()
+        <span class="cov8" title="1">r.fatalMu.Unlock()
         r.cancel()</span>
 }
 
-func (r *run) fatalErr() error <span class="cov5" title="17">{
+func (r *run) fatalErr() error <span class="cov8" title="1">{
         r.fatalMu.Lock()
         defer r.fatalMu.Unlock()
         return r.fatal
 }</span>
 
-func (r *run) logErr(name, msg string, err error) <span class="cov3" title="5">{
+func (r *run) logErr(name, msg string, err error) <span class="cov8" title="1">{
         r.e.log.Named(name).Error(msg, logging.Error(logging.ErrorKey, err))
 }</span>
 
 // drain は、in-flight の完了を DrainTimeout まで待ちます（C1。未完は Ack されず再配送へ）。
-func (r *run) drain() <span class="cov5" title="18">{
+func (r *run) drain() <span class="cov8" title="1">{
         done := make(chan struct{})
-        go func() </span><span class="cov5" title="18">{
+        go func() </span><span class="cov8" title="1">{
                 r.wg.Wait()
                 close(done)
         }</span>()
 
-        <span class="cov5" title="18">select </span>{
-        case &lt;-done:<span class="cov5" title="17"></span>
-        case &lt;-time.After(r.e.set.DrainTimeout):<span class="cov1" title="1"></span>
+        <span class="cov8" title="1">select </span>{
+        case &lt;-done:<span class="cov8" title="1"></span>
+        case &lt;-time.After(r.e.set.DrainTimeout):<span class="cov8" title="1"></span>
         }
 }
 </pre>
@@ -7634,16 +7625,16 @@ func New(
         tf observability.TracerFactory,
         met *observability.WorkerMetrics,
         log logging.Logger,
-) (*Engine, error) <span class="cov7" title="45">{
+) (*Engine, error) <span class="cov8" title="1">{
         m := make(map[string]worker.Worker, len(workers))
-        for _, w := range workers </span><span class="cov7" title="42">{
+        for _, w := range workers </span><span class="cov8" title="1">{
                 name := w.Name()
-                if _, exists := m[name]; exists </span><span class="cov2" title="2">{
+                if _, exists := m[name]; exists </span><span class="cov8" title="1">{
                         return nil, xerrors.Wrap(ErrDuplicateWorker, name)
                 }</span>
-                <span class="cov7" title="40">m[name] = w</span>
+                <span class="cov8" title="1">m[name] = w</span>
         }
-        <span class="cov7" title="43">set.normalize()
+        <span class="cov8" title="1">set.normalize()
 
         return &amp;Engine{
                 workers: m,
@@ -7655,24 +7646,24 @@ func New(
 }
 
 // Names は、登録されている worker 名の一覧を返します。
-func (e *Engine) Names() []string <span class="cov3" title="5">{
+func (e *Engine) Names() []string <span class="cov8" title="1">{
         out := make([]string, 0, len(e.workers))
-        for k := range e.workers </span><span class="cov4" title="7">{
+        for k := range e.workers </span><span class="cov8" title="1">{
                 out = append(out, k)
         }</span>
-        <span class="cov3" title="5">sort.Strings(out)
+        <span class="cov8" title="1">sort.Strings(out)
         return out</span>
 }
 
 // Run は、指定された worker を実行します。ctx 完了 or Fatal で drain して返ります。
 // 通常（Retryable/Permanent のみ）の場合は ctx 完了まで常駐します。
-func (e *Engine) Run(ctx context.Context, name string) error <span class="cov6" title="21">{
+func (e *Engine) Run(ctx context.Context, name string) error <span class="cov8" title="1">{
         w, ok := e.workers[name]
-        if !ok </span><span class="cov3" title="4">{
+        if !ok </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrUnknownWorker, name)
         }</span>
 
-        <span class="cov5" title="17">e.active.Store(true)
+        <span class="cov8" title="1">e.active.Store(true)
         e.markProgress()
         defer e.active.Store(false)
 
@@ -7680,16 +7671,16 @@ func (e *Engine) Run(ctx context.Context, name string) error <span class="cov6" 
 }
 
 // Healthy は、readiness 判定を返します。Run 実行中かつ poll 進捗が閾値内のとき true。
-func (e *Engine) Healthy() bool <span class="cov2" title="3">{
-        if !e.active.Load() </span><span class="cov1" title="1">{
+func (e *Engine) Healthy() bool <span class="cov8" title="1">{
+        if !e.active.Load() </span><span class="cov8" title="1">{
                 return false
         }</span>
-        <span class="cov2" title="2">last := time.Unix(0, e.progress.Load())
+        <span class="cov8" title="1">last := time.Unix(0, e.progress.Load())
         return time.Since(last) &lt; e.set.ProgressStaleAfter</span>
 }
 
 // markProgress は、poll loop が進んだ時刻を記録します（stuck 検出の基準）。
-func (e *Engine) markProgress() <span class="cov10" title="206">{
+func (e *Engine) markProgress() <span class="cov8" title="1">{
         e.progress.Store(time.Now().UnixNano())
 }</span>
 </pre>
@@ -7751,38 +7742,38 @@ type Settings struct {
 }
 
 // normalize は、ゼロ値に安全な既定値を補います。
-func (s *Settings) normalize() <span class="cov8" title="52">{
-        if s.Concurrency &lt; 1 </span><span class="cov4" title="7">{
+func (s *Settings) normalize() <span class="cov8" title="1">{
+        if s.Concurrency &lt; 1 </span><span class="cov8" title="1">{
                 s.Concurrency = 1
         }</span>
-        <span class="cov8" title="52">if s.MaxInFlight &lt; s.Concurrency </span><span class="cov4" title="8">{
+        <span class="cov8" title="1">if s.MaxInFlight &lt; s.Concurrency </span><span class="cov8" title="1">{
                 s.MaxInFlight = s.Concurrency
         }</span>
-        <span class="cov8" title="52">if s.BatchSize &lt; 1 </span><span class="cov4" title="8">{
+        <span class="cov8" title="1">if s.BatchSize &lt; 1 </span><span class="cov8" title="1">{
                 s.BatchSize = 1
         }</span>
-        <span class="cov8" title="52">if s.BatchSize &gt; s.MaxInFlight </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if s.BatchSize &gt; s.MaxInFlight </span><span class="cov8" title="1">{
                 s.BatchSize = s.MaxInFlight
         }</span>
-        <span class="cov8" title="52">if s.DrainTimeout &lt;= 0 </span><span class="cov5" title="10">{
+        <span class="cov8" title="1">if s.DrainTimeout &lt;= 0 </span><span class="cov8" title="1">{
                 s.DrainTimeout = defaultDrainTimeout
         }</span>
-        <span class="cov8" title="52">if s.CircuitHalfOpenProbe &lt; 1 </span><span class="cov7" title="44">{
+        <span class="cov8" title="1">if s.CircuitHalfOpenProbe &lt; 1 </span><span class="cov8" title="1">{
                 s.CircuitHalfOpenProbe = 1
         }</span>
-        <span class="cov8" title="52">if s.ProgressStaleAfter &lt;= 0 </span><span class="cov7" title="43">{
+        <span class="cov8" title="1">if s.ProgressStaleAfter &lt;= 0 </span><span class="cov8" title="1">{
                 s.ProgressStaleAfter = defaultProgressStaleAfter
         }</span>
-        <span class="cov8" title="52">if s.NackBackoffInitial &lt;= 0 </span><span class="cov7" title="44">{
+        <span class="cov8" title="1">if s.NackBackoffInitial &lt;= 0 </span><span class="cov8" title="1">{
                 s.NackBackoffInitial = defaultNackBackoffInitial
         }</span>
-        <span class="cov8" title="52">if s.NackBackoffMax &lt;= 0 </span><span class="cov7" title="44">{
+        <span class="cov8" title="1">if s.NackBackoffMax &lt;= 0 </span><span class="cov8" title="1">{
                 s.NackBackoffMax = defaultNackBackoffMax
         }</span>
 }
 
 // circuitBackoff は、Settings から Open の cooldown 算出器を構築します。
-func (s *Settings) circuitBackoff() backoff.Exponential <span class="cov6" title="27">{
+func (s *Settings) circuitBackoff() backoff.Exponential <span class="cov8" title="1">{
         return backoff.Exponential{
                 Initial:    s.CircuitOpenBackoffInitial,
                 Max:        s.CircuitOpenBackoffMax,
@@ -7791,7 +7782,7 @@ func (s *Settings) circuitBackoff() backoff.Exponential <span class="cov6" title
 }</span>
 
 // nackBackoff は、Settings から per-message 再配送 backoff の算出器を構築します。
-func (s *Settings) nackBackoff() backoff.Exponential <span class="cov10" title="156">{
+func (s *Settings) nackBackoff() backoff.Exponential <span class="cov8" title="1">{
         return backoff.Exponential{
                 Initial:    s.NackBackoffInitial,
                 Max:        s.NackBackoffMax,
@@ -7817,12 +7808,12 @@ type state struct {
 }
 
 // NewState は、新しい State インスタンスを生成します。
-func NewState() worker.State <span class="cov10" title="10">{
+func NewState() worker.State <span class="cov8" title="1">{
         return &amp;state{}
 }</span>
 
 // Set は、起動対象の worker 名・引数と done チャネルを設定します。
-func (s *state) Set(name string, args []string, done chan error) <span class="cov8" title="6">{
+func (s *state) Set(name string, args []string, done chan error) <span class="cov8" title="1">{
         s.mu.Lock()
         defer s.mu.Unlock()
         s.name = name
@@ -7831,7 +7822,7 @@ func (s *state) Set(name string, args []string, done chan error) <span class="co
 }</span>
 
 // Snapshot は、現在の起動対象と done チャネルをスナップショットとして取得します。
-func (s *state) Snapshot() (string, []string, chan error) <span class="cov9" title="9">{
+func (s *state) Snapshot() (string, []string, chan error) <span class="cov8" title="1">{
         s.mu.Lock()
         defer s.mu.Unlock()
         return s.name, s.args, s.done
@@ -7850,21 +7841,21 @@ import (
 
 // withTrace は、Message.Attributes の traceparent から trace context を継続します（D1）。
 // producer → consumer → handler を 1 trace に繋ぎます。
-func (r *run) withTrace(ctx context.Context, m worker.Message) context.Context <span class="cov9" title="181">{
+func (r *run) withTrace(ctx context.Context, m worker.Message) context.Context <span class="cov8" title="1">{
         return observability.ExtractFromCarrier(ctx, m.Attributes)
 }</span>
 
 // msgFields は、構造化ログ用のフィールド（worker 名 / message id / receive count / trace id）を返します（D3）。
-func msgFields(ctx context.Context, name string, m worker.Message) []*logging.Field <span class="cov10" title="208">{
+func msgFields(ctx context.Context, name string, m worker.Message) []*logging.Field <span class="cov8" title="1">{
         fields := []*logging.Field{
                 logging.String(logging.WorkerNameKey, name),
                 logging.String(logging.MessageIDKey, m.ID),
                 logging.Int(logging.ReceiveCountKey, m.ReceiveCount),
         }
-        if traceID := observability.ExtractTraceContext(ctx).TraceID(); traceID != "" </span><span class="cov1" title="1">{
+        if traceID := observability.ExtractTraceContext(ctx).TraceID(); traceID != "" </span><span class="cov8" title="1">{
                 fields = append(fields, logging.String(logging.TraceIDKey, traceID))
         }</span>
-        <span class="cov10" title="208">return fields</span>
+        <span class="cov8" title="1">return fields</span>
 }
 </pre>
 		
@@ -7882,74 +7873,74 @@ type fxEventLogger struct {
 }
 
 // NewFxEventLogger は、fx.WithLogger に渡す fxevent.Logger を生成します。
-func NewFxEventLogger(logger logging.Logger) fxevent.Logger <span class="cov5" title="37">{
+func NewFxEventLogger(logger logging.Logger) fxevent.Logger <span class="cov8" title="1">{
         return &amp;fxEventLogger{logger: logger.Named("fx")}
 }</span>
 
-func (f *fxEventLogger) LogEvent(event fxevent.Event) <span class="cov10" title="1986">{
+func (f *fxEventLogger) LogEvent(event fxevent.Event) <span class="cov8" title="1">{
         switch e := event.(type) </span>{
-        case *fxevent.OnStartExecuted:<span class="cov2" title="5">
+        case *fxevent.OnStartExecuted:<span class="cov8" title="1">
                 f.record(e.Err,
                         "fx OnStart hook failed",
                         []*logging.Field{logging.String("callee", e.FunctionName), logging.String("caller", e.CallerName)},
                         f.logger.Debug, "fx OnStart hook executed",
                         logging.String("callee", e.FunctionName), logging.String("caller", e.CallerName),
                         logging.DurationMs("runtime_ms", e.Runtime))</span>
-        case *fxevent.OnStopExecuted:<span class="cov3" title="10">
+        case *fxevent.OnStopExecuted:<span class="cov8" title="1">
                 f.record(e.Err,
                         "fx OnStop hook failed",
                         []*logging.Field{logging.String("callee", e.FunctionName), logging.String("caller", e.CallerName)},
                         f.logger.Debug, "fx OnStop hook executed",
                         logging.String("callee", e.FunctionName), logging.String("caller", e.CallerName),
                         logging.DurationMs("runtime_ms", e.Runtime))</span>
-        case *fxevent.Supplied:<span class="cov1" title="2">
+        case *fxevent.Supplied:<span class="cov8" title="1">
                 f.record(e.Err,
                         "fx supply failed",
                         []*logging.Field{logging.String("type", e.TypeName), logging.String("module", e.ModuleName)},
                         f.logger.Debug, "fx supplied",
                         logging.String("type", e.TypeName), logging.String("module", e.ModuleName))</span>
-        case *fxevent.Provided:<span class="cov8" title="852">
+        case *fxevent.Provided:<span class="cov8" title="1">
                 f.record(e.Err,
                         "fx provide failed",
                         []*logging.Field{logging.String("constructor", e.ConstructorName), logging.String("module", e.ModuleName)},
                         f.logger.Debug, "fx provided",
                         logging.String("constructor", e.ConstructorName), logging.String("module", e.ModuleName),
                         logging.Strings("output_types", e.OutputTypeNames))</span>
-        case *fxevent.Invoked:<span class="cov6" title="78">
+        case *fxevent.Invoked:<span class="cov8" title="1">
                 f.record(e.Err,
                         "fx invoke failed",
                         []*logging.Field{logging.String("function", e.FunctionName), logging.String("module", e.ModuleName)},
                         f.logger.Debug, "fx invoked",
                         logging.String("function", e.FunctionName), logging.String("module", e.ModuleName))</span>
-        case *fxevent.Replaced:<span class="cov1" title="2">
+        case *fxevent.Replaced:<span class="cov8" title="1">
                 f.record(e.Err,
                         "fx replace failed",
                         []*logging.Field{logging.String("module", e.ModuleName)},
                         f.logger.Debug, "fx replaced",
                         logging.Strings("output_types", e.OutputTypeNames), logging.String("module", e.ModuleName))</span>
-        case *fxevent.Decorated:<span class="cov1" title="2">
+        case *fxevent.Decorated:<span class="cov8" title="1">
                 f.record(e.Err,
                         "fx decorate failed",
                         []*logging.Field{logging.String("decorator", e.DecoratorName), logging.String("module", e.ModuleName)},
                         f.logger.Debug, "fx decorated",
                         logging.String("decorator", e.DecoratorName), logging.String("module", e.ModuleName),
                         logging.Strings("output_types", e.OutputTypeNames))</span>
-        case *fxevent.LoggerInitialized:<span class="cov4" title="14">
+        case *fxevent.LoggerInitialized:<span class="cov8" title="1">
                 f.record(e.Err,
                         "fx logger initialization failed", nil,
                         f.logger.Debug, "fx custom logger initialized",
                         logging.String("constructor", e.ConstructorName))</span>
-        case *fxevent.Started:<span class="cov3" title="9">
+        case *fxevent.Started:<span class="cov8" title="1">
                 f.record(e.Err,
                         "fx application failed to start", nil,
                         f.logger.Info, "fx application started")</span>
-        case *fxevent.Stopped:<span class="cov3" title="11">
+        case *fxevent.Stopped:<span class="cov8" title="1">
                 f.record(e.Err,
                         "fx application failed to stop", nil,
                         f.logger.Info, "fx application stopped")</span>
-        case *fxevent.RollingBack:<span class="cov2" title="4">
+        case *fxevent.RollingBack:<span class="cov8" title="1">
                 f.logger.Error("fx start failed, rolling back", logging.Error(logging.ErrorKey, e.StartErr))</span>
-        case *fxevent.RolledBack:<span class="cov2" title="5">
+        case *fxevent.RolledBack:<span class="cov8" title="1">
                 f.record(e.Err,
                         "fx rollback failed", nil,
                         f.logger.Debug, "fx rolled back")</span>
@@ -7961,12 +7952,12 @@ func (f *fxEventLogger) record(
         err error,
         failMsg string, failFields []*logging.Field,
         logOK func(string, ...*logging.Field), okMsg string, okFields ...*logging.Field,
-) <span class="cov9" title="990">{
-        if err != nil </span><span class="cov4" title="17">{
+) <span class="cov8" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 f.logger.Error(failMsg, append(failFields, logging.Error(logging.ErrorKey, err))...)
                 return
         }</span>
-        <span class="cov9" title="973">logOK(okMsg, okFields...)</span>
+        <span class="cov8" title="1">logOK(okMsg, okFields...)</span>
 }
 </pre>
 		
@@ -7997,7 +7988,7 @@ type (
 )
 
 // NewJobCore は、ジョブ実行用の fx.App を構成する fx.Option を返します。
-func NewJobCore() fx.Option <span class="cov10" title="6">{
+func NewJobCore() fx.Option <span class="cov8" title="1">{
         return fx.Options(
                 // Shutdowner Module
                 shutdowner.Module(),
@@ -8020,7 +8011,7 @@ func NewJobCore() fx.Option <span class="cov10" title="6">{
 // RunJob は、ジョブ実行用の開始関数・停止関数を生成して返します。context／タイムアウトの制御は返した関数の呼出側が担います。
 // grace（APP_SHUTDOWN_TIMEOUT）を fx.StopTimeout に設定し、停止時に fx 既定（15s）が
 // 停止猶予より先に teardown を打ち切らないようにします（停止軸を grace に一本化）。
-func RunJob(grace time.Duration) (StartFunc, StopFunc) <span class="cov7" title="4">{
+func RunJob(grace time.Duration) (StartFunc, StopFunc) <span class="cov8" title="1">{
         var (
                 state  job.State
                 logger logging.Logger
@@ -8034,12 +8025,12 @@ func RunJob(grace time.Duration) (StartFunc, StopFunc) <span class="cov7" title=
                 fx.WithLogger(NewFxEventLogger),
         )
 
-        start := func(ctx context.Context, name string, args []string) &lt;-chan error </span><span class="cov4" title="2">{
+        start := func(ctx context.Context, name string, args []string) &lt;-chan error </span><span class="cov8" title="1">{
                 l := logger.Named("job.RunJob").CallerSkip(callSkip)
                 done := make(chan error, 1)
                 state.Set(name, args, done)
 
-                if err := app.Start(ctx); err != nil </span><span class="cov1" title="1">{
+                if err := app.Start(ctx); err != nil </span><span class="cov8" title="1">{
                         fields := append(jobEventFields(logging.EventTypeStart, osCfg.TimeZone()),
                                 logging.String(logging.JobNameKey, name),
                                 logging.Strings(logging.JobArgsKey, args),
@@ -8053,7 +8044,7 @@ func RunJob(grace time.Duration) (StartFunc, StopFunc) <span class="cov7" title=
                         return failCh
                 }</span>
 
-                <span class="cov1" title="1">fields := append(jobEventFields(logging.EventTypeStart, osCfg.TimeZone()),
+                <span class="cov8" title="1">fields := append(jobEventFields(logging.EventTypeStart, osCfg.TimeZone()),
                         logging.String(logging.JobNameKey, name),
                         logging.Strings(logging.JobArgsKey, args),
                 )
@@ -8062,9 +8053,9 @@ func RunJob(grace time.Duration) (StartFunc, StopFunc) <span class="cov7" title=
                 return done</span>
         }
 
-        <span class="cov7" title="4">stop := func(ctx context.Context) error </span><span class="cov7" title="4">{
+        <span class="cov8" title="1">stop := func(ctx context.Context) error </span><span class="cov8" title="1">{
                 l := logger.Named("job.RunJob").CallerSkip(callSkip)
-                if err := app.Stop(ctx); err != nil </span><span class="cov1" title="1">{
+                if err := app.Stop(ctx); err != nil </span><span class="cov8" title="1">{
                         fields := append(jobEventFields(logging.EventTypeEnd, osCfg.TimeZone()),
                                 logging.Error(logging.JobErrorKey, err),
                         )
@@ -8072,15 +8063,15 @@ func RunJob(grace time.Duration) (StartFunc, StopFunc) <span class="cov7" title=
                         return err
                 }</span>
 
-                <span class="cov6" title="3">l.Info("job application finished", jobEventFields(logging.EventTypeEnd, osCfg.TimeZone())...)
+                <span class="cov8" title="1">l.Info("job application finished", jobEventFields(logging.EventTypeEnd, osCfg.TimeZone())...)
                 return nil</span>
         }
 
-        <span class="cov7" title="4">return start, stop</span>
+        <span class="cov8" title="1">return start, stop</span>
 }
 
 // jobEventFields は、ジョブ起動／停止ログ共通のイベントフィールド（種別・発生時刻・TZ）を返します。
-func jobEventFields(eventType, tz string) []*logging.Field <span class="cov10" title="6">{
+func jobEventFields(eventType, tz string) []*logging.Field <span class="cov8" title="1">{
         return []*logging.Field{
                 logging.String(logging.EventTypeKey, eventType),
                 logging.Time(logging.EventAtKey, time.Now()),
@@ -8115,9 +8106,9 @@ func RegisterJobHooks(
         logger logging.Logger,
         osCfg *config.OperatingSystemConfig,
         state job.State,
-) <span class="cov10" title="6">{
+) <span class="cov8" title="1">{
         lifecycle.SupervisedRunner{
-                Body: func(ctx context.Context) </span><span class="cov6" title="3">{ runJobAndShutdown(ctx, sd, runner, logger, osCfg, state) }</span>,
+                Body: func(ctx context.Context) </span><span class="cov8" title="1">{ runJobAndShutdown(ctx, sd, runner, logger, osCfg, state) }</span>,
         }.Register(reg)
 }
 
@@ -8133,9 +8124,9 @@ func runJobAndShutdown(
         logger logging.Logger,
         osCfg *config.OperatingSystemConfig,
         state job.State,
-) <span class="cov9" title="5">{
+) <span class="cov8" title="1">{
         name, args, done := state.Snapshot()
-        if done == nil </span><span class="cov4" title="2">{
+        if done == nil </span><span class="cov8" title="1">{
                 logger.Named("job.Hooks").Info(
                         "No job to run",
                         logging.String(logging.EventTypeKey, logging.EventTypeStart),
@@ -8148,7 +8139,7 @@ func runJobAndShutdown(
                 return
         }</span>
 
-        <span class="cov6" title="3">defer close(done)
+        <span class="cov8" title="1">defer close(done)
 
         done &lt;- runner.Run(jobCtx, name, args)
 
@@ -8157,8 +8148,8 @@ func runJobAndShutdown(
 
 // shutdown は、ジョブ完了後のアプリ停止を要求し、失敗時はジョブ系のログ様式に合わせて記録します。
 // エラーは黙殺せずログ記録する。
-func shutdown(sd shutdowner.Shutdowner, logger logging.Logger) <span class="cov10" title="6">{
-        if err := sd.Shutdown(); err != nil </span><span class="cov1" title="1">{
+func shutdown(sd shutdowner.Shutdowner, logger logging.Logger) <span class="cov8" title="1">{
+        if err := sd.Shutdown(); err != nil </span><span class="cov8" title="1">{
                 logger.Named("job.Hooks").Error(
                         "failed to shutdown",
                         logging.Error(logging.JobErrorKey, err),
@@ -8185,7 +8176,7 @@ type RunnerIn struct {
 }
 
 // ProvideRunner は、ジョブランナーを提供します。
-func ProvideRunner(in RunnerIn) (job.Runner, error) <span class="cov10" title="8">{
+func ProvideRunner(in RunnerIn) (job.Runner, error) <span class="cov8" title="1">{
         return jobrunner.NewRunner(in.Jobs)
 }</span>
 </pre>
@@ -8215,17 +8206,17 @@ type lifecycleRegistrar struct {
 }
 
 // NewLifecycleRegistrar は、fx.Lifecycle を用いて Registrar の実装を提供します。
-func NewLifecycleRegistrar(lc fx.Lifecycle) Registrar <span class="cov8" title="19">{
+func NewLifecycleRegistrar(lc fx.Lifecycle) Registrar <span class="cov8" title="1">{
         return lifecycleRegistrar{lc: lc}
 }</span>
 
-func (r lifecycleRegistrar) RegisterStart(start func(ctx context.Context) error) <span class="cov7" title="14">{
+func (r lifecycleRegistrar) RegisterStart(start func(ctx context.Context) error) <span class="cov8" title="1">{
         r.lc.Append(fx.Hook{
                 OnStart: start,
         })
 }</span>
 
-func (r lifecycleRegistrar) RegisterStop(stop func(ctx context.Context) error) <span class="cov10" title="44">{
+func (r lifecycleRegistrar) RegisterStop(stop func(ctx context.Context) error) <span class="cov8" title="1">{
         r.lc.Append(fx.Hook{
                 OnStop: stop,
         })
@@ -8237,7 +8228,7 @@ func (r lifecycleRegistrar) RegisterStop(stop func(ctx context.Context) error) <
 import "go.uber.org/fx"
 
 // Module は、LifecycleRegistrarを提供するfx.Moduleを返します。
-func Module() fx.Option <span class="cov10" title="34">{
+func Module() fx.Option <span class="cov8" title="1">{
         return fx.Module("lifecycle.registrar",
                 fx.Provide(
                         NewLifecycleRegistrar,
@@ -8275,34 +8266,34 @@ type SupervisedRunner struct {
 }
 
 // Register は、SupervisedRunner を reg のライフサイクルへ登録します。
-func (s SupervisedRunner) Register(reg Registrar) <span class="cov10" title="20">{
+func (s SupervisedRunner) Register(reg Registrar) <span class="cov8" title="1">{
         // 実行 context は OnStop でのみキャンセルする（OnStart 完了後の startCtx キャンセルに巻き込まれない）。
         runCtx, cancel := context.WithCancel(context.Background())
         done := make(chan struct{})
 
-        reg.RegisterStart(func(_ context.Context) error </span><span class="cov8" title="14">{
-                if s.OnStartAux != nil </span><span class="cov6" title="6">{
+        reg.RegisterStart(func(_ context.Context) error </span><span class="cov8" title="1">{
+                if s.OnStartAux != nil </span><span class="cov8" title="1">{
                         s.OnStartAux()
                 }</span>
-                <span class="cov8" title="14">go func() </span><span class="cov8" title="14">{
+                <span class="cov8" title="1">go func() </span><span class="cov8" title="1">{
                         defer close(done)
-                        if s.Body != nil </span><span class="cov8" title="13">{
+                        if s.Body != nil </span><span class="cov8" title="1">{
                                 s.Body(runCtx)
                         }</span>
                 }()
-                <span class="cov8" title="14">return nil</span>
+                <span class="cov8" title="1">return nil</span>
         })
 
-        <span class="cov10" title="20">reg.RegisterStop(func(stopCtx context.Context) error </span><span class="cov8" title="12">{
+        <span class="cov8" title="1">reg.RegisterStop(func(stopCtx context.Context) error </span><span class="cov8" title="1">{
                 cancel()
                 select </span>{
-                case &lt;-done:<span class="cov8" title="11"></span> // Body 完了（drain 完了）
-                case &lt;-stopCtx.Done():<span class="cov1" title="1"></span> // 猶予切れ
+                case &lt;-done:<span class="cov8" title="1"></span> // Body 完了（drain 完了）
+                case &lt;-stopCtx.Done():<span class="cov8" title="1"></span> // 猶予切れ
                 }
-                <span class="cov8" title="12">if s.OnStopAux != nil </span><span class="cov5" title="5">{
+                <span class="cov8" title="1">if s.OnStopAux != nil </span><span class="cov8" title="1">{
                         s.OnStopAux(stopCtx)
                 }</span>
-                <span class="cov8" title="12">return nil</span>
+                <span class="cov8" title="1">return nil</span>
         })
 }
 </pre>
@@ -8327,7 +8318,7 @@ const callerSkipCount = 1
 // authzModule は、認可（Authorizer）の依存を提供するfx.Moduleです。
 // Authorizer は usecase 層から参照されるため、usecase に依存を供給する
 // InfrastructureModule の一部として提供します。
-func authzModule() fx.Option <span class="cov10" title="27">{
+func authzModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("authz",
                 fx.Provide(
                         provideAuthorizer,
@@ -8338,16 +8329,16 @@ func authzModule() fx.Option <span class="cov10" title="27">{
 // provideAuthorizer は、環境（EnvLocal / EnvCI / EnvTest）に対応した Authorizer を返します。
 // 現状の実装は全許可（allowall）の割り切りであるため、本番相当の環境では誤って全許可を
 // 配線しないようエラーを返し、RBAC / 外部ポリシーエンジン実装への差し替えを強制します。
-func provideAuthorizer(appCfg *config.ApplicationConfig, logger logging.Logger) (authzbd.Authorizer, error) <span class="cov7" title="12">{
+func provideAuthorizer(appCfg *config.ApplicationConfig, logger logging.Logger) (authzbd.Authorizer, error) <span class="cov8" title="1">{
         switch appCfg.Env() </span>{
-        case config.EnvLocal, config.EnvCI, config.EnvTest:<span class="cov7" title="9">
+        case config.EnvLocal, config.EnvCI, config.EnvTest:<span class="cov8" title="1">
                 logger.Named("authz").CallerSkip(callerSkipCount).Warn(
                         "Allow-all authorizer wired: every request is permitted (non-production only)",
                         logging.String("env", appCfg.Env()),
                 )
 
                 return allowall.New(), nil</span>
-        default:<span class="cov4" title="3">
+        default:<span class="cov8" title="1">
                 logger.Named("authz").CallerSkip(callerSkipCount).Error(
                         "No authorizer configured for the current environment",
                         logging.String("env", appCfg.Env()),
@@ -8368,7 +8359,7 @@ import (
 
 // clockModule は、時刻・待機関連の依存を提供するfx.Moduleです。
 // SystemModule() の "system" ラベルとの衝突を避けるため "clock" としています。
-func clockModule() fx.Option <span class="cov10" title="30">{
+func clockModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("clock",
                 fx.Provide(
                         system.NewClock,
@@ -8388,7 +8379,7 @@ import (
 )
 
 // ConfigModule は、アプリケーションの設定をDI用に提供するfx.Moduleです。
-func ConfigModule() fx.Option <span class="cov10" title="33">{
+func ConfigModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("config",
                 fx.Provide(
                         config.SetUpConfig,
@@ -8432,7 +8423,7 @@ import (
 )
 
 // ControllerModule は、コントローラー層の依存関係を提供するfx.Moduleです。
-func ControllerModule() fx.Option <span class="cov10" title="3">{
+func ControllerModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("controller",
                 fx.Invoke(
                         health.BindHandler,
@@ -8472,7 +8463,7 @@ import (
 const callerSkipCount = 1
 
 // AuthnModule は、認証関連の依存関係を提供するfxモジュールを返します。
-func AuthnModule() fx.Option <span class="cov7" title="4">{
+func AuthnModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("core.authn",
                 fx.Provide(
                         provideAuthenticator,
@@ -8483,16 +8474,16 @@ func AuthnModule() fx.Option <span class="cov7" title="4">{
 
 // provideAuthenticator は、環境（EnvLocal / EnvCI / EnvTest）に対応した Authenticator を返します。
 // それ以外の環境ではエラーを返し、FX の起動に失敗します。
-func provideAuthenticator(appCfg *config.ApplicationConfig, logger logging.Logger) (authbd.Authenticator, error) <span class="cov10" title="8">{
+func provideAuthenticator(appCfg *config.ApplicationConfig, logger logging.Logger) (authbd.Authenticator, error) <span class="cov8" title="1">{
         switch appCfg.Env() </span>{
-        case config.EnvLocal, config.EnvCI, config.EnvTest:<span class="cov7" title="5">
+        case config.EnvLocal, config.EnvCI, config.EnvTest:<span class="cov8" title="1">
                 logger.Named("core.authn").CallerSkip(callerSkipCount).Warn(
                         "Local authenticator wired: authentication is stubbed (non-production only)",
                         logging.String("env", appCfg.Env()),
                 )
 
                 return local.New(), nil</span>
-        default:<span class="cov5" title="3">
+        default:<span class="cov8" title="1">
                 logger.Named("core.authn").CallerSkip(callerSkipCount).Error(
                         "No authenticator configured for the current environment",
                         logging.String("env", appCfg.Env()),
@@ -8512,7 +8503,7 @@ import (
 )
 
 // BasicAuthModule は Basic 認証機能を提供する Fx モジュールを返します。
-func BasicAuthModule() fx.Option <span class="cov10" title="4">{
+func BasicAuthModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("core.basicauth",
                 fx.Provide(
                         basicauth.NewBasicAuthValidator,
@@ -8530,7 +8521,7 @@ import (
 )
 
 // SecurityCookieModule は、セキュリティCookieのコア機能部分を提供するfxモジュールを返します。
-func SecurityCookieModule() fx.Option <span class="cov10" title="4">{
+func SecurityCookieModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("core.security_cookie",
                 fx.Provide(
                         cookie.NewSecurityCookie,
@@ -8548,7 +8539,7 @@ import (
 )
 
 // SkipperModule は Oapi ミドルウェアのスキッパー機能を提供する Fx モジュールを返します。
-func SkipperModule() fx.Option <span class="cov10" title="4">{
+func SkipperModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("core.skipper",
                 fx.Provide(
                         skipper.New,
@@ -8569,7 +8560,7 @@ import (
 )
 
 // ValidatorModule は、ルーティング時に自動で解決されるバリデーションのコア機能部分を提供するfxモジュールを返します。
-func ValidatorModule() fx.Option <span class="cov10" title="4">{
+func ValidatorModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("core.validator",
                 fx.Provide(
                         validator.GetValidator,
@@ -8589,7 +8580,7 @@ import (
 )
 
 // DatabaseModule は、データベース関連の依存関係を提供するfx.Moduleです。
-func DatabaseModule() fx.Option <span class="cov10" title="33">{
+func DatabaseModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("db",
                 fx.Provide(
                         driver.NewQueryTracer,
@@ -8624,13 +8615,13 @@ type HTTPClientProfilesIn struct {
 }
 
 // provideHTTPClientRegistry は、グループに集まった Profile から Registry を生成します。
-func provideHTTPClientRegistry(in HTTPClientProfilesIn) httpclient.Registry <span class="cov3" title="3">{
+func provideHTTPClientRegistry(in HTTPClientProfilesIn) httpclient.Registry <span class="cov8" title="1">{
         return httpclient.NewRegistryFromProfiles(in.Profiles)
 }</span>
 
 // httpClientModule は、resilient な外部 HTTP client substrate を提供するfx.Moduleです。
 // httpclient_profiles グループに集まった各 Downstream の Profile を registry がまとめて解決します。
-func httpClientModule() fx.Option <span class="cov9" title="29">{
+func httpClientModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("httpclient",
                 fx.Provide(
                         provideHTTPClientRegistry,
@@ -8641,9 +8632,9 @@ func httpClientModule() fx.Option <span class="cov9" title="29">{
 
 // provideHTTPClientProfiles は、各 Downstream の Profile コンストラクタを httpclient_profiles
 // グループへ登録します（producer 側）。各コンストラクタへの fx.Annotate 重複を排するヘルパーです。
-func provideHTTPClientProfiles(constructors ...any) fx.Option <span class="cov10" title="32">{
+func provideHTTPClientProfiles(constructors ...any) fx.Option <span class="cov8" title="1">{
         opts := make([]fx.Option, len(constructors))
-        for i, c := range constructors </span><span class="cov10" title="32">{
+        for i, c := range constructors </span><span class="cov8" title="1">{
                 opts[i] = fx.Provide(
                         fx.Annotate(
                                 c,
@@ -8651,7 +8642,7 @@ func provideHTTPClientProfiles(constructors ...any) fx.Option <span class="cov10
                         ),
                 )
         }</span>
-        <span class="cov10" title="32">return fx.Options(opts...)</span>
+        <span class="cov8" title="1">return fx.Options(opts...)</span>
 }
 </pre>
 		
@@ -8664,7 +8655,7 @@ import (
 // InfrastructureModule は、全プロセス共通のインフラストラクチャ層の依存関係を集約して提供するfx.Moduleです。
 // 含む concern は永続化 / clock / HTTP client / webapi gateway / security / authz です。
 // outbox publisher は relay 専用のため含めず、OutboxRelayModule 側で提供します。
-func InfrastructureModule() fx.Option <span class="cov10" title="26">{
+func InfrastructureModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("infrastructure",
                 persistenceModule(),
                 clockModule(),
@@ -8690,7 +8681,7 @@ import (
 )
 
 // JobModule は、バックグラウンドジョブ関連の依存関係を提供するfx.Moduleです。
-func JobModule() fx.Option <span class="cov6" title="7">{
+func JobModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("job",
                 provideJobs(
                         // ここにジョブのコンストラクタを追加します。
@@ -8707,9 +8698,9 @@ func JobModule() fx.Option <span class="cov6" title="7">{
 }</span>
 
 // provideJobs は、ジョブのコンストラクタをfxのオプションとして提供します。
-func provideJobs(constructors ...any) fx.Option <span class="cov6" title="8">{
+func provideJobs(constructors ...any) fx.Option <span class="cov8" title="1">{
         opts := make([]fx.Option, len(constructors))
-        for i, c := range constructors </span><span class="cov10" title="23">{
+        for i, c := range constructors </span><span class="cov8" title="1">{
                 opts[i] = fx.Provide(
                         fx.Annotate(
                                 c,
@@ -8717,7 +8708,7 @@ func provideJobs(constructors ...any) fx.Option <span class="cov6" title="8">{
                         ),
                 )
         }</span>
-        <span class="cov6" title="8">return fx.Options(opts...)</span>
+        <span class="cov8" title="1">return fx.Options(opts...)</span>
 }
 </pre>
 		
@@ -8734,7 +8725,7 @@ import (
 )
 
 // LoggingModule は、ロギング関連の依存関係を提供するfx.Moduleです。
-func LoggingModule() fx.Option <span class="cov10" title="33">{
+func LoggingModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("logging",
                 fx.Provide(
                         provideLogger,
@@ -8745,18 +8736,18 @@ func LoggingModule() fx.Option <span class="cov10" title="33">{
 
 // provideLogger は、アプリケーション設定に応じた Logger を生成します。
 // logCore が非 nil のときは、その core を Tee した Logger を返します。
-func provideLogger(appCfg *config.ApplicationConfig, logCore logging.LogCore) (logging.Logger, error) <span class="cov8" title="21">{
+func provideLogger(appCfg *config.ApplicationConfig, logCore logging.LogCore) (logging.Logger, error) <span class="cov8" title="1">{
         level, err := logging.ParseLevel(appCfg.LogLevel())
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(err, fmt.Sprintf("invalid APP_LOG_LEVEL %q", appCfg.LogLevel()))
         }</span>
 
-        <span class="cov8" title="20">switch </span>{
-        case appCfg.IsProductionMode():<span class="cov2" title="2">
+        <span class="cov8" title="1">switch </span>{
+        case appCfg.IsProductionMode():<span class="cov8" title="1">
                 return logging.WithCore(logging.NewJSONLogger(level, logging.LevelError()), logCore), nil</span>
-        case appCfg.IsDevelopmentMode():<span class="cov8" title="17">
+        case appCfg.IsDevelopmentMode():<span class="cov8" title="1">
                 return logging.WithCore(logging.NewConsoleLogger(level, logging.LevelWarn()), logCore), nil</span>
-        default:<span class="cov1" title="1">
+        default:<span class="cov8" title="1">
                 return nil, xerrors.New("unknown app mode: " + appCfg.Mode())</span>
         }
 }
@@ -8773,7 +8764,7 @@ import (
 )
 
 // ObservabilityModule は、オブザーバビリティ（トレーシング / メトリクス / ロギング）関連の依存関係を提供するfx.Moduleです。
-func ObservabilityModule() fx.Option <span class="cov10" title="34">{
+func ObservabilityModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("observability",
                 fx.Provide(
                         observability.NewResource,
@@ -8808,7 +8799,7 @@ import (
 )
 
 // outboxPublisherModule は、transactional outbox の publish 先（HTTP）を提供するfx.Moduleです。
-func outboxPublisherModule() fx.Option <span class="cov10" title="5">{
+func outboxPublisherModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("outbox_publisher",
                 fx.Provide(
                         outboxpublisher.NewEndpoint,
@@ -8837,7 +8828,7 @@ import (
 // relay 専用プロセス（cmd outbox-relay）でのみ使用します。
 // outboxPublisherModule は非標準の httpclient profile（MaxAttempts=1 等）を value group へ寄与するため、
 // relay 以外のプロセスへ漏れないよう共有 InfrastructureModule ではなくここに閉じ込めます。
-func OutboxRelayModule() fx.Option <span class="cov10" title="4">{
+func OutboxRelayModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("outbox-relay",
                 outboxPublisherModule(),
                 fx.Provide(
@@ -8856,13 +8847,13 @@ func OutboxRelayModule() fx.Option <span class="cov10" title="4">{
 
 // provideRelaySettings は、OutboxConfig から relay engine の設定を生成します。
 // BatchSize が 0 以下だとスピンループを招くため DefaultBatchSize へ clamp します。
-func provideRelaySettings(cfg *config.OutboxConfig) outboxengine.Settings <span class="cov10" title="4">{
+func provideRelaySettings(cfg *config.OutboxConfig) outboxengine.Settings <span class="cov8" title="1">{
         batchSize := outboxuc.DefaultBatchSize
-        if cfg.BatchSize() &gt; 0 </span><span class="cov5" title="2">{
+        if cfg.BatchSize() &gt; 0 </span><span class="cov8" title="1">{
                 //nolint:gosec // BatchSize は設定由来の小さな正整数であり int32 に収まる
                 batchSize = int32(cfg.BatchSize())
         }</span>
-        <span class="cov10" title="4">return outboxengine.Settings{
+        <span class="cov8" title="1">return outboxengine.Settings{
                 BatchSize:    batchSize,
                 PollInterval: cfg.PollInterval(),
                 ErrorBackoff: cfg.ErrorBackoff(),
@@ -8886,7 +8877,7 @@ import (
 // persistenceModule は、RDB を背後に持つ永続化系の依存（repository / query_service /
 // command_service / system_query）を提供するfx.Moduleです。DatabaseModule() の db 接続層
 // とは区別され、その上に載るデータアクセス実装をまとめます。
-func persistenceModule() fx.Option <span class="cov10" title="27">{
+func persistenceModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("persistence",
                 fx.Module("repository",
                         fx.Provide(
@@ -8932,7 +8923,7 @@ import (
 )
 
 // securityModule は、パスワードハッシュ化などのセキュリティ関連の依存を提供するfx.Moduleです。
-func securityModule() fx.Option <span class="cov10" title="27">{
+func securityModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("security",
                 fx.Provide(
                         security.NewBcryptHasher,
@@ -8950,7 +8941,7 @@ import (
 )
 
 // SystemModule は、システム情報関連の依存関係を提供するfx.Moduleです。
-func SystemModule() fx.Option <span class="cov10" title="33">{
+func SystemModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("system",
                 fx.Provide(
                         system.NewBuildInfo,
@@ -8974,7 +8965,7 @@ import (
 )
 
 // UsecaseModule は、ユースケース層の依存関係を提供するfx.Moduleです。
-func UsecaseModule() fx.Option <span class="cov10" title="25">{
+func UsecaseModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("usecase",
                 fx.Provide(
                         healthcheck.New,
@@ -9009,7 +9000,7 @@ import (
 )
 
 // webapiModule は、外部 Web API クライアント（gateway）を提供するfx.Moduleです。
-func webapiModule() fx.Option <span class="cov10" title="27">{
+func webapiModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("webapi",
                 fx.Provide(
                         // サンプルの外部サービス gateway（DTO モード）
@@ -9044,7 +9035,7 @@ type queueStatsTargetsIn struct {
 
 // WorkerModule は、worker engine 関連の依存関係を提供する fx.Module です。
 // 既定では worker を 1 つも登録しません。
-func WorkerModule() fx.Option <span class="cov9" title="8">{
+func WorkerModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("worker",
                 provideWorkers(
                 // ここに worker のコンストラクタを追加します（例: &lt;pkg&gt;.New）。
@@ -9071,14 +9062,14 @@ func WorkerModule() fx.Option <span class="cov9" title="8">{
 
 // provideQueueStatsCollector は、収集対象から queue depth / DLQ 収集器を生成します。
 // 対象が 1 つも無い場合は、何も出力しない収集器になります。
-func provideQueueStatsCollector(in queueStatsTargetsIn) *queuemetrics.StatsCollector <span class="cov8" title="6">{
+func provideQueueStatsCollector(in queueStatsTargetsIn) *queuemetrics.StatsCollector <span class="cov8" title="1">{
         return queuemetrics.NewStatsCollector(in.Targets)
 }</span>
 
 // provideQueueStatsTargets は、QueueStatsTarget のコンストラクタ群を group へ登録します。
-func provideQueueStatsTargets(constructors ...any) fx.Option <span class="cov10" title="9">{
+func provideQueueStatsTargets(constructors ...any) fx.Option <span class="cov8" title="1">{
         opts := make([]fx.Option, len(constructors))
-        for i, c := range constructors </span><span class="cov1" title="1">{
+        for i, c := range constructors </span><span class="cov8" title="1">{
                 opts[i] = fx.Provide(
                         fx.Annotate(
                                 c,
@@ -9086,13 +9077,13 @@ func provideQueueStatsTargets(constructors ...any) fx.Option <span class="cov10"
                         ),
                 )
         }</span>
-        <span class="cov10" title="9">return fx.Options(opts...)</span>
+        <span class="cov8" title="1">return fx.Options(opts...)</span>
 }
 
 // provideWorkers は、worker のコンストラクタ群を worker グループへ登録します。
-func provideWorkers(constructors ...any) fx.Option <span class="cov10" title="9">{
+func provideWorkers(constructors ...any) fx.Option <span class="cov8" title="1">{
         opts := make([]fx.Option, len(constructors))
-        for i, c := range constructors </span><span class="cov1" title="1">{
+        for i, c := range constructors </span><span class="cov8" title="1">{
                 opts[i] = fx.Provide(
                         fx.Annotate(
                                 c,
@@ -9100,7 +9091,7 @@ func provideWorkers(constructors ...any) fx.Option <span class="cov10" title="9"
                         ),
                 )
         }</span>
-        <span class="cov10" title="9">return fx.Options(opts...)</span>
+        <span class="cov8" title="1">return fx.Options(opts...)</span>
 }
 </pre>
 		
@@ -9121,7 +9112,7 @@ import (
 )
 
 // outboxRelayCommonOptions は、relay / replay が共有する共通モジュール群を返します。
-func outboxRelayCommonOptions() []fx.Option <span class="cov10" title="5">{
+func outboxRelayCommonOptions() []fx.Option <span class="cov8" title="1">{
         return []fx.Option{
                 lifecycle.Module(),
                 module.ConfigModule(),
@@ -9135,21 +9126,21 @@ func outboxRelayCommonOptions() []fx.Option <span class="cov10" title="5">{
 }</span>
 
 // NewOutboxRelayCore は、relay 常駐プロセス用の fx.App を構成する fx.Option を返します。
-func NewOutboxRelayCore() fx.Option <span class="cov7" title="3">{
+func NewOutboxRelayCore() fx.Option <span class="cov8" title="1">{
         return fx.Options(append(outboxRelayCommonOptions(), module.OutboxRelayModule())...)
 }</span>
 
 // NewOutboxRelayApp は、relay 常駐プロセス用の fx.App を生成します。
 // grace（APP_SHUTDOWN_TIMEOUT）を fx.StopTimeout に設定し、fx 既定（15s）が停止猶予より
 // 先に teardown を打ち切らないようにします（停止軸を grace に一本化）。
-func NewOutboxRelayApp(grace time.Duration) *fx.App <span class="cov4" title="2">{
+func NewOutboxRelayApp(grace time.Duration) *fx.App <span class="cov8" title="1">{
         return fx.New(NewOutboxRelayCore(), fx.StopTimeout(grace), fx.WithLogger(NewFxEventLogger))
 }</span>
 
 // RunOutboxReplay は、dead 状態の outbox 行を pending へ戻すワンショット実行を行い、
 // 書き換えた行数と発生したエラーを返します。messageID が nil の場合は全 dead 行を対象とします。
 // 停止処理のエラーは runErr と errors.Join で結合して返します。
-func RunOutboxReplay(ctx context.Context, messageID *uuid.UUID) (int64, error) <span class="cov4" title="2">{
+func RunOutboxReplay(ctx context.Context, messageID *uuid.UUID) (int64, error) <span class="cov8" title="1">{
         var (
                 replay outboxuc.ReplayUsecase
                 appCfg *config.ApplicationConfig
@@ -9159,11 +9150,11 @@ func RunOutboxReplay(ctx context.Context, messageID *uuid.UUID) (int64, error) <
                 fx.Populate(&amp;replay, &amp;appCfg), fx.WithLogger(NewFxEventLogger))
         app := fx.New(opts...)
 
-        if err := app.Start(ctx); err != nil </span><span class="cov1" title="1">{
+        if err := app.Start(ctx); err != nil </span><span class="cov8" title="1">{
                 return 0, err
         }</span>
 
-        <span class="cov1" title="1">result, runErr := replay.ReplayDead(ctx, messageID)
+        <span class="cov8" title="1">result, runErr := replay.ReplayDead(ctx, messageID)
 
         // 停止猶予は APP_SHUTDOWN_TIMEOUT に一本化（独立した magic number を持たない）。
         stopCtx, cancel := context.WithTimeout(context.Background(), appCfg.ShutdownTimeout())
@@ -9188,9 +9179,9 @@ import (
 // RegisterRelayHooks は、relay engine の poll ループを fx ライフサイクルに結線します。
 //   - OnStart: poll ループを detached goroutine で起動する（OnStart はブロックしない）。
 //   - OnStop:  engine の context をキャンセルしてループの終了を（stopCtx の範囲で）待つ。
-func RegisterRelayHooks(reg lifecycle.Registrar, engine *outboxengine.Engine) <span class="cov10" title="2">{
+func RegisterRelayHooks(reg lifecycle.Registrar, engine *outboxengine.Engine) <span class="cov8" title="1">{
         lifecycle.SupervisedRunner{
-                Body: func(ctx context.Context) </span><span class="cov1" title="1">{ _ = engine.Run(ctx) }</span>,
+                Body: func(ctx context.Context) </span><span class="cov8" title="1">{ _ = engine.Run(ctx) }</span>,
         }.Register(reg)
 }
 </pre>
@@ -9210,20 +9201,20 @@ import (
 )
 
 // NewApplicationServer は、組み立て済みの fx.App を受け取り、その起動／停止を行う lifecycle 関数（start, stop）を返します。
-func NewApplicationServer(app *fx.App) (func(context.Context) error, func(context.Context) error) <span class="cov10" title="2">{
-        start := func(ctx context.Context) error </span><span class="cov10" title="2">{
+func NewApplicationServer(app *fx.App) (func(context.Context) error, func(context.Context) error) <span class="cov8" title="1">{
+        start := func(ctx context.Context) error </span><span class="cov8" title="1">{
                 return app.Start(ctx)
         }</span>
 
-        <span class="cov10" title="2">stop := func(ctx context.Context) error </span><span class="cov10" title="2">{
+        <span class="cov8" title="1">stop := func(ctx context.Context) error </span><span class="cov8" title="1">{
                 return app.Stop(ctx)
         }</span>
 
-        <span class="cov10" title="2">return start, stop</span>
+        <span class="cov8" title="1">return start, stop</span>
 }
 
 // applicationCoreOptions は、アプリケーションコアを構成する fx.Option 群を返します。
-func applicationCoreOptions() []fx.Option <span class="cov10" title="2">{
+func applicationCoreOptions() []fx.Option <span class="cov8" title="1">{
         return []fx.Option{
                 // Lifecycle Module
                 lifecycle.Module(),
@@ -9253,7 +9244,7 @@ func applicationCoreOptions() []fx.Option <span class="cov10" title="2">{
 
 // NewApplicationCore は、アプリケーションの fx.App インスタンスを作成します。
 // extra はテスト時に依存を差し替える（fx.Replace / fx.Decorate）ための seam で、本番呼び出しでは渡しません。
-func NewApplicationCore(extra ...fx.Option) *fx.App <span class="cov1" title="1">{
+func NewApplicationCore(extra ...fx.Option) *fx.App <span class="cov8" title="1">{
         opts := append(applicationCoreOptions(), fx.WithLogger(NewFxEventLogger))
         return fx.New(append(opts, extra...)...)
 }</span>
@@ -9345,54 +9336,54 @@ type middlewareEntry struct {
 
 // ApplyExtends は、サーバー拡張を適用します。
 // ApplyExtends は、Pre・Use ミドルウェアおよびサーバー設定関数を Priority 昇順に Echo へ適用する。同一 kind 内で Priority が重複するミドルウェアが存在する場合はエラーを返す。
-func ApplyExtends(e *echo.Echo, logger logging.Logger, extends ServerExtends) (*AppliedServerExtends, error) <span class="cov4" title="4">{
-        if err := ApplyPreMiddlewares(e, logger, extends.PreList); err != nil </span><span class="cov1" title="1">{
+func ApplyExtends(e *echo.Echo, logger logging.Logger, extends ServerExtends) (*AppliedServerExtends, error) <span class="cov8" title="1">{
+        if err := ApplyPreMiddlewares(e, logger, extends.PreList); err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov3" title="3">if err := ApplyUseMiddlewares(e, logger, extends.UseList); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err := ApplyUseMiddlewares(e, logger, extends.UseList); err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov2" title="2">ApplyConfigurators(e, logger, extends.CfgList)
+        <span class="cov8" title="1">ApplyConfigurators(e, logger, extends.CfgList)
         return &amp;AppliedServerExtends{}, nil</span>
 }
 
 // ApplyPreMiddlewares は、Echoに対してPreのミドルウェアを適用します。
 // ApplyPreMiddlewares は、mws を Priority 昇順に Echo.Pre として適用する。Priority が重複するエントリが存在する場合はエラーを返す。
-func ApplyPreMiddlewares(e *echo.Echo, logger logging.Logger, mws []PreMiddleware) error <span class="cov5" title="7">{
+func ApplyPreMiddlewares(e *echo.Echo, logger logging.Logger, mws []PreMiddleware) error <span class="cov8" title="1">{
         entries := make([]middlewareEntry, len(mws))
-        for i, mw := range mws </span><span class="cov6" title="10">{
+        for i, mw := range mws </span><span class="cov8" title="1">{
                 entries[i] = middlewareEntry{name: mw.Name, priority: mw.Priority, middleware: mw.Middleware}
         }</span>
-        <span class="cov5" title="7">return applyMiddlewares(logger, "pre", entries, e.Pre)</span>
+        <span class="cov8" title="1">return applyMiddlewares(logger, "pre", entries, e.Pre)</span>
 }
 
 // ApplyUseMiddlewares は、Echoに対してUseのミドルウェアを適用します。
 // ApplyUseMiddlewares は、mws を Priority 昇順に Echo.Use として適用する。Priority が重複するエントリが存在する場合はエラーを返す。
-func ApplyUseMiddlewares(e *echo.Echo, logger logging.Logger, mws []UseMiddleware) error <span class="cov5" title="6">{
+func ApplyUseMiddlewares(e *echo.Echo, logger logging.Logger, mws []UseMiddleware) error <span class="cov8" title="1">{
         entries := make([]middlewareEntry, len(mws))
-        for i, mw := range mws </span><span class="cov7" title="17">{
+        for i, mw := range mws </span><span class="cov8" title="1">{
                 entries[i] = middlewareEntry{name: mw.Name, priority: mw.Priority, middleware: mw.Middleware}
         }</span>
-        <span class="cov5" title="6">return applyMiddlewares(logger, "use", entries, e.Use)</span>
+        <span class="cov8" title="1">return applyMiddlewares(logger, "use", entries, e.Use)</span>
 }
 
 // applyMiddlewares は、kind 種別のミドルウェアを優先度順に apply で適用します。
-func applyMiddlewares(logger logging.Logger, kind string, mws []middlewareEntry, apply func(...echo.MiddlewareFunc)) error <span class="cov7" title="13">{
-        if err := validatePriorityConflicts(kind, mws); err != nil </span><span class="cov4" title="4">{
+func applyMiddlewares(logger logging.Logger, kind string, mws []middlewareEntry, apply func(...echo.MiddlewareFunc)) error <span class="cov8" title="1">{
+        if err := validatePriorityConflicts(kind, mws); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov6" title="9">log := logger.Named("ApplyMiddlewares").CallerSkip(callerSkip)
+        <span class="cov8" title="1">log := logger.Named("ApplyMiddlewares").CallerSkip(callerSkip)
         log.Info(
                 fmt.Sprintf("Applying %s middleware", kind),
                 logging.Int("count", len(mws)),
         )
 
-        sort.Slice(mws, func(i, j int) bool </span><span class="cov9" title="32">{
+        sort.Slice(mws, func(i, j int) bool </span><span class="cov8" title="1">{
                 return mws[i].priority &lt; mws[j].priority
         }</span>)
 
-        <span class="cov6" title="9">for _, mw := range mws </span><span class="cov8" title="19">{
+        <span class="cov8" title="1">for _, mw := range mws </span><span class="cov8" title="1">{
                 log.Info(
                         fmt.Sprintf("Applying %s middleware", kind),
                         logging.Int("priority", mw.priority),
@@ -9400,56 +9391,56 @@ func applyMiddlewares(logger logging.Logger, kind string, mws []middlewareEntry,
                 )
                 apply(mw.middleware)
         }</span>
-        <span class="cov6" title="9">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // validatePriorityConflicts は、kind 種別のミドルウェアに Priority の重複がないか検証します。
-func validatePriorityConflicts(kind string, mws []middlewareEntry) error <span class="cov7" title="17">{
+func validatePriorityConflicts(kind string, mws []middlewareEntry) error <span class="cov8" title="1">{
         byPriority := make(map[int][]string)
 
-        for _, mw := range mws </span><span class="cov9" title="37">{
+        for _, mw := range mws </span><span class="cov8" title="1">{
                 byPriority[mw.priority] = append(byPriority[mw.priority], mw.name)
         }</span>
 
-        <span class="cov7" title="17">conflicts := extractPriorityConflicts(byPriority)
+        <span class="cov8" title="1">conflicts := extractPriorityConflicts(byPriority)
 
-        if len(conflicts) &gt; 0 </span><span class="cov5" title="7">{
+        if len(conflicts) &gt; 0 </span><span class="cov8" title="1">{
                 return xerrors.New(fmt.Sprintf("duplicate %s middleware priorities: %s",
                         kind, strings.Join(conflicts, "; "),
                 ))
         }</span>
 
-        <span class="cov6" title="10">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // extractPriorityConflicts は、priority ごとに名前が重複しているものを抽出して返します。
 // 戻り値は priority 昇順の conflict 表現の文字列スライス。
-func extractPriorityConflicts(byPriority map[int][]string) []string <span class="cov8" title="21">{
+func extractPriorityConflicts(byPriority map[int][]string) []string <span class="cov8" title="1">{
         priorities := make([]int, 0, len(byPriority))
-        for p := range byPriority </span><span class="cov10" title="39">{
+        for p := range byPriority </span><span class="cov8" title="1">{
                 priorities = append(priorities, p)
         }</span>
-        <span class="cov8" title="21">sort.Ints(priorities)
+        <span class="cov8" title="1">sort.Ints(priorities)
 
         var conflicts []string
-        for _, p := range priorities </span><span class="cov10" title="39">{
+        for _, p := range priorities </span><span class="cov8" title="1">{
                 names := byPriority[p]
-                if len(names) &gt; 1 </span><span class="cov6" title="11">{
+                if len(names) &gt; 1 </span><span class="cov8" title="1">{
                         conflicts = append(conflicts,
                                 fmt.Sprintf("priority=%d: %v", p, names),
                         )
                 }</span>
         }
-        <span class="cov8" title="21">return conflicts</span>
+        <span class="cov8" title="1">return conflicts</span>
 }
 
 // ApplyConfigurators は、Echoに対して設定関数を適用します。
-func ApplyConfigurators(e *echo.Echo, logger logging.Logger, cfgs []SrvCfg) <span class="cov4" title="4">{
+func ApplyConfigurators(e *echo.Echo, logger logging.Logger, cfgs []SrvCfg) <span class="cov8" title="1">{
         logger.Named("ApplyConfigurators").CallerSkip(callerSkip).Info(
                 "Applying server configurator",
                 logging.Int("count", len(cfgs)),
         )
-        for _, cfg := range cfgs </span><span class="cov4" title="5">{
+        for _, cfg := range cfgs </span><span class="cov8" title="1">{
                 cfg(e)
         }</span>
 }
@@ -9472,7 +9463,7 @@ import (
 const bodyLimitPrePriority = 3
 
 // BodyLimitModule は、リクエストボディ上限のミドルウェアを提供する fx モジュールを返します。
-func BodyLimitModule() fx.Option <span class="cov10" title="6">{
+func BodyLimitModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("mw.bodylimit",
                 fx.Provide(
                         BodyLimitPreMiddleware,
@@ -9482,7 +9473,7 @@ func BodyLimitModule() fx.Option <span class="cov10" title="6">{
 
 // BodyLimitPreMiddleware は、SERVER_BODY_LIMIT_MB を上限とする body limit ミドルウェアを
 // Pre ミドルウェアとして提供します。
-func BodyLimitPreMiddleware(srvCfg *config.ServerConfig) extension.PreMiddlewareOut <span class="cov6" title="3">{
+func BodyLimitPreMiddleware(srvCfg *config.ServerConfig) extension.PreMiddlewareOut <span class="cov8" title="1">{
         return extension.PreMiddlewareOut{
                 Middleware: extension.PreMiddleware{
                         Name:       "bodyLimit",
@@ -9505,7 +9496,7 @@ import (
 )
 
 // IPExtractorModule は、IP Extractor モジュールを提供します。
-func IPExtractorModule() fx.Option <span class="cov10" title="6">{
+func IPExtractorModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("server.ipextractor",
                 fx.Provide(
                         provideIPExtractorServeConfig,
@@ -9516,9 +9507,9 @@ func IPExtractorModule() fx.Option <span class="cov10" title="6">{
 // provideIPExtractorServeConfig は、IP Extractor のサーバー設定を提供します。
 func provideIPExtractorServeConfig(
         appCfg *config.ApplicationConfig, secCfg *config.SecurityConfig,
-) extension.ServeCfgOut <span class="cov7" title="4">{
+) extension.ServeCfgOut <span class="cov8" title="1">{
         return extension.ServeCfgOut{
-                SrvCfg: func(e *echo.Echo) </span><span class="cov6" title="3">{
+                SrvCfg: func(e *echo.Echo) </span><span class="cov8" title="1">{
                         ipextractor.New(e, appCfg, secCfg)
                 }</span>,
         }
@@ -9542,7 +9533,7 @@ import (
 const openapiUsePriority = 6
 
 // OpenAPIModule は、OpenAPIバリデーションのミドルウェアを提供するfxモジュールを返します。
-func OpenAPIModule() fx.Option <span class="cov10" title="6">{
+func OpenAPIModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("mw.openapi",
                 fx.Provide(
                         OpenAPIMiddleware,
@@ -9555,7 +9546,7 @@ func OpenAPIMiddleware(
         spec *openapi3.T,
         skipper echomw.Skipper,
         authFunc openapi3filter.AuthenticationFunc,
-) extension.UseMiddlewareOut <span class="cov6" title="3">{
+) extension.UseMiddlewareOut <span class="cov8" title="1">{
         return extension.UseMiddlewareOut{
                 Middleware: extension.UseMiddleware{
                         Name:       "openapi",
@@ -9582,7 +9573,7 @@ import (
 const timeoutPrePriority = 2
 
 // TimeoutModule は、リクエスト deadline budget のミドルウェアを提供する fx モジュールを返します。
-func TimeoutModule() fx.Option <span class="cov10" title="6">{
+func TimeoutModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("mw.timeout",
                 fx.Provide(
                         TimeoutPreMiddleware,
@@ -9592,7 +9583,7 @@ func TimeoutModule() fx.Option <span class="cov10" title="6">{
 
 // TimeoutPreMiddleware は、SERVER_REQUEST_TIMEOUT を deadline budget とする
 // timeout ミドルウェアを Pre ミドルウェアとして提供します。
-func TimeoutPreMiddleware(srvCfg *config.ServerConfig) extension.PreMiddlewareOut <span class="cov6" title="3">{
+func TimeoutPreMiddleware(srvCfg *config.ServerConfig) extension.PreMiddlewareOut <span class="cov8" title="1">{
         return extension.PreMiddlewareOut{
                 Middleware: extension.PreMiddleware{
                         Name:       "timeout",
@@ -9615,7 +9606,7 @@ import (
 const uriPrePriority = 1
 
 // URIModule は、URI制御のミドルウェアを提供するfxモジュールを返します。
-func URIModule() fx.Option <span class="cov10" title="6">{
+func URIModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("mw.uri",
                 fx.Provide(
                         URIPreMiddleware,
@@ -9624,7 +9615,7 @@ func URIModule() fx.Option <span class="cov10" title="6">{
 }</span>
 
 // URIPreMiddleware は、URI 末尾スラッシュ除去ミドルウェアを Pre ミドルウェアとして提供します。
-func URIPreMiddleware() extension.PreMiddlewareOut <span class="cov6" title="3">{
+func URIPreMiddleware() extension.PreMiddlewareOut <span class="cov8" title="1">{
         return extension.PreMiddlewareOut{
                 Middleware: extension.PreMiddleware{
                         Name:       "uri",
@@ -9652,7 +9643,7 @@ import (
 const httpREDMetricsPriority = 8
 
 // HTTPRedMetricsModule は、HTTP RED（Rate / Errors / Duration）メトリクスのミドルウェアを提供するfxモジュールを返します。
-func HTTPRedMetricsModule() fx.Option <span class="cov10" title="6">{
+func HTTPRedMetricsModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("mw.httpredmetrics",
                 fx.Provide(
                         redmetrics.NewPrometheusRecorder,
@@ -9666,12 +9657,12 @@ func HTTPRedMetricsModule() fx.Option <span class="cov10" title="6">{
 }</span>
 
 // newHTTPRedMetricsRecorder は、PrometheusRecorder を Recorder インターフェースとして提供します。
-func newHTTPRedMetricsRecorder(r *redmetrics.PrometheusRecorder) redmetrics.Recorder <span class="cov6" title="3">{
+func newHTTPRedMetricsRecorder(r *redmetrics.PrometheusRecorder) redmetrics.Recorder <span class="cov8" title="1">{
         return r
 }</span>
 
 // HTTPRedMetricsMiddleware は、HTTP RED メトリクスを計測するミドルウェアを提供します。
-func HTTPRedMetricsMiddleware(rec redmetrics.Recorder) extension.UseMiddlewareOut <span class="cov6" title="3">{
+func HTTPRedMetricsMiddleware(rec redmetrics.Recorder) extension.UseMiddlewareOut <span class="cov8" title="1">{
         return extension.UseMiddlewareOut{
                 Middleware: extension.UseMiddleware{
                         Name:       "httpredmetrics",
@@ -9699,7 +9690,7 @@ import (
 const loggingPriority = 9
 
 // LoggingModule は、ロギング制御のミドルウェアを提供するfxモジュールを返します。
-func LoggingModule() fx.Option <span class="cov10" title="6">{
+func LoggingModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("mw.logging",
                 fx.Provide(
                         LoggingMiddleware,
@@ -9708,7 +9699,7 @@ func LoggingModule() fx.Option <span class="cov10" title="6">{
 }</span>
 
 // LoggingMiddleware は、HTTPリクエスト／レスポンスのアクセスログを出力するミドルウェアを提供します（OTel トレースコンテキストの TraceID・SpanID を含む）。
-func LoggingMiddleware(z logging.Logger, lf logging.LogFieldBuilder) extension.UseMiddlewareOut <span class="cov6" title="3">{
+func LoggingMiddleware(z logging.Logger, lf logging.LogFieldBuilder) extension.UseMiddlewareOut <span class="cov8" title="1">{
         return extension.UseMiddlewareOut{
                 Middleware: extension.UseMiddleware{
                         Name:       "logging",
@@ -9732,7 +9723,7 @@ import (
 const observabilityPriority = 2
 
 // ObservabilityModule は、可観測性のミドルウェアを提供するfxモジュールを返します。
-func ObservabilityModule() fx.Option <span class="cov10" title="6">{
+func ObservabilityModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("mw.observability",
                 fx.Provide(
                         ObservabilityMiddleware,
@@ -9743,13 +9734,13 @@ func ObservabilityModule() fx.Option <span class="cov10" title="6">{
 // ObservabilityMiddleware は、可観測性ミドルウェアを提供します。トレースが無効なら素通しミドルウェアを返します。
 func ObservabilityMiddleware(
         appCfg *config.ApplicationConfig, obsCfg *config.ObservabilityConfig,
-) extension.UseMiddlewareOut <span class="cov7" title="4">{
+) extension.UseMiddlewareOut <span class="cov8" title="1">{
         mw := observability.PassthroughMiddleware()
-        if obsCfg.TracesEnabled() </span><span class="cov4" title="2">{
+        if obsCfg.TracesEnabled() </span><span class="cov8" title="1">{
                 mw = observability.Middleware(appCfg.Name())
         }</span>
 
-        <span class="cov7" title="4">return extension.UseMiddlewareOut{
+        <span class="cov8" title="1">return extension.UseMiddlewareOut{
                 Middleware: extension.UseMiddleware{
                         Name:       "observability",
                         Priority:   observabilityPriority,
@@ -9771,7 +9762,7 @@ import (
 const requestIDPriority = 1
 
 // RequestIDModule は、リクエストID制御のミドルウェアを提供するfxモジュールを返します。
-func RequestIDModule() fx.Option <span class="cov10" title="6">{
+func RequestIDModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("mw.requestid",
                 fx.Provide(
                         RequestIDMiddleware,
@@ -9780,7 +9771,7 @@ func RequestIDModule() fx.Option <span class="cov10" title="6">{
 }</span>
 
 // RequestIDMiddleware は、リクエストIDの生成ミドルウェアを提供します。
-func RequestIDMiddleware() extension.UseMiddlewareOut <span class="cov6" title="3">{
+func RequestIDMiddleware() extension.UseMiddlewareOut <span class="cov8" title="1">{
         return extension.UseMiddlewareOut{
                 Middleware: extension.UseMiddleware{
                         Name:       "requestid",
@@ -9804,7 +9795,7 @@ import (
 )
 
 // DebugModeModule は、デバッグモードを制御するためのモジュールです。
-func DebugModeModule() fx.Option <span class="cov10" title="6">{
+func DebugModeModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("server.debugmode",
                 fx.Provide(
                         provideDebugModeServeConfig,
@@ -9813,9 +9804,9 @@ func DebugModeModule() fx.Option <span class="cov10" title="6">{
 }</span>
 
 // provideDebugModeServeConfig は、デバッグモードのサーバー設定を提供します。
-func provideDebugModeServeConfig(appCfg *config.ApplicationConfig) extension.ServeCfgOut <span class="cov7" title="4">{
+func provideDebugModeServeConfig(appCfg *config.ApplicationConfig) extension.ServeCfgOut <span class="cov8" title="1">{
         return extension.ServeCfgOut{
-                SrvCfg: func(e *echo.Echo) </span><span class="cov6" title="3">{
+                SrvCfg: func(e *echo.Echo) </span><span class="cov8" title="1">{
                         debugmode.New(e, appCfg)
                 }</span>,
         }
@@ -9836,7 +9827,7 @@ import (
 )
 
 // ErrorHandlerModule は、Error Handler モジュールを提供します。
-func ErrorHandlerModule() fx.Option <span class="cov10" title="6">{
+func ErrorHandlerModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("server.errorhandler",
                 fx.Provide(
                         provideErrorHandlerServeConfig,
@@ -9847,9 +9838,9 @@ func ErrorHandlerModule() fx.Option <span class="cov10" title="6">{
 // provideErrorHandlerServeConfig は、Error Handler のサーバー設定を提供します。
 func provideErrorHandlerServeConfig(
         log logging.Logger, lf logging.LogFieldBuilder, obsCfg *config.ObservabilityConfig,
-) extension.ServeCfgOut <span class="cov6" title="3">{
+) extension.ServeCfgOut <span class="cov8" title="1">{
         return extension.ServeCfgOut{
-                SrvCfg: func(e *echo.Echo) </span><span class="cov4" title="2">{
+                SrvCfg: func(e *echo.Echo) </span><span class="cov8" title="1">{
                         errorhandler.New(e, log, lf, obsCfg)
                 }</span>,
         }
@@ -9868,7 +9859,7 @@ import (
 const forceJSONPriority = 7
 
 // ForceJSONModule は、レスポンスの Content-Type を application/json に強制するミドルウェアを提供するfxモジュールを返します。
-func ForceJSONModule() fx.Option <span class="cov10" title="6">{
+func ForceJSONModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("mw.forcejson",
                 fx.Provide(
                         ForceJSONMiddleware,
@@ -9877,7 +9868,7 @@ func ForceJSONModule() fx.Option <span class="cov10" title="6">{
 }</span>
 
 // ForceJSONMiddleware は、Content-Type を application/json に強制するミドルウェアを提供します。
-func ForceJSONMiddleware() extension.UseMiddlewareOut <span class="cov6" title="3">{
+func ForceJSONMiddleware() extension.UseMiddlewareOut <span class="cov8" title="1">{
         return extension.UseMiddlewareOut{
                 Middleware: extension.UseMiddleware{
                         Name:       "forcejson",
@@ -9902,7 +9893,7 @@ import (
 const recoveryPriority = 3
 
 // RecoveryModule は、リカバリ制御のミドルウェアを提供するfxモジュールを返します。
-func RecoveryModule() fx.Option <span class="cov10" title="6">{
+func RecoveryModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("mw.recovery",
                 fx.Provide(
                         RecoveryMiddleware,
@@ -9913,7 +9904,7 @@ func RecoveryModule() fx.Option <span class="cov10" title="6">{
 // RecoveryMiddleware は、リカバリ制御ミドルウェアを提供します。
 func RecoveryMiddleware(
         logger logging.Logger, lf logging.LogFieldBuilder, appCfg *config.ApplicationConfig,
-) extension.UseMiddlewareOut <span class="cov6" title="3">{
+) extension.UseMiddlewareOut <span class="cov8" title="1">{
         return extension.UseMiddlewareOut{
                 Middleware: extension.UseMiddleware{
                         Name:       "recovery",
@@ -9936,7 +9927,7 @@ import (
 const cookiePriority = 10
 
 // CookieModule は、Cookie制御のミドルウェアを提供するfxモジュールを返します。
-func CookieModule() fx.Option <span class="cov10" title="6">{
+func CookieModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("mw.secure_cookie",
                 fx.Provide(
                         CookieMiddleware,
@@ -9945,7 +9936,7 @@ func CookieModule() fx.Option <span class="cov10" title="6">{
 }</span>
 
 // CookieMiddleware は、セキュアCookieのミドルウェアを提供します。
-func CookieMiddleware(secCookie *cookie.SecurityCookie) extension.UseMiddlewareOut <span class="cov6" title="3">{
+func CookieMiddleware(secCookie *cookie.SecurityCookie) extension.UseMiddlewareOut <span class="cov8" title="1">{
         return extension.UseMiddlewareOut{
                 Middleware: extension.UseMiddleware{
                         Name:       "secure_cookie",
@@ -9969,7 +9960,7 @@ import (
 const corsPriority = 4
 
 // CORSModule は、CORS制御のミドルウェアを提供するfxモジュールを返します。
-func CORSModule() fx.Option <span class="cov10" title="6">{
+func CORSModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("mw.cors",
                 fx.Provide(
                         CORSMiddleware,
@@ -9978,7 +9969,7 @@ func CORSModule() fx.Option <span class="cov10" title="6">{
 }</span>
 
 // CORSMiddleware は、CORS制御のミドルウェアを生成します。
-func CORSMiddleware(secCfg *config.SecurityConfig) extension.UseMiddlewareOut <span class="cov6" title="3">{
+func CORSMiddleware(secCfg *config.SecurityConfig) extension.UseMiddlewareOut <span class="cov8" title="1">{
         return extension.UseMiddlewareOut{
                 Middleware: extension.UseMiddleware{
                         Name:       "cors",
@@ -10003,7 +9994,7 @@ import (
 const securityPriority = 5
 
 // Module は、セキュリティ制御のミドルウェアを提供するfxモジュールを返します。
-func Module() fx.Option <span class="cov10" title="6">{
+func Module() fx.Option <span class="cov8" title="1">{
         return fx.Module("mw.security",
                 fx.Provide(
                         Middleware,
@@ -10012,7 +10003,7 @@ func Module() fx.Option <span class="cov10" title="6">{
 }</span>
 
 // Middleware は、セキュリティミドルウェアを提供します。
-func Middleware(secCfg *config.SecurityConfig) extension.UseMiddlewareOut <span class="cov6" title="3">{
+func Middleware(secCfg *config.SecurityConfig) extension.UseMiddlewareOut <span class="cov8" title="1">{
         return extension.UseMiddlewareOut{
                 Middleware: extension.UseMiddleware{
                         Name:       "security",
@@ -10035,7 +10026,7 @@ import (
 )
 
 // RequireProvidesOne は、与えたモジュール群が指定 group に要素をちょうど1件 provide することを検証する。
-func RequireProvidesOne[T any](t *testing.T, group string, opts ...fx.Option) <span class="cov10" title="16">{
+func RequireProvidesOne[T any](t *testing.T, group string, opts ...fx.Option) <span class="cov8" title="1">{
         t.Helper()
 
         var got []T
@@ -10045,9 +10036,9 @@ func RequireProvidesOne[T any](t *testing.T, group string, opts ...fx.Option) <s
         )...)
 
         require.NoError(t, app.Start(context.Background()))
-        defer func() </span><span class="cov10" title="16">{ require.NoError(t, app.Stop(context.Background())) }</span>()
+        defer func() </span><span class="cov8" title="1">{ require.NoError(t, app.Stop(context.Background())) }</span>()
 
-        <span class="cov10" title="16">require.Len(t, got, 1)</span>
+        <span class="cov8" title="1">require.Len(t, got, 1)</span>
 }
 </pre>
 		
@@ -10066,15 +10057,15 @@ func RegisterDBCloseHooks(
         reg lifecycle.Registrar,
         db driver.DatabaseDriver,
         logger logging.Logger,
-) <span class="cov10" title="17">{
-        reg.RegisterStop(func(_ context.Context) error </span><span class="cov7" title="8">{
+) <span class="cov8" title="1">{
+        reg.RegisterStop(func(_ context.Context) error </span><span class="cov8" title="1">{
                 l := logger.Named("db.CloseHook")
                 l.Info("Closing database connection")
-                if err := db.Close(); err != nil </span><span class="cov1" title="1">{
+                if err := db.Close(); err != nil </span><span class="cov8" title="1">{
                         l.Error("failed to close database", logging.Error(logging.ErrorKey, err))
                         return err
                 }</span>
-                <span class="cov7" title="7">return nil</span>
+                <span class="cov8" title="1">return nil</span>
         })
 }
 </pre>
@@ -10113,7 +10104,7 @@ func RegisterHTTPServerHooks(
         osCfg *config.OperatingSystemConfig,
         // 下記はサーバー機能の拡張が適用されたことを示すトークン
         _ *extension.AppliedServerExtends,
-) <span class="cov4" title="2">{
+) <span class="cov8" title="1">{
         reg.RegisterStart(newStartServerFunc(e, log, appCfg, secCfg, srvCfg, osCfg))
         reg.RegisterStop(newStopServerFunc(e, log, osCfg))
 }</span>
@@ -10126,23 +10117,23 @@ func newStartServerFunc(
         secCfg *config.SecurityConfig,
         srvCfg *config.ServerConfig,
         osCfg *config.OperatingSystemConfig,
-) func(context.Context) error <span class="cov9" title="5">{
-        return func(ctx context.Context) error </span><span class="cov7" title="4">{
+) func(context.Context) error <span class="cov8" title="1">{
+        return func(ctx context.Context) error </span><span class="cov8" title="1">{
                 port := srvCfg.Port()
 
                 lc := &amp;net.ListenConfig{}
                 ln, err := lc.Listen(ctx, "tcp", ":"+strconv.Itoa(port))
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return xerrors.Wrap(err, fmt.Sprintf("failed to listen on port %d", port))
                 }</span>
-                <span class="cov6" title="3">e.Listener = ln
+                <span class="cov8" title="1">e.Listener = ln
 
-                go func() </span><span class="cov6" title="3">{
-                        if err := e.Start(""); err != nil &amp;&amp; !xerrors.Is(err, http.ErrServerClosed) </span><span class="cov1" title="1">{
+                go func() </span><span class="cov8" title="1">{
+                        if err := e.Start(""); err != nil &amp;&amp; !xerrors.Is(err, http.ErrServerClosed) </span><span class="cov8" title="1">{
                                 log.Named("server.Start").Error("failed to start http server", logging.Error(logging.ErrorKey, err))
                         }</span>
                 }()
-                <span class="cov6" title="3">fields := append(lifecycleEventFields(logging.EventTypeStart, osCfg.TimeZone()),
+                <span class="cov8" title="1">fields := append(lifecycleEventFields(logging.EventTypeStart, osCfg.TimeZone()),
                         logging.String("port", strconv.Itoa(port)),
                         logging.Strings("allowed_origins", secCfg.AllowedOrigins()),
                         logging.String("cidr", secCfg.CIDR().IP.String()),
@@ -10156,20 +10147,20 @@ func newStartServerFunc(
 // newStopServerFunc は、HTTPサーバーを停止する関数を生成します。
 func newStopServerFunc(
         e *echo.Echo, log logging.Logger, osCfg *config.OperatingSystemConfig,
-) func(context.Context) error <span class="cov7" title="4">{
-        return func(ctx context.Context) error </span><span class="cov6" title="3">{
+) func(context.Context) error <span class="cov8" title="1">{
+        return func(ctx context.Context) error </span><span class="cov8" title="1">{
                 l := log.Named("server.Stop").CallerSkip(serverCallerSkip)
                 l.Info("http stopping", lifecycleEventFields(logging.EventTypeEnd, osCfg.TimeZone())...)
-                if err := e.Shutdown(ctx); err != nil </span><span class="cov1" title="1">{
+                if err := e.Shutdown(ctx); err != nil </span><span class="cov8" title="1">{
                         l.Error("failed to shutdown http server", logging.Error(logging.ErrorKey, err))
                         return err
                 }</span>
-                <span class="cov4" title="2">return nil</span>
+                <span class="cov8" title="1">return nil</span>
         }
 }
 
 // lifecycleEventFields は、起動／停止ログ共通のイベントフィールド（種別・発生時刻・TZ）を返します。
-func lifecycleEventFields(eventType, tz string) []*logging.Field <span class="cov10" title="6">{
+func lifecycleEventFields(eventType, tz string) []*logging.Field <span class="cov8" title="1">{
         return []*logging.Field{
                 logging.String(logging.EventTypeKey, eventType),
                 logging.Time(logging.EventAtKey, time.Now()),
@@ -10187,7 +10178,7 @@ import (
 
 // RegisterObservabilityShutdownHooks は、アプリケーションのシャットダウン時に
 // TracerProvider / MeterProvider を Shutdown するためのフックを登録します。
-func RegisterObservabilityShutdownHooks(reg lifecycle.Registrar, shutdowner observability.ProviderShutdowner) <span class="cov10" title="19">{
+func RegisterObservabilityShutdownHooks(reg lifecycle.Registrar, shutdowner observability.ProviderShutdowner) <span class="cov8" title="1">{
         reg.RegisterStop(shutdowner.Shutdown)
 }</span>
 </pre>
@@ -10209,7 +10200,7 @@ import (
 )
 
 // Module は、サーバー関連の依存関係を提供するfx.Moduleです。
-func Module() fx.Option <span class="cov10" title="5">{
+func Module() fx.Option <span class="cov8" title="1">{
         return fx.Module("server",
                 fx.Provide(
                         server.NewAppServer,
@@ -10218,7 +10209,7 @@ func Module() fx.Option <span class="cov10" title="5">{
 }</span>
 
 // HookModule は、サーバーのライフサイクルフックを提供するfx.Moduleです。
-func HookModule() fx.Option <span class="cov10" title="5">{
+func HookModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("server.hook",
                 fx.Invoke(
                         hook.RegisterHTTPServerHooks,
@@ -10227,7 +10218,7 @@ func HookModule() fx.Option <span class="cov10" title="5">{
 }</span>
 
 // MiddlewareModule は、HTTP スタック関連の依存関係を提供するfx.Moduleです。
-func MiddlewareModule() fx.Option <span class="cov10" title="5">{
+func MiddlewareModule() fx.Option <span class="cov8" title="1">{
         return fx.Module("server.httpstack",
                 // Middleware Modules
                 inbound.IPExtractorModule(),
@@ -10271,11 +10262,11 @@ type shutdowner struct {
 }
 
 // NewShutdowner は、新しい Shutdowner インスタンスを生成します。
-func NewShutdowner(sd fx.Shutdowner) Shutdowner <span class="cov10" title="9">{
+func NewShutdowner(sd fx.Shutdowner) Shutdowner <span class="cov8" title="1">{
         return &amp;shutdowner{sd: sd}
 }</span>
 
-func (s *shutdowner) Shutdown() error <span class="cov7" title="5">{
+func (s *shutdowner) Shutdown() error <span class="cov8" title="1">{
         return s.sd.Shutdown()
 }</span>
 </pre>
@@ -10285,7 +10276,7 @@ func (s *shutdowner) Shutdown() error <span class="cov7" title="5">{
 import "go.uber.org/fx"
 
 // Module は、Shutdownerを提供するfx.Moduleを返します。
-func Module() fx.Option <span class="cov10" title="14">{
+func Module() fx.Option <span class="cov8" title="1">{
         return fx.Module("shutdowner",
                 fx.Provide(
                         NewShutdowner,
@@ -10310,7 +10301,7 @@ import (
 )
 
 // NewWorkerCore は、worker 実行用の fx.App を構成する fx.Option を返します。
-func NewWorkerCore() fx.Option <span class="cov10" title="6">{
+func NewWorkerCore() fx.Option <span class="cov8" title="1">{
         return fx.Options(
                 shutdowner.Module(),
                 lifecycle.Module(),
@@ -10328,7 +10319,7 @@ func NewWorkerCore() fx.Option <span class="cov10" title="6">{
 // RunWorker は、worker 実行用の開始関数・停止関数を生成して返します。
 // grace（APP_SHUTDOWN_TIMEOUT）を fx.StopTimeout に設定し、停止時に fx 既定（15s）が
 // DrainTimeout より先に drain を打ち切らないようにします。
-func RunWorker(grace time.Duration) (StartFunc, StopFunc) <span class="cov7" title="4">{
+func RunWorker(grace time.Duration) (StartFunc, StopFunc) <span class="cov8" title="1">{
         var (
                 state  workerboundary.State
                 logger logging.Logger
@@ -10341,12 +10332,12 @@ func RunWorker(grace time.Duration) (StartFunc, StopFunc) <span class="cov7" tit
                 fx.WithLogger(NewFxEventLogger),
         )
 
-        start := func(ctx context.Context, name string, args []string) &lt;-chan error </span><span class="cov6" title="3">{
+        start := func(ctx context.Context, name string, args []string) &lt;-chan error </span><span class="cov8" title="1">{
                 l := logger.Named("worker.RunWorker").CallerSkip(callSkip)
                 done := make(chan error, 1)
                 state.Set(name, args, done)
 
-                if err := app.Start(ctx); err != nil </span><span class="cov1" title="1">{
+                if err := app.Start(ctx); err != nil </span><span class="cov8" title="1">{
                         l.Error(
                                 "failed to start worker application",
                                 logging.String(logging.WorkerNameKey, name),
@@ -10359,21 +10350,21 @@ func RunWorker(grace time.Duration) (StartFunc, StopFunc) <span class="cov7" tit
                         return failCh
                 }</span>
 
-                <span class="cov4" title="2">l.Info("worker started", logging.String(logging.WorkerNameKey, name))
+                <span class="cov8" title="1">l.Info("worker started", logging.String(logging.WorkerNameKey, name))
                 return done</span>
         }
 
-        <span class="cov7" title="4">stop := func(ctx context.Context) error </span><span class="cov7" title="4">{
+        <span class="cov8" title="1">stop := func(ctx context.Context) error </span><span class="cov8" title="1">{
                 l := logger.Named("worker.RunWorker").CallerSkip(callSkip)
-                if err := app.Stop(ctx); err != nil </span><span class="cov1" title="1">{
+                if err := app.Stop(ctx); err != nil </span><span class="cov8" title="1">{
                         l.Error("failed to stop worker application", logging.Error(logging.ErrorKey, err))
                         return err
                 }</span>
-                <span class="cov6" title="3">l.Info("worker application finished")
+                <span class="cov8" title="1">l.Info("worker application finished")
                 return nil</span>
         }
 
-        <span class="cov7" title="4">return start, stop</span>
+        <span class="cov8" title="1">return start, stop</span>
 }
 </pre>
 		
@@ -10400,18 +10391,18 @@ func RegisterWorkerHooks(
         state workerboundary.State,
         wc *config.WorkerConfig,
         logger logging.Logger,
-) <span class="cov10" title="7">{
+) <span class="cov8" title="1">{
         startHealth, stopHealth := cliworker.NewHealthServer(wc.HealthListenAddr(), engine.Healthy, logger)
 
         lifecycle.SupervisedRunner{
                 OnStartAux: startHealth,
-                Body: func(ctx context.Context) </span><span class="cov8" title="5">{
+                Body: func(ctx context.Context) </span><span class="cov8" title="1">{
                         name, _, done := state.Snapshot()
-                        if done == nil </span><span class="cov4" title="2">{
+                        if done == nil </span><span class="cov8" title="1">{
                                 logger.Named("worker.Hooks").Info("No worker to run", logging.String(logging.WorkerNameKey, name))
                                 return
                         }</span>
-                        <span class="cov6" title="3">defer close(done)
+                        <span class="cov8" title="1">defer close(done)
                         done &lt;- engine.Run(ctx, name)</span> // 猶予超過時の未完は Ack されず再配送へ
                 },
                 OnStopAux: stopHealth,
@@ -10456,21 +10447,21 @@ type EngineIn struct {
 // 単一軸とする grace）で決まります。WORKER_DRAIN_TIMEOUT &gt;= grace だと OnStop の drain が grace で
 // 打ち切られ、未完了の in-flight handler と後続の停止処理（DB pool close 等）が競合します。
 // 設定不整合は起動時に失敗させ、運用時の競合を未然に防ぎます。
-func ValidateShutdownGrace(appCfg *config.ApplicationConfig, workerCfg *config.WorkerConfig) error <span class="cov8" title="7">{
+func ValidateShutdownGrace(appCfg *config.ApplicationConfig, workerCfg *config.WorkerConfig) error <span class="cov8" title="1">{
         return validateShutdownGrace(workerCfg.DrainTimeout(), appCfg.ShutdownTimeout())
 }</span>
 
 // validateShutdownGrace は、drain &lt; grace を検証します。
-func validateShutdownGrace(drain, grace time.Duration) error <span class="cov10" title="10">{
-        if drain &gt;= grace </span><span class="cov5" title="3">{
+func validateShutdownGrace(drain, grace time.Duration) error <span class="cov8" title="1">{
+        if drain &gt;= grace </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrInvalidShutdownGrace, fmt.Sprintf(
                         "WORKER_DRAIN_TIMEOUT (%s) must be shorter than APP_SHUTDOWN_TIMEOUT (%s)", drain, grace))
         }</span>
-        <span class="cov8" title="7">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // ProvideEngine は、WorkerConfig の設定から Engine を生成します。
-func ProvideEngine(in EngineIn) (*workerengine.Engine, error) <span class="cov9" title="8">{
+func ProvideEngine(in EngineIn) (*workerengine.Engine, error) <span class="cov8" title="1">{
         c := in.Config
         set := workerengine.Settings{
                 Concurrency:               c.Concurrency(),
@@ -10519,21 +10510,21 @@ func New(
         id uuid.UUID,
         name string,
         code int,
-) (*Prefecture, error) <span class="cov10" title="25">{
-        if id.IsNil() </span><span class="cov1" title="1">{
+) (*Prefecture, error) <span class="cov8" title="1">{
+        if id.IsNil() </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(ErrInvalidID, "id is required")
         }</span>
-        <span class="cov9" title="24">if ok, msg := stringkit.ValidateInRange(name, minNameLength, maxNameLength); !ok </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if ok, msg := stringkit.ValidateInRange(name, minNameLength, maxNameLength); !ok </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(ErrInvalidName, msg)
         }</span>
-        <span class="cov9" title="22">if code &lt; minCode || maxCode &lt; code </span><span class="cov4" title="3">{
+        <span class="cov8" title="1">if code &lt; minCode || maxCode &lt; code </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(
                         ErrInvalidCode,
                         fmt.Sprintf("code must be between %d and %d, got %d", minCode, maxCode, code),
                 )
         }</span>
 
-        <span class="cov9" title="19">return &amp;Prefecture{
+        <span class="cov8" title="1">return &amp;Prefecture{
                 id:   id,
                 name: name,
                 code: code,
@@ -10541,13 +10532,13 @@ func New(
 }
 
 // ID は、都道府県のIDを返します。
-func (p *Prefecture) ID() uuid.UUID <span class="cov8" title="16">{ return p.id }</span>
+func (p *Prefecture) ID() uuid.UUID <span class="cov8" title="1">{ return p.id }</span>
 
 // Name は、都道府県名を返します。
-func (p *Prefecture) Name() string <span class="cov9" title="18">{ return p.name }</span>
+func (p *Prefecture) Name() string <span class="cov8" title="1">{ return p.name }</span>
 
 // Code は、都道府県コードを返します。
-func (p *Prefecture) Code() int <span class="cov1" title="1">{ return p.code }</span>
+func (p *Prefecture) Code() int <span class="cov8" title="1">{ return p.code }</span>
 </pre>
 		
 		<pre class="file" id="file150" style="display: none">package user
@@ -10565,26 +10556,26 @@ type RawPassword struct {
 }
 
 // NewRawPassword は、与えられた文字列を検証し、有効な場合に RawPassword を構築します。
-func NewRawPassword(v string) (RawPassword, error) <span class="cov10" title="29">{
-        if !stringkit.InRange(v, MinRawPasswordLength, MaxRawPasswordLength) </span><span class="cov5" title="5">{
+func NewRawPassword(v string) (RawPassword, error) <span class="cov8" title="1">{
+        if !stringkit.InRange(v, MinRawPasswordLength, MaxRawPasswordLength) </span><span class="cov8" title="1">{
                 return RawPassword{}, xerrors.Wrap(
                         ErrInvalidRawPassword,
                         fmt.Sprintf("password must be between %d and %d characters", MinRawPasswordLength, MaxRawPasswordLength),
                 )
         }</span>
-        <span class="cov9" title="24">return RawPassword{value: v}, nil</span>
+        <span class="cov8" title="1">return RawPassword{value: v}, nil</span>
 }
 
 // Value は、保持している平文パスワード文字列を返します。
-func (p RawPassword) Value() string <span class="cov8" title="15">{
+func (p RawPassword) Value() string <span class="cov8" title="1">{
         return p.value
 }</span>
 
 // String は、平文パスワードが fmt 経由で露出しないよう秘匿した文字列を返します。
-func (p RawPassword) String() string <span class="cov3" title="3">{ return "[REDACTED]" }</span>
+func (p RawPassword) String() string <span class="cov8" title="1">{ return "[REDACTED]" }</span>
 
 // GoString は、%#v 経由でも平文パスワードが露出しないよう秘匿した文字列を返します。
-func (p RawPassword) GoString() string <span class="cov1" title="1">{ return "[REDACTED]" }</span>
+func (p RawPassword) GoString() string <span class="cov8" title="1">{ return "[REDACTED]" }</span>
 </pre>
 		
 		<pre class="file" id="file151" style="display: none">// Package user は、ユーザードメインを定義します。User エンティティ（論理削除・パスワード変更・プロフィール更新）・RawPassword 値オブジェクト・FeedCursor 値オブジェクト・Repository インターフェースを提供します。
@@ -10637,30 +10628,30 @@ func New(
         createdAt time.Time,
         updatedAt time.Time,
         deletedAt *time.Time,
-) (*User, error) <span class="cov9" title="126">{
-        if id.IsNil() </span><span class="cov1" title="1">{
+) (*User, error) <span class="cov8" title="1">{
+        if id.IsNil() </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(ErrInvalidID, "id is required")
         }</span>
 
-        <span class="cov9" title="125">if err := validateProfileFields(firstName, lastName, email, phone, prefectureID, city, street, building, postalCode); err != nil </span><span class="cov6" title="23">{
+        <span class="cov8" title="1">if err := validateProfileFields(firstName, lastName, email, phone, prefectureID, city, street, building, postalCode); err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov9" title="102">if err := validatePasswordHash(passwordHash); err != nil </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if err := validatePasswordHash(passwordHash); err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov9" title="100">if updatedAt.Before(createdAt) </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if updatedAt.Before(createdAt) </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(ErrInvalidUpdatedAt, "updatedAt must be after or equal to createdAt")
         }</span>
 
-        <span class="cov9" title="99">if deletedAt != nil </span><span class="cov5" title="12">{
-                if err := validateDeletedAt(*deletedAt, createdAt, updatedAt); err != nil </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if deletedAt != nil </span><span class="cov8" title="1">{
+                if err := validateDeletedAt(*deletedAt, createdAt, updatedAt); err != nil </span><span class="cov8" title="1">{
                         return nil, err
                 }</span>
         }
 
-        <span class="cov9" title="97">return &amp;User{
+        <span class="cov8" title="1">return &amp;User{
                 id:           id,
                 firstName:    firstName,
                 lastName:     lastName,
@@ -10679,49 +10670,49 @@ func New(
 }
 
 // ID は、ユーザーのIDを返します。
-func (u *User) ID() uuid.UUID <span class="cov7" title="43">{ return u.id }</span>
+func (u *User) ID() uuid.UUID <span class="cov8" title="1">{ return u.id }</span>
 
 // FirstName は、ユーザーの名前を返します。
-func (u *User) FirstName() string <span class="cov7" title="30">{ return u.firstName }</span>
+func (u *User) FirstName() string <span class="cov8" title="1">{ return u.firstName }</span>
 
 // LastName は、ユーザーの名字を返します。
-func (u *User) LastName() string <span class="cov7" title="30">{ return u.lastName }</span>
+func (u *User) LastName() string <span class="cov8" title="1">{ return u.lastName }</span>
 
 // PasswordHash は、ユーザーのパスワードハッシュを返します。
-func (u *User) PasswordHash() string <span class="cov5" title="13">{ return u.passwordHash }</span>
+func (u *User) PasswordHash() string <span class="cov8" title="1">{ return u.passwordHash }</span>
 
 // Email は、ユーザーのメールアドレスを返します。
-func (u *User) Email() string <span class="cov7" title="30">{ return u.email }</span>
+func (u *User) Email() string <span class="cov8" title="1">{ return u.email }</span>
 
 // Phone は、ユーザーの電話番号を返します。
-func (u *User) Phone() string <span class="cov7" title="30">{ return u.phone }</span>
+func (u *User) Phone() string <span class="cov8" title="1">{ return u.phone }</span>
 
 // PrefectureID は、ユーザーの都道府県IDを返します。
-func (u *User) PrefectureID() uuid.UUID <span class="cov7" title="35">{ return u.prefectureID }</span>
+func (u *User) PrefectureID() uuid.UUID <span class="cov8" title="1">{ return u.prefectureID }</span>
 
 // City は、ユーザーの市区町村名を返します。
-func (u *User) City() string <span class="cov7" title="30">{ return u.city }</span>
+func (u *User) City() string <span class="cov8" title="1">{ return u.city }</span>
 
 // Street は、ユーザーの番地を返します。
-func (u *User) Street() string <span class="cov7" title="30">{ return u.street }</span>
+func (u *User) Street() string <span class="cov8" title="1">{ return u.street }</span>
 
 // Building は、ユーザーの建物名を返します。
-func (u *User) Building() *string <span class="cov7" title="38">{ return ptr.Copy(u.building) }</span>
+func (u *User) Building() *string <span class="cov8" title="1">{ return ptr.Copy(u.building) }</span>
 
 // PostalCode は、ユーザーの郵便番号を返します。
-func (u *User) PostalCode() string <span class="cov7" title="30">{ return u.postalCode }</span>
+func (u *User) PostalCode() string <span class="cov8" title="1">{ return u.postalCode }</span>
 
 // DeletedAt は、ユーザーの削除日時を返します。
-func (u *User) DeletedAt() *time.Time <span class="cov6" title="23">{ return ptr.Copy(u.deletedAt) }</span>
+func (u *User) DeletedAt() *time.Time <span class="cov8" title="1">{ return ptr.Copy(u.deletedAt) }</span>
 
 // CreatedAt は、ユーザーの作成日時を返します。
-func (u *User) CreatedAt() time.Time <span class="cov4" title="8">{ return u.createdAt }</span>
+func (u *User) CreatedAt() time.Time <span class="cov8" title="1">{ return u.createdAt }</span>
 
 // UpdatedAt は、ユーザーの更新日時を返します。
-func (u *User) UpdatedAt() time.Time <span class="cov4" title="7">{ return u.updatedAt }</span>
+func (u *User) UpdatedAt() time.Time <span class="cov8" title="1">{ return u.updatedAt }</span>
 
 // FullName は、ユーザーのフルネームを返します。
-func (u *User) FullName() string <span class="cov1" title="1">{ return u.firstName + " " + u.lastName }</span>
+func (u *User) FullName() string <span class="cov8" title="1">{ return u.firstName + " " + u.lastName }</span>
 
 // UpdateProfile は、プロフィール（氏名・連絡先・住所・都道府県ID）と更新日時を一括で置き換えます。
 // パスワードは変更しません。各フィールドは New と同じ不変条件で検証します。論理削除済みユーザーには ErrAlreadyDeleted を返します。
@@ -10732,18 +10723,18 @@ func (u *User) UpdateProfile(
         building *string,
         postalCode string,
         updatedAt time.Time,
-) error <span class="cov5" title="13">{
-        if err := u.ensureNotDeleted(); err != nil </span><span class="cov1" title="1">{
+) error <span class="cov8" title="1">{
+        if err := u.ensureNotDeleted(); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov5" title="12">if err := validateProfileFields(firstName, lastName, email, phone, prefectureID, city, street, building, postalCode); err != nil </span><span class="cov3" title="3">{
+        <span class="cov8" title="1">if err := validateProfileFields(firstName, lastName, email, phone, prefectureID, city, street, building, postalCode); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov5" title="9">if err := u.ensureUpdatedAt(updatedAt); err != nil </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if err := u.ensureUpdatedAt(updatedAt); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov4" title="7">u.firstName = firstName
+        <span class="cov8" title="1">u.firstName = firstName
         u.lastName = lastName
         u.email = email
         u.phone = phone
@@ -10757,65 +10748,65 @@ func (u *User) UpdateProfile(
 }
 
 // ChangePassword は、パスワードハッシュと更新日時を置き換えます。論理削除済みユーザーには ErrAlreadyDeleted を返します。updatedAt は現在値以降（単調非減少）である必要があり、違反時は ErrInvalidUpdatedAt を返します。
-func (u *User) ChangePassword(passwordHash string, updatedAt time.Time) error <span class="cov4" title="8">{
-        if err := u.ensureNotDeleted(); err != nil </span><span class="cov1" title="1">{
+func (u *User) ChangePassword(passwordHash string, updatedAt time.Time) error <span class="cov8" title="1">{
+        if err := u.ensureNotDeleted(); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov4" title="7">if err := validatePasswordHash(passwordHash); err != nil </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if err := validatePasswordHash(passwordHash); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov3" title="5">if err := u.ensureUpdatedAt(updatedAt); err != nil </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if err := u.ensureUpdatedAt(updatedAt); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov3" title="3">u.passwordHash = passwordHash
+        <span class="cov8" title="1">u.passwordHash = passwordHash
         u.updatedAt = updatedAt
         return nil</span>
 }
 
 // MarkAsDeleted は、ユーザーを論理削除します（deletedAt を設定）。論理削除は更新操作でもあるため updatedAt も deletedAt の値に更新されます。既に削除済みの場合は ErrAlreadyDeleted を返します。
-func (u *User) MarkAsDeleted(deletedAt time.Time) error <span class="cov5" title="10">{
-        if err := u.ensureNotDeleted(); err != nil </span><span class="cov2" title="2">{
+func (u *User) MarkAsDeleted(deletedAt time.Time) error <span class="cov8" title="1">{
+        if err := u.ensureNotDeleted(); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov4" title="8">if err := validateDeletedAt(deletedAt, u.createdAt, u.updatedAt); err != nil </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if err := validateDeletedAt(deletedAt, u.createdAt, u.updatedAt); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov4" title="6">u.deletedAt = &amp;deletedAt
+        <span class="cov8" title="1">u.deletedAt = &amp;deletedAt
         // 論理削除も更新操作のため、updatedAt を削除時刻（usecase が clock から取得した現在時刻）に追従させる。
         u.updatedAt = deletedAt
         return nil</span>
 }
 
 // ensureNotDeleted は、論理削除済みユーザーへの変更操作を拒否します（削除済みは不変）。
-func (u *User) ensureNotDeleted() error <span class="cov7" title="31">{
-        if u.deletedAt != nil </span><span class="cov3" title="4">{
+func (u *User) ensureNotDeleted() error <span class="cov8" title="1">{
+        if u.deletedAt != nil </span><span class="cov8" title="1">{
                 return ErrAlreadyDeleted
         }</span>
-        <span class="cov7" title="27">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // ensureUpdatedAt は、更新日時が createdAt 以降かつ現在の updatedAt 以降（単調非減少）であることを検証します。
-func (u *User) ensureUpdatedAt(updatedAt time.Time) error <span class="cov5" title="14">{
-        if updatedAt.Before(u.createdAt) </span><span class="cov2" title="2">{
+func (u *User) ensureUpdatedAt(updatedAt time.Time) error <span class="cov8" title="1">{
+        if updatedAt.Before(u.createdAt) </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrInvalidUpdatedAt, "updatedAt must be after or equal to createdAt")
         }</span>
-        <span class="cov5" title="12">if updatedAt.Before(u.updatedAt) </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if updatedAt.Before(u.updatedAt) </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrInvalidUpdatedAt, "updatedAt must be after or equal to current updatedAt")
         }</span>
-        <span class="cov5" title="10">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // validateDeletedAt は、削除日時が createdAt / updatedAt 以降であることを検証します。
-func validateDeletedAt(deletedAt, createdAt, updatedAt time.Time) error <span class="cov6" title="20">{
-        if deletedAt.Before(createdAt) </span><span class="cov2" title="2">{
+func validateDeletedAt(deletedAt, createdAt, updatedAt time.Time) error <span class="cov8" title="1">{
+        if deletedAt.Before(createdAt) </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrInvalidDeletedAt, "deletedAt must be after or equal to createdAt")
         }</span>
-        <span class="cov6" title="18">if deletedAt.Before(updatedAt) </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if deletedAt.Before(updatedAt) </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrInvalidDeletedAt, "deletedAt must be after or equal to updatedAt")
         }</span>
-        <span class="cov6" title="16">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // validateProfileFields は、プロフィール系フィールドの不変条件を検証します。
@@ -10825,45 +10816,45 @@ func validateProfileFields(
         city, street string,
         building *string,
         postalCode string,
-) error <span class="cov10" title="137">{
-        if ok, msg := stringkit.ValidateInRange(firstName, minLength, maxFirstNameLength); !ok </span><span class="cov4" title="6">{
+) error <span class="cov8" title="1">{
+        if ok, msg := stringkit.ValidateInRange(firstName, minLength, maxFirstNameLength); !ok </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrInvalidFirstName, msg)
         }</span>
-        <span class="cov9" title="131">if ok, msg := stringkit.ValidateInRange(lastName, minLength, maxLastNameLength); !ok </span><span class="cov4" title="7">{
+        <span class="cov8" title="1">if ok, msg := stringkit.ValidateInRange(lastName, minLength, maxLastNameLength); !ok </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrInvalidLastName, msg)
         }</span>
-        <span class="cov9" title="124">if ok, msg := stringkit.ValidateInRange(email, minLength, maxEmailLength); !ok </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if ok, msg := stringkit.ValidateInRange(email, minLength, maxEmailLength); !ok </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrInvalidEmail, msg)
         }</span>
-        <span class="cov9" title="122">if ok, msg := stringkit.ValidateInRange(phone, minLength, maxPhoneLength); !ok </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if ok, msg := stringkit.ValidateInRange(phone, minLength, maxPhoneLength); !ok </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrInvalidPhone, msg)
         }</span>
-        <span class="cov9" title="120">if prefectureID.IsNil() </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if prefectureID.IsNil() </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrInvalidPrefectureID, "prefectureID is required")
         }</span>
-        <span class="cov9" title="119">if ok, msg := stringkit.ValidateInRange(city, minLength, maxCityLength); !ok </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if ok, msg := stringkit.ValidateInRange(city, minLength, maxCityLength); !ok </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrInvalidCity, msg)
         }</span>
-        <span class="cov9" title="117">if ok, msg := stringkit.ValidateInRange(street, minLength, maxStreetLength); !ok </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if ok, msg := stringkit.ValidateInRange(street, minLength, maxStreetLength); !ok </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrInvalidStreet, msg)
         }</span>
-        <span class="cov9" title="115">if building != nil </span><span class="cov9" title="85">{
-                if ok, msg := stringkit.ValidateInRange(*building, minLength, maxBuildingLength); !ok </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if building != nil </span><span class="cov8" title="1">{
+                if ok, msg := stringkit.ValidateInRange(*building, minLength, maxBuildingLength); !ok </span><span class="cov8" title="1">{
                         return xerrors.Wrap(ErrInvalidBuilding, msg)
                 }</span>
         }
-        <span class="cov9" title="113">if ok, msg := stringkit.ValidateInRange(postalCode, minLength, maxPostalCodeLength); !ok </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if ok, msg := stringkit.ValidateInRange(postalCode, minLength, maxPostalCodeLength); !ok </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrInvalidPostalCode, msg)
         }</span>
-        <span class="cov9" title="111">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // validatePasswordHash は、パスワードハッシュの不変条件を検証します。
-func validatePasswordHash(passwordHash string) error <span class="cov9" title="109">{
-        if ok, msg := stringkit.ValidateInRange(passwordHash, minLength, maxPasswordHashLength); !ok </span><span class="cov3" title="4">{
+func validatePasswordHash(passwordHash string) error <span class="cov8" title="1">{
+        if ok, msg := stringkit.ValidateInRange(passwordHash, minLength, maxPasswordHashLength); !ok </span><span class="cov8" title="1">{
                 return xerrors.Wrap(ErrInvalidPasswordHash, msg)
         }</span>
-        <span class="cov9" title="105">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 </pre>
 		
@@ -10883,15 +10874,15 @@ type FeedCursor struct {
 }
 
 // NewFeedCursor は、作成日時と ID から FeedCursor を生成します。
-func NewFeedCursor(createdAt time.Time, id uuid.UUID) FeedCursor <span class="cov10" title="9">{
+func NewFeedCursor(createdAt time.Time, id uuid.UUID) FeedCursor <span class="cov8" title="1">{
         return FeedCursor{createdAt: createdAt, id: id}
 }</span>
 
 // CreatedAt は、境界となる作成日時を返します。
-func (c FeedCursor) CreatedAt() time.Time <span class="cov9" title="8">{ return c.createdAt }</span>
+func (c FeedCursor) CreatedAt() time.Time <span class="cov8" title="1">{ return c.createdAt }</span>
 
 // ID は、境界となるユーザー ID を返します。
-func (c FeedCursor) ID() uuid.UUID <span class="cov9" title="8">{ return c.id }</span>
+func (c FeedCursor) ID() uuid.UUID <span class="cov8" title="1">{ return c.id }</span>
 </pre>
 		
 		<pre class="file" id="file153" style="display: none">// Package local はローカル開発用の認証基盤実装を提供します。
@@ -10919,23 +10910,23 @@ var ErrLocalMockAuthenticatorInvalidToken = xerrors.Wrap(apperror.ErrUnauthentic
 type authenticator struct{}
 
 // New は local 用 Authenticator のコンストラクタです。
-func New() authbd.Authenticator <span class="cov10" title="12">{
+func New() authbd.Authenticator <span class="cov8" title="1">{
         return &amp;authenticator{}
 }</span>
 
 // Authenticate は与えられた認証情報を基に認証を行い、認証結果を返します。
 // cred が nil の場合は無効トークンとして扱います。
-func (a *authenticator) Authenticate(_ context.Context, cred *authbd.Credential) (*authbd.Authn, error) <span class="cov4" title="3">{
-        if cred == nil </span><span class="cov1" title="1">{
+func (a *authenticator) Authenticate(_ context.Context, cred *authbd.Credential) (*authbd.Authn, error) <span class="cov8" title="1">{
+        if cred == nil </span><span class="cov8" title="1">{
                 return nil, ErrLocalMockAuthenticatorInvalidToken
         }</span>
 
-        <span class="cov3" title="2">sub := a.resolveSubject(cred.AccessToken())
-        if sub == "" </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">sub := a.resolveSubject(cred.AccessToken())
+        if sub == "" </span><span class="cov8" title="1">{
                 return nil, ErrLocalMockAuthenticatorInvalidToken
         }</span>
 
-        <span class="cov1" title="1">return authbd.New(
+        <span class="cov8" title="1">return authbd.New(
                 sub,
                 authbd.ProviderMock,
                 nil,
@@ -10944,15 +10935,15 @@ func (a *authenticator) Authenticate(_ context.Context, cred *authbd.Credential)
 }
 
 // resolveSubject は token から localPrefix を除いた Subject を抽出します。
-func (a *authenticator) resolveSubject(token string) string <span class="cov7" title="6">{
-        if after, ok := strings.CutPrefix(token, localPrefix); ok </span><span class="cov6" title="4">{
+func (a *authenticator) resolveSubject(token string) string <span class="cov8" title="1">{
+        if after, ok := strings.CutPrefix(token, localPrefix); ok </span><span class="cov8" title="1">{
                 sub := strings.TrimSpace(after)
-                if sub != "" </span><span class="cov3" title="2">{
+                if sub != "" </span><span class="cov8" title="1">{
                         return sub
                 }</span>
         }
 
-        <span class="cov6" title="4">return ""</span>
+        <span class="cov8" title="1">return ""</span>
 }
 </pre>
 		
@@ -10970,12 +10961,12 @@ import (
 type authorizer struct{}
 
 // New は、全許可 Authorizer のコンストラクタです。
-func New() authzbd.Authorizer <span class="cov10" title="17">{
+func New() authzbd.Authorizer <span class="cov8" title="1">{
         return &amp;authorizer{}
 }</span>
 
 // Authorize は、action / resource によらず常に許可（nil）を返します。
-func (a *authorizer) Authorize(_ context.Context, _ *authbd.Authn, _ authzbd.Action, _ *authzbd.Resource) error <span class="cov5" title="4">{
+func (a *authorizer) Authorize(_ context.Context, _ *authbd.Authn, _ authzbd.Action, _ *authzbd.Resource) error <span class="cov8" title="1">{
         return nil
 }</span>
 </pre>
@@ -11023,84 +11014,84 @@ type breakerManager struct {
 }
 
 // newBreaker は、closed 状態の breaker を生成します。
-func newBreaker(config BreakerConfig) *breaker <span class="cov8" title="39">{
+func newBreaker(config BreakerConfig) *breaker <span class="cov8" title="1">{
         return &amp;breaker{config: config, state: breakerClosed}
 }</span>
 
 // allow は、now 時点でリクエストを通してよいかと、その試行が属するエポックを返します。
 // 返したエポックは record にそのまま渡します。
 // open は OpenDuration 経過で half-open へ遷移し、half-open は HalfOpenProbes 件までプローブを通します。
-func (b *breaker) allow(now time.Time) (bool, uint64) <span class="cov9" title="66">{
+func (b *breaker) allow(now time.Time) (bool, uint64) <span class="cov8" title="1">{
         b.mu.Lock()
         defer b.mu.Unlock()
 
         switch b.state </span>{
-        case breakerOpen:<span class="cov5" title="11">
-                if now.Sub(b.openedAt) &gt;= b.config.OpenDuration </span><span class="cov4" title="7">{
+        case breakerOpen:<span class="cov8" title="1">
+                if now.Sub(b.openedAt) &gt;= b.config.OpenDuration </span><span class="cov8" title="1">{
                         b.toHalfOpen()
                         b.halfOpenProbes++
                         return true, b.generation
                 }</span>
-                <span class="cov3" title="4">return false, b.generation</span>
-        case breakerHalfOpen:<span class="cov4" title="5">
-                if b.halfOpenProbes &lt; b.config.HalfOpenProbes </span><span class="cov3" title="4">{
+                <span class="cov8" title="1">return false, b.generation</span>
+        case breakerHalfOpen:<span class="cov8" title="1">
+                if b.halfOpenProbes &lt; b.config.HalfOpenProbes </span><span class="cov8" title="1">{
                         b.halfOpenProbes++
                         return true, b.generation
                 }</span>
-                <span class="cov1" title="1">return false, b.generation</span>
-        default:<span class="cov8" title="50"> // breakerClosed
+                <span class="cov8" title="1">return false, b.generation</span>
+        default:<span class="cov8" title="1"> // breakerClosed
                 return true, b.generation</span>
         }
 }
 
 // record は、試行結果を記録し状態遷移を行います。success=false は downstream 起因の失敗です。
-func (b *breaker) record(success bool, now time.Time, generation uint64) <span class="cov10" title="105">{
+func (b *breaker) record(success bool, now time.Time, generation uint64) <span class="cov8" title="1">{
         b.mu.Lock()
         defer b.mu.Unlock()
 
         switch b.state </span>{
-        case breakerHalfOpen:<span class="cov5" title="8">
+        case breakerHalfOpen:<span class="cov8" title="1">
                 // half-open は厳密にプローブ数で回復判定するため、別エポックの遅延結果を無視する。
-                if generation != b.generation </span><span class="cov1" title="1">{
+                if generation != b.generation </span><span class="cov8" title="1">{
                         return
                 }</span>
-                <span class="cov4" title="7">if !success </span><span class="cov2" title="2">{
+                <span class="cov8" title="1">if !success </span><span class="cov8" title="1">{
                         b.toOpen(now)
                         return
                 }</span>
-                <span class="cov4" title="5">b.halfOpenSuccess++
-                if b.halfOpenSuccess &gt;= b.config.HalfOpenProbes </span><span class="cov2" title="2">{
+                <span class="cov8" title="1">b.halfOpenSuccess++
+                if b.halfOpenSuccess &gt;= b.config.HalfOpenProbes </span><span class="cov8" title="1">{
                         b.toClosed()
                 }</span>
-        case breakerClosed:<span class="cov9" title="96">
+        case breakerClosed:<span class="cov8" title="1">
                 // closed の集計は状態遷移時にリセットされるため、競合した遅延 record も無害に計上できる。
                 b.requests++
-                if !success </span><span class="cov9" title="82">{
+                if !success </span><span class="cov8" title="1">{
                         b.failures++
                 }</span>
-                <span class="cov9" title="96">if b.shouldOpen() </span><span class="cov5" title="12">{
+                <span class="cov8" title="1">if b.shouldOpen() </span><span class="cov8" title="1">{
                         b.toOpen(now)
                 }</span>
-        default:<span class="cov1" title="1"></span> // breakerOpen（allow が遷移を司るため記録は無視）
+        default:<span class="cov8" title="1"></span> // breakerOpen（allow が遷移を司るため記録は無視）
         }
 }
 
 // currentState は、現在の状態を返します。
-func (b *breaker) currentState() breakerState <span class="cov8" title="45">{
+func (b *breaker) currentState() breakerState <span class="cov8" title="1">{
         b.mu.Lock()
         defer b.mu.Unlock()
         return b.state
 }</span>
 
-func (b *breaker) shouldOpen() bool <span class="cov9" title="96">{
-        if b.requests &lt; b.config.MinRequests </span><span class="cov9" title="83">{
+func (b *breaker) shouldOpen() bool <span class="cov8" title="1">{
+        if b.requests &lt; b.config.MinRequests </span><span class="cov8" title="1">{
                 return false
         }</span>
-        <span class="cov5" title="13">rate := float64(b.failures) / float64(b.requests)
+        <span class="cov8" title="1">rate := float64(b.failures) / float64(b.requests)
         return rate &gt;= b.config.FailureThreshold</span>
 }
 
-func (b *breaker) toOpen(now time.Time) <span class="cov6" title="14">{
+func (b *breaker) toOpen(now time.Time) <span class="cov8" title="1">{
         b.state = breakerOpen
         b.openedAt = now
         b.generation++
@@ -11108,14 +11099,14 @@ func (b *breaker) toOpen(now time.Time) <span class="cov6" title="14">{
         b.halfOpenSuccess = 0
 }</span>
 
-func (b *breaker) toHalfOpen() <span class="cov4" title="7">{
+func (b *breaker) toHalfOpen() <span class="cov8" title="1">{
         b.state = breakerHalfOpen
         b.generation++
         b.halfOpenProbes = 0
         b.halfOpenSuccess = 0
 }</span>
 
-func (b *breaker) toClosed() <span class="cov2" title="2">{
+func (b *breaker) toClosed() <span class="cov8" title="1">{
         b.state = breakerClosed
         b.generation++
         b.requests = 0
@@ -11125,21 +11116,21 @@ func (b *breaker) toClosed() <span class="cov2" title="2">{
 }</span>
 
 // newBreakerManager は、breakerManager を生成します。
-func newBreakerManager() *breakerManager <span class="cov7" title="31">{
+func newBreakerManager() *breakerManager <span class="cov8" title="1">{
         return &amp;breakerManager{breakers: make(map[Downstream]*breaker)}
 }</span>
 
 // get は、d に対応する breaker を返します（無ければ config で新規生成）。
-func (m *breakerManager) get(d Downstream, config BreakerConfig) *breaker <span class="cov7" title="33">{
+func (m *breakerManager) get(d Downstream, config BreakerConfig) *breaker <span class="cov8" title="1">{
         m.mu.Lock()
         defer m.mu.Unlock()
 
         b, ok := m.breakers[d]
-        if !ok </span><span class="cov7" title="28">{
+        if !ok </span><span class="cov8" title="1">{
                 b = newBreaker(config)
                 m.breakers[d] = b
         }</span>
-        <span class="cov7" title="33">return b</span>
+        <span class="cov8" title="1">return b</span>
 }
 </pre>
 		
@@ -11166,32 +11157,32 @@ type retryBudget struct {
 }
 
 // newRetryBudget は、retryBudget を生成します。
-func newRetryBudget() *retryBudget <span class="cov7" title="34">{
+func newRetryBudget() *retryBudget <span class="cov8" title="1">{
         return &amp;retryBudget{tokens: make(map[Downstream]float64)}
 }</span>
 
 // refill は、リクエスト開始時に ratio 分のトークンを補充します（上限 retryBudgetMaxTokens）。
-func (b *retryBudget) refill(d Downstream, ratio float64) <span class="cov10" title="133">{
+func (b *retryBudget) refill(d Downstream, ratio float64) <span class="cov8" title="1">{
         b.mu.Lock()
         defer b.mu.Unlock()
 
         current, ok := b.tokens[d]
-        if !ok </span><span class="cov7" title="29">{
+        if !ok </span><span class="cov8" title="1">{
                 current = retryBudgetInitialTokens // 初回は小さく始め、refill で上限まで獲得させる
         }</span>
-        <span class="cov10" title="133">b.tokens[d] = min(retryBudgetMaxTokens, current+ratio)</span>
+        <span class="cov8" title="1">b.tokens[d] = min(retryBudgetMaxTokens, current+ratio)</span>
 }
 
 // tryConsume は、retry 1 回分のトークンを消費できれば true を返します。
-func (b *retryBudget) tryConsume(d Downstream) bool <span class="cov8" title="48">{
+func (b *retryBudget) tryConsume(d Downstream) bool <span class="cov8" title="1">{
         b.mu.Lock()
         defer b.mu.Unlock()
 
-        if b.tokens[d] &gt;= retryBudgetRetryCost </span><span class="cov7" title="40">{
+        if b.tokens[d] &gt;= retryBudgetRetryCost </span><span class="cov8" title="1">{
                 b.tokens[d] -= retryBudgetRetryCost
                 return true
         }</span>
-        <span class="cov4" title="8">return false</span>
+        <span class="cov8" title="1">return false</span>
 }
 </pre>
 		
@@ -11238,7 +11229,7 @@ func New(
         clk clock.Clock,
         registry Registry,
         metrics *observability.HTTPClientMetrics,
-) Client <span class="cov8" title="29">{
+) Client <span class="cov8" title="1">{
         return &amp;client{
                 httpClient: &amp;http.Client{
                         Transport:     transport.RoundTripper(),
@@ -11255,20 +11246,20 @@ func New(
 
 // noFollowRedirect は、リダイレクトを追従せず最終レスポンス（3xx）をそのまま返します。
 // 追従先の検証を呼び出し側に委ね、未検証ホストへの自動接続（SSRF 面）を避けます。
-func noFollowRedirect(_ *http.Request, _ []*http.Request) error <span class="cov1" title="1">{
+func noFollowRedirect(_ *http.Request, _ []*http.Request) error <span class="cov8" title="1">{
         return http.ErrUseLastResponse
 }</span>
 
 // Do は、req を送信し Response を返します。retry / backoff / deadline 規律を含みます。
-func (c *client) Do(ctx context.Context, req *Request) (*Response, error) <span class="cov8" title="31">{
-        if req.method == (Method{}) </span><span class="cov1" title="1">{
+func (c *client) Do(ctx context.Context, req *Request) (*Response, error) <span class="cov8" title="1">{
+        if req.method == (Method{}) </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrInvalidArgument, "Method is required")
         }</span>
-        <span class="cov8" title="30">if req.allowRetry &amp;&amp; req.idempotencyKey == "" </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if req.allowRetry &amp;&amp; req.idempotencyKey == "" </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrInvalidArgument, "AllowRetry requires IdempotencyKey")
         }</span>
 
-        <span class="cov8" title="29">profile := c.registry.Profile(req.downstream)
+        <span class="cov8" title="1">profile := c.registry.Profile(req.downstream)
         ds := string(req.downstream)
 
         // overall I/O デッドラインは実時間で設定する。context のタイマーは実時刻基準のため、
@@ -11292,48 +11283,48 @@ func (c *client) Do(ctx context.Context, req *Request) (*Response, error) <span 
 
 // doWithRetry は、breaker / budget / backoff を伴う retry ループを回します。
 // overallDeadline は注入 clock 基準の overall デッドラインで、retry 可否判定に用います。
-func (c *client) doWithRetry(ctx context.Context, req *Request, profile Profile, ds string, overallDeadline time.Time) (*Response, error) <span class="cov8" title="29">{
+func (c *client) doWithRetry(ctx context.Context, req *Request, profile Profile, ds string, overallDeadline time.Time) (*Response, error) <span class="cov8" title="1">{
         retrySafe := isRetrySafe(req)
         br := c.breakers.get(req.downstream, profile.Breaker)
 
         // breaker 状態は level（gauge）なので、最終状態を呼び出し終了時に 1 回だけ記録する。
-        defer func() </span><span class="cov8" title="29">{ c.metrics.SetBreakerState(ctx, ds, int64(br.currentState())) }</span>()
+        defer func() </span><span class="cov8" title="1">{ c.metrics.SetBreakerState(ctx, ds, int64(br.currentState())) }</span>()
 
         // MaxAttempts が未設定/不正でも最低 1 回は試行し、(nil, nil) を返さないようにする。
-        <span class="cov8" title="29">maxAttempts := max(1, profile.MaxAttempts)
+        <span class="cov8" title="1">maxAttempts := max(1, profile.MaxAttempts)
 
         var resp *Response
         var err error
-        for attempt := 1; attempt &lt;= maxAttempts; attempt++ </span><span class="cov10" title="51">{
+        for attempt := 1; attempt &lt;= maxAttempts; attempt++ </span><span class="cov8" title="1">{
                 allowed, generation := br.allow(c.clk.Now())
-                if !allowed </span><span class="cov2" title="2">{
-                        if resp == nil </span><span class="cov1" title="1">{
+                if !allowed </span><span class="cov8" title="1">{
+                        if resp == nil </span><span class="cov8" title="1">{
                                 return nil, xerrors.Wrap(errCircuitOpen, ds)
                         }</span>
-                        <span class="cov1" title="1">return resp, err</span>
+                        <span class="cov8" title="1">return resp, err</span>
                 }
 
-                <span class="cov9" title="49">resp, err = c.attempt(ctx, req, profile)
+                <span class="cov8" title="1">resp, err = c.attempt(ctx, req, profile)
                 serverFault := isRetryableOutcome(resp, err)
                 br.record(!serverFault, c.clk.Now(), generation)
 
-                if !retrySafe || !serverFault </span><span class="cov6" title="10">{
+                if !retrySafe || !serverFault </span><span class="cov8" title="1">{
                         return resp, err
                 }</span>
-                <span class="cov9" title="39">if attempt == maxAttempts </span><span class="cov7" title="14">{
+                <span class="cov8" title="1">if attempt == maxAttempts </span><span class="cov8" title="1">{
                         return resp, err
                 }</span>
-                <span class="cov8" title="25">if !c.budget.tryConsume(req.downstream) </span><span class="cov1" title="1">{
-                        return resp, err
-                }</span>
-
-                <span class="cov8" title="24">wait := retryWait(attempt, profile, resp, c.clk.Now())
-                if !c.canRetryWithin(overallDeadline, wait) </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">if !c.budget.tryConsume(req.downstream) </span><span class="cov8" title="1">{
                         return resp, err
                 }</span>
 
-                <span class="cov8" title="23">c.metrics.RecordRetry(ctx, ds)
-                if serr := c.sleeper.Sleep(ctx, wait); serr != nil </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">wait := retryWait(attempt, profile, resp, c.clk.Now())
+                if !c.canRetryWithin(overallDeadline, wait) </span><span class="cov8" title="1">{
+                        return resp, err
+                }</span>
+
+                <span class="cov8" title="1">c.metrics.RecordRetry(ctx, ds)
+                if serr := c.sleeper.Sleep(ctx, wait); serr != nil </span><span class="cov8" title="1">{
                         return nil, normalizeTransportError(serr)
                 }</span>
         }
@@ -11342,103 +11333,103 @@ func (c *client) doWithRetry(ctx context.Context, req *Request, profile Profile,
 
 // canRetryWithin は、backoff 待機後も overall デッドライン内に次の試行を開始できるかを、
 // 注入 clock のタイムライン上で判定します（実時間・jitter に依存しない決定的判定）。
-func (c *client) canRetryWithin(overallDeadline time.Time, backoff time.Duration) bool <span class="cov8" title="24">{
+func (c *client) canRetryWithin(overallDeadline time.Time, backoff time.Duration) bool <span class="cov8" title="1">{
         return c.clk.Now().Add(backoff).Before(overallDeadline)
 }</span>
 
 // attempt は、1 回の HTTP 試行を行います。
-func (c *client) attempt(ctx context.Context, req *Request, profile Profile) (*Response, error) <span class="cov9" title="49">{
+func (c *client) attempt(ctx context.Context, req *Request, profile Profile) (*Response, error) <span class="cov8" title="1">{
         attemptCtx, cancel := context.WithTimeout(ctx, profile.PerAttemptTimeout)
         defer cancel()
         attemptCtx = observability.ContextWithTracePropagation(attemptCtx, profile.PropagateTrace)
         attemptCtx = observability.ContextWithAllowPrivateNetwork(attemptCtx, profile.AllowPrivateNetwork)
 
         httpReq, err := buildRequest(attemptCtx, req)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrInvalidArgument, redactErrMessage(err))
         }</span>
 
-        <span class="cov9" title="48">httpResp, err := c.httpClient.Do(httpReq)
-        if err != nil </span><span class="cov4" title="5">{
+        <span class="cov8" title="1">httpResp, err := c.httpClient.Do(httpReq)
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, normalizeTransportError(err)
         }</span>
-        <span class="cov9" title="43">defer func() </span><span class="cov9" title="43">{ _ = httpResp.Body.Close() }</span>()
+        <span class="cov8" title="1">defer func() </span><span class="cov8" title="1">{ _ = httpResp.Body.Close() }</span>()
 
-        <span class="cov9" title="43">body, err := readBody(httpResp.Body, profile.MaxResponseBytes)
-        if err != nil </span><span class="cov4" title="4">{
+        <span class="cov8" title="1">body, err := readBody(httpResp.Body, profile.MaxResponseBytes)
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Join(apperror.ErrUnavailable, err)
         }</span>
 
-        <span class="cov9" title="39">resp := &amp;Response{
+        <span class="cov8" title="1">resp := &amp;Response{
                 StatusCode: httpResp.StatusCode,
                 Header:     Header(httpResp.Header),
                 Body:       body,
         }
 
-        if appErr := statusToAppError(httpResp.StatusCode); appErr != nil </span><span class="cov9" title="36">{
+        if appErr := statusToAppError(httpResp.StatusCode); appErr != nil </span><span class="cov8" title="1">{
                 msg := fmt.Sprintf("downstream %s returned status %d", req.downstream, httpResp.StatusCode)
                 return resp, xerrors.Wrap(appErr, msg)
         }</span>
-        <span class="cov3" title="3">return resp, nil</span>
+        <span class="cov8" title="1">return resp, nil</span>
 }
 
 // recordOutcome は、呼び出し結果を metrics に計上します。
-func (c *client) recordOutcome(ctx context.Context, ds string, resp *Response, err error) <span class="cov8" title="29">{
+func (c *client) recordOutcome(ctx context.Context, ds string, resp *Response, err error) <span class="cov8" title="1">{
         var class string
-        if resp != nil </span><span class="cov7" title="21">{
+        if resp != nil </span><span class="cov8" title="1">{
                 class = statusClass(resp.StatusCode)
                 c.metrics.RecordRequest(ctx, ds, class)
         }</span>
-        <span class="cov8" title="29">if err == nil </span><span class="cov3" title="3">{
+        <span class="cov8" title="1">if err == nil </span><span class="cov8" title="1">{
                 return
         }</span>
 
-        <span class="cov8" title="26">switch </span>{
-        case resp != nil:<span class="cov7" title="18">
+        <span class="cov8" title="1">switch </span>{
+        case resp != nil:<span class="cov8" title="1">
                 c.metrics.RecordError(ctx, ds, "http_"+class)</span>
-        case xerrors.Is(err, errCircuitOpen):<span class="cov1" title="1">
+        case xerrors.Is(err, errCircuitOpen):<span class="cov8" title="1">
                 c.metrics.RecordError(ctx, ds, "circuit_open")</span>
-        case xerrors.Is(err, apperror.ErrCanceled):<span class="cov2" title="2">
+        case xerrors.Is(err, apperror.ErrCanceled):<span class="cov8" title="1">
                 c.metrics.RecordError(ctx, ds, "canceled")</span>
-        default:<span class="cov4" title="5">
+        default:<span class="cov8" title="1">
                 c.metrics.RecordError(ctx, ds, "transport")</span>
         }
 }
 
 // buildRequest は、自前型の Request から net/http のリクエストを組み立てます。
-func buildRequest(ctx context.Context, req *Request) (*http.Request, error) <span class="cov9" title="50">{
+func buildRequest(ctx context.Context, req *Request) (*http.Request, error) <span class="cov8" title="1">{
         var body io.Reader
-        if len(req.body) &gt; 0 </span><span class="cov2" title="2">{
+        if len(req.body) &gt; 0 </span><span class="cov8" title="1">{
                 body = bytes.NewReader(req.body)
         }</span>
 
-        <span class="cov9" title="50">httpReq, err := http.NewRequestWithContext(ctx, req.method.String(), req.url, body)
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">httpReq, err := http.NewRequestWithContext(ctx, req.method.String(), req.url, body)
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov9" title="49">for key, values := range req.header </span><span class="cov1" title="1">{
-                for _, v := range values </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">for key, values := range req.header </span><span class="cov8" title="1">{
+                for _, v := range values </span><span class="cov8" title="1">{
                         httpReq.Header.Add(key, v)
                 }</span>
         }
-        <span class="cov9" title="49">if req.idempotencyKey != "" </span><span class="cov4" title="5">{
+        <span class="cov8" title="1">if req.idempotencyKey != "" </span><span class="cov8" title="1">{
                 httpReq.Header.Set(idempotencyHeader, req.idempotencyKey)
         }</span>
-        <span class="cov9" title="49">return httpReq, nil</span>
+        <span class="cov8" title="1">return httpReq, nil</span>
 }
 
 // readBody は、レスポンスボディを maxBytes まで読み込みます。上限超過時はエラーを返します。
-func readBody(body io.Reader, maxBytes int64) ([]byte, error) <span class="cov9" title="43">{
+func readBody(body io.Reader, maxBytes int64) ([]byte, error) <span class="cov8" title="1">{
         limited := io.LimitReader(body, maxBytes+1)
         data, err := io.ReadAll(limited)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov9" title="42">if int64(len(data)) &gt; maxBytes </span><span class="cov3" title="3">{
+        <span class="cov8" title="1">if int64(len(data)) &gt; maxBytes </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrUnavailable, "response body exceeds max bytes")
         }</span>
-        <span class="cov9" title="39">return data, nil</span>
+        <span class="cov8" title="1">return data, nil</span>
 }
 </pre>
 		
@@ -11466,80 +11457,80 @@ const (
 // 2xx は nil を返します。3xx はリダイレクト非追従のため未解決とみなし ErrUnavailable を返します
 // （resp に Location を残すので、追従が必要な呼び出し側はそれを参照できます）。
 // 写像は substrate 内部に閉じます。
-func statusToAppError(statusCode int) error <span class="cov10" title="54">{
+func statusToAppError(statusCode int) error <span class="cov8" title="1">{
         switch statusCode </span>{
-        case http.StatusBadRequest:<span class="cov3" title="3">
+        case http.StatusBadRequest:<span class="cov8" title="1">
                 return apperror.ErrInvalidArgument</span>
-        case http.StatusUnauthorized:<span class="cov1" title="1">
+        case http.StatusUnauthorized:<span class="cov8" title="1">
                 return apperror.ErrUnauthenticated</span>
-        case http.StatusForbidden:<span class="cov1" title="1">
+        case http.StatusForbidden:<span class="cov8" title="1">
                 return apperror.ErrPermissionDenied</span>
-        case http.StatusNotFound:<span class="cov2" title="2">
+        case http.StatusNotFound:<span class="cov8" title="1">
                 return apperror.ErrNotFound</span>
-        case http.StatusConflict:<span class="cov1" title="1">
+        case http.StatusConflict:<span class="cov8" title="1">
                 return apperror.ErrConflict</span>
-        case http.StatusUnprocessableEntity:<span class="cov1" title="1">
+        case http.StatusUnprocessableEntity:<span class="cov8" title="1">
                 return apperror.ErrValidation</span>
-        case http.StatusTooManyRequests:<span class="cov4" title="4">
+        case http.StatusTooManyRequests:<span class="cov8" title="1">
                 return apperror.ErrTooManyRequests</span>
         }
 
-        <span class="cov9" title="41">switch </span>{
-        case statusCode &gt;= statusServerErrorMin:<span class="cov8" title="31">
+        <span class="cov8" title="1">switch </span>{
+        case statusCode &gt;= statusServerErrorMin:<span class="cov8" title="1">
                 return apperror.ErrUnavailable</span>
-        case statusCode &gt;= statusClientErrorMin:<span class="cov1" title="1">
+        case statusCode &gt;= statusClientErrorMin:<span class="cov8" title="1">
                 return apperror.ErrInvalidArgument</span>
-        case statusCode &gt;= statusRedirectMin:<span class="cov3" title="3">
+        case statusCode &gt;= statusRedirectMin:<span class="cov8" title="1">
                 return apperror.ErrUnavailable</span> // 3xx: リダイレクト非追従のため未解決
-        default:<span class="cov5" title="6">
+        default:<span class="cov8" title="1">
                 return nil</span> // 2xx
         }
 }
 
 // normalizeTransportError は、応答取得前の transport 事象を apperror sentinel に写像します。
 // ctx cancel は ErrCanceled、それ以外（network / DNS / TLS / deadline 超過）は ErrUnavailable です。
-func normalizeTransportError(err error) error <span class="cov6" title="10">{
-        if xerrors.Is(err, context.Canceled) </span><span class="cov4" title="4">{
+func normalizeTransportError(err error) error <span class="cov8" title="1">{
+        if xerrors.Is(err, context.Canceled) </span><span class="cov8" title="1">{
                 return xerrors.Wrap(apperror.ErrCanceled, redactErrMessage(err))
         }</span>
-        <span class="cov5" title="6">return xerrors.Wrap(apperror.ErrUnavailable, redactErrMessage(err))</span>
+        <span class="cov8" title="1">return xerrors.Wrap(apperror.ErrUnavailable, redactErrMessage(err))</span>
 }
 
 // redactErrMessage は、エラーメッセージから URL のクエリ等の機密になり得る情報を除去します。
 // *url.Error は完全 URL（クエリ込み）を出力するため、クエリ・userinfo・fragment を除去し scheme/host/path を残します。
-func redactErrMessage(err error) string <span class="cov7" title="15">{
+func redactErrMessage(err error) string <span class="cov8" title="1">{
         var urlErr *url.Error
-        if xerrors.As(err, &amp;urlErr) </span><span class="cov6" title="10">{
+        if xerrors.As(err, &amp;urlErr) </span><span class="cov8" title="1">{
                 return fmt.Sprintf("%s %s: %v", urlErr.Op, redactURL(urlErr.URL), urlErr.Err)
         }</span>
-        <span class="cov4" title="5">return err.Error()</span>
+        <span class="cov8" title="1">return err.Error()</span>
 }
 
 // redactURL は、URL から機密になり得るクエリ・userinfo・fragment のみを除去し、
 // 診断に有用な scheme/host/path は残します。パース不能時のみ "upstream" を返します。
-func redactURL(rawURL string) string <span class="cov6" title="10">{
+func redactURL(rawURL string) string <span class="cov8" title="1">{
         parsed, err := url.Parse(rawURL)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return "upstream"
         }</span>
-        <span class="cov5" title="9">parsed.RawQuery = ""
+        <span class="cov8" title="1">parsed.RawQuery = ""
         parsed.User = nil
         parsed.Fragment = ""
         return parsed.String()</span>
 }
 
 // statusClass は、ステータスコードを metrics ラベル用のクラス文字列に変換します。
-func statusClass(statusCode int) string <span class="cov8" title="26">{
+func statusClass(statusCode int) string <span class="cov8" title="1">{
         switch </span>{
-        case statusCode &gt;= statusServerErrorMin:<span class="cov6" title="14">
+        case statusCode &gt;= statusServerErrorMin:<span class="cov8" title="1">
                 return "5xx"</span>
-        case statusCode &gt;= statusClientErrorMin:<span class="cov4" title="5">
+        case statusCode &gt;= statusClientErrorMin:<span class="cov8" title="1">
                 return "4xx"</span>
-        case statusCode &gt;= statusRedirectMin:<span class="cov2" title="2">
+        case statusCode &gt;= statusRedirectMin:<span class="cov8" title="1">
                 return "3xx"</span>
-        case statusCode &gt;= statusSuccessMin:<span class="cov4" title="4">
+        case statusCode &gt;= statusSuccessMin:<span class="cov8" title="1">
                 return "2xx"</span>
-        default:<span class="cov1" title="1">
+        default:<span class="cov8" title="1">
                 return "1xx"</span>
         }
 }
@@ -11627,88 +11618,88 @@ type Response struct {
 // MethodGet は、HTTP GET メソッドを返します。
 //
 // パッケージ外からの再代入で定義済み値が破壊されるのを防ぐため、関数として提供します。
-func MethodGet() Method <span class="cov10" title="69">{ return Method{"GET"} }</span>
+func MethodGet() Method <span class="cov8" title="1">{ return Method{"GET"} }</span>
 
 // MethodPost は、HTTP POST メソッドを返します。
-func MethodPost() Method <span class="cov7" title="24">{ return Method{"POST"} }</span>
+func MethodPost() Method <span class="cov8" title="1">{ return Method{"POST"} }</span>
 
 // MethodPut は、HTTP PUT メソッドを返します。
-func MethodPut() Method <span class="cov6" title="12">{ return Method{"PUT"} }</span>
+func MethodPut() Method <span class="cov8" title="1">{ return Method{"PUT"} }</span>
 
 // MethodPatch は、HTTP PATCH メソッドを返します。
-func MethodPatch() Method <span class="cov4" title="6">{ return Method{"PATCH"} }</span>
+func MethodPatch() Method <span class="cov8" title="1">{ return Method{"PATCH"} }</span>
 
 // MethodDelete は、HTTP DELETE メソッドを返します。
-func MethodDelete() Method <span class="cov6" title="11">{ return Method{"DELETE"} }</span>
+func MethodDelete() Method <span class="cov8" title="1">{ return Method{"DELETE"} }</span>
 
 // String は、HTTP メソッド文字列を返します（ゼロ値は ""）。
-func (m Method) String() string <span class="cov9" title="56">{ return m.s }</span>
+func (m Method) String() string <span class="cov8" title="1">{ return m.s }</span>
 
 // NewRequest は、必須項目（method / downstream / url）をシグネチャで強制してリクエストを生成します。
 // 任意メソッド文字列は型で排除済み。空メソッドや AllowRetry の key 不在は Do 実行時に弾かれます。
-func NewRequest(method Method, downstream Downstream, url string, opts ...RequestOption) *Request <span class="cov8" title="37">{
+func NewRequest(method Method, downstream Downstream, url string, opts ...RequestOption) *Request <span class="cov8" title="1">{
         r := &amp;Request{
                 downstream: downstream,
                 method:     method,
                 url:        url,
         }
-        for _, opt := range opts </span><span class="cov7" title="18">{
+        for _, opt := range opts </span><span class="cov8" title="1">{
                 opt(r)
         }</span>
-        <span class="cov8" title="37">return r</span>
+        <span class="cov8" title="1">return r</span>
 }
 
 // WithHeader は、リクエストヘッダを設定します。
-func WithHeader(h Header) RequestOption <span class="cov4" title="5">{ return func(r *Request) </span><span class="cov4" title="5">{ r.header = h }</span> }
+func WithHeader(h Header) RequestOption <span class="cov8" title="1">{ return func(r *Request) </span><span class="cov8" title="1">{ r.header = h }</span> }
 
 // WithBody は、リクエストボディを設定します。
-func WithBody(b []byte) RequestOption <span class="cov4" title="6">{ return func(r *Request) </span><span class="cov4" title="6">{ r.body = b }</span> }
+func WithBody(b []byte) RequestOption <span class="cov8" title="1">{ return func(r *Request) </span><span class="cov8" title="1">{ r.body = b }</span> }
 
 // WithIdempotencyKey は、冪等性キーを設定します（retry は許可しません）。
-func WithIdempotencyKey(key string) RequestOption <span class="cov3" title="4">{
-        return func(r *Request) </span><span class="cov3" title="4">{ r.idempotencyKey = key }</span>
+func WithIdempotencyKey(key string) RequestOption <span class="cov8" title="1">{
+        return func(r *Request) </span><span class="cov8" title="1">{ r.idempotencyKey = key }</span>
 }
 
 // WithRetry は、非冪等メソッドの retry を許可し idempotencyKey を同時に設定します。
 // 空 key のまま（WithRetry("")）Do を呼ぶと ErrInvalidArgument で弾かれます（二重実行防止）。
-func WithRetry(idempotencyKey string) RequestOption <span class="cov3" title="3">{
-        return func(r *Request) </span><span class="cov3" title="3">{
+func WithRetry(idempotencyKey string) RequestOption <span class="cov8" title="1">{
+        return func(r *Request) </span><span class="cov8" title="1">{
                 r.allowRetry = true
                 r.idempotencyKey = idempotencyKey
         }</span>
 }
 
 // Downstream は、論理依存名を返します。
-func (r *Request) Downstream() Downstream <span class="cov3" title="3">{ return r.downstream }</span>
+func (r *Request) Downstream() Downstream <span class="cov8" title="1">{ return r.downstream }</span>
 
 // Method は、HTTP メソッドを返します。
-func (r *Request) Method() Method <span class="cov3" title="4">{ return r.method }</span>
+func (r *Request) Method() Method <span class="cov8" title="1">{ return r.method }</span>
 
 // URL は、リクエスト先 URL を返します。
-func (r *Request) URL() string <span class="cov4" title="5">{ return r.url }</span>
+func (r *Request) URL() string <span class="cov8" title="1">{ return r.url }</span>
 
 // Header は、リクエストヘッダの防御的コピーを返します（Request は不変値オブジェクトのため内部状態を共有しません）。
-func (r *Request) Header() Header <span class="cov5" title="8">{ return r.header.clone() }</span>
+func (r *Request) Header() Header <span class="cov8" title="1">{ return r.header.clone() }</span>
 
 // Body は、リクエストボディの防御的コピーを返します（Request は不変値オブジェクトのため内部状態を共有しません）。
-func (r *Request) Body() []byte <span class="cov4" title="6">{ return slices.Clone(r.body) }</span>
+func (r *Request) Body() []byte <span class="cov8" title="1">{ return slices.Clone(r.body) }</span>
 
 // IdempotencyKey は、冪等性キーを返します（未設定時は ""）。
-func (r *Request) IdempotencyKey() string <span class="cov4" title="5">{ return r.idempotencyKey }</span>
+func (r *Request) IdempotencyKey() string <span class="cov8" title="1">{ return r.idempotencyKey }</span>
 
 // AllowRetry は、非冪等メソッドの retry 許可フラグを返します。
-func (r *Request) AllowRetry() bool <span class="cov4" title="5">{ return r.allowRetry }</span>
+func (r *Request) AllowRetry() bool <span class="cov8" title="1">{ return r.allowRetry }</span>
 
 // clone は、Header の深いコピーを返します（map と各値スライスを複製し、内部状態との共有を断ちます）。
-func (h Header) clone() Header <span class="cov5" title="8">{
-        if h == nil </span><span class="cov1" title="1">{
+func (h Header) clone() Header <span class="cov8" title="1">{
+        if h == nil </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov5" title="7">out := make(Header, len(h))
-        for k, v := range h </span><span class="cov5" title="9">{
+        <span class="cov8" title="1">out := make(Header, len(h))
+        for k, v := range h </span><span class="cov8" title="1">{
                 out[k] = slices.Clone(v)
         }</span>
-        <span class="cov5" title="7">return out</span>
+        <span class="cov8" title="1">return out</span>
 }
 </pre>
 		
@@ -11797,7 +11788,7 @@ type staticRegistry struct {
 }
 
 // DefaultProfile は、未登録 Downstream に適用される安全側のデフォルト Profile を返します。
-func DefaultProfile() Profile <span class="cov10" title="61">{
+func DefaultProfile() Profile <span class="cov8" title="1">{
         return Profile{
                 PerAttemptTimeout:   defaultPerAttemptTimeout,
                 OverallTimeout:      defaultOverallTimeout,
@@ -11818,7 +11809,7 @@ func DefaultProfile() Profile <span class="cov10" title="61">{
 }</span>
 
 // NewRegistry は、profiles を保持する Registry を生成します。未登録キーは DefaultProfile に fallback します。
-func NewRegistry(profiles map[Downstream]Profile) Registry <span class="cov8" title="34">{
+func NewRegistry(profiles map[Downstream]Profile) Registry <span class="cov8" title="1">{
         return &amp;staticRegistry{
                 profiles: profiles,
                 fallback: DefaultProfile(),
@@ -11827,20 +11818,20 @@ func NewRegistry(profiles map[Downstream]Profile) Registry <span class="cov8" ti
 
 // NewRegistryFromProfiles は、各 gateway が寄与した DownstreamProfile 群から Registry を生成します。
 // 未登録の Downstream には DefaultProfile が適用されます。
-func NewRegistryFromProfiles(profiles []DownstreamProfile) Registry <span class="cov4" title="6">{
+func NewRegistryFromProfiles(profiles []DownstreamProfile) Registry <span class="cov8" title="1">{
         m := make(map[Downstream]Profile, len(profiles))
-        for _, p := range profiles </span><span class="cov4" title="6">{
+        for _, p := range profiles </span><span class="cov8" title="1">{
                 m[p.Name] = p.Profile
         }</span>
-        <span class="cov4" title="6">return NewRegistry(m)</span>
+        <span class="cov8" title="1">return NewRegistry(m)</span>
 }
 
 // Profile は、d に対応する Profile を返します。未登録なら fallback を返します。
-func (r *staticRegistry) Profile(d Downstream) Profile <span class="cov8" title="35">{
-        if p, ok := r.profiles[d]; ok </span><span class="cov7" title="22">{
+func (r *staticRegistry) Profile(d Downstream) Profile <span class="cov8" title="1">{
+        if p, ok := r.profiles[d]; ok </span><span class="cov8" title="1">{
                 return p
         }</span>
-        <span class="cov6" title="13">return r.fallback</span>
+        <span class="cov8" title="1">return r.fallback</span>
 }
 </pre>
 		
@@ -11870,42 +11861,42 @@ const (
 
 // isRetrySafe は、req が retry してよいリクエストかを返します。
 // 冪等メソッド(GET/PUT/DELETE)は常に安全、非冪等メソッド(POST/PATCH)は AllowRetry 明示時のみ安全です。
-func isRetrySafe(req *Request) bool <span class="cov6" title="37">{
+func isRetrySafe(req *Request) bool <span class="cov8" title="1">{
         switch req.method </span>{
-        case MethodGet(), MethodPut(), MethodDelete():<span class="cov5" title="29">
+        case MethodGet(), MethodPut(), MethodDelete():<span class="cov8" title="1">
                 return true</span>
-        case MethodPost(), MethodPatch():<span class="cov3" title="7">
+        case MethodPost(), MethodPatch():<span class="cov8" title="1">
                 return req.allowRetry</span>
-        default:<span class="cov1" title="1">
+        default:<span class="cov8" title="1">
                 return false</span>
         }
 }
 
 // isRetryableOutcome は、試行結果が retry 対象かを返します。
 // 5xx / 429 / 応答未取得の transport 失敗は retry 対象、4xx / 成功 / ctx cancel は対象外です。
-func isRetryableOutcome(resp *Response, err error) bool <span class="cov6" title="59">{
-        if err == nil </span><span class="cov2" title="4">{
+func isRetryableOutcome(resp *Response, err error) bool <span class="cov8" title="1">{
+        if err == nil </span><span class="cov8" title="1">{
                 return false
         }</span>
-        <span class="cov6" title="55">if xerrors.Is(err, apperror.ErrCanceled) </span><span class="cov1" title="2">{
+        <span class="cov8" title="1">if xerrors.Is(err, apperror.ErrCanceled) </span><span class="cov8" title="1">{
                 return false
         }</span>
-        <span class="cov6" title="53">if resp != nil </span><span class="cov6" title="41">{
+        <span class="cov8" title="1">if resp != nil </span><span class="cov8" title="1">{
                 return resp.StatusCode == retryableStatusTooManyRequests ||
                         resp.StatusCode &gt;= retryableStatusServerErrorMin
         }</span>
         // 応答未取得は transport 失敗(ErrUnavailable)のみ retry 対象。
         // buildRequest 由来の client エラー(ErrInvalidArgument 等)は決定的なので retry しない。
-        <span class="cov4" title="12">return xerrors.Is(err, apperror.ErrUnavailable)</span>
+        <span class="cov8" title="1">return xerrors.Is(err, apperror.ErrUnavailable)</span>
 }
 
 // computeBackoff は、attempt（1 起算）に対する指数バックオフ + full jitter の待機時間を返します。
-func computeBackoff(attempt int, profile Profile) time.Duration <span class="cov10" title="524">{
-        if attempt &lt; 1 </span><span class="cov1" title="1">{
+func computeBackoff(attempt int, profile Profile) time.Duration <span class="cov8" title="1">{
+        if attempt &lt; 1 </span><span class="cov8" title="1">{
                 attempt = 1
         }</span>
 
-        <span class="cov10" title="524">exp := backoff.Exponential{
+        <span class="cov8" title="1">exp := backoff.Exponential{
                 Initial:    profile.BaseBackoff,
                 Max:        profile.MaxBackoff,
                 Multiplier: backoffMultiplier,
@@ -11916,44 +11907,44 @@ func computeBackoff(attempt int, profile Profile) time.Duration <span class="cov
 // retryWait は、次の retry までの待機時間を決定します。
 // レスポンスに Retry-After があればそれを優先し、無ければ指数バックオフ + full jitter を用います。
 // Retry-After が過大でも overall deadline 規律（canRetryWithin）が別途打ち切るため、ここでは上限を設けません。
-func retryWait(attempt int, profile Profile, resp *Response, now time.Time) time.Duration <span class="cov7" title="126">{
-        if resp != nil </span><span class="cov7" title="72">{
-                if d, ok := retryAfter(resp.Header, now); ok </span><span class="cov2" title="3">{
+func retryWait(attempt int, profile Profile, resp *Response, now time.Time) time.Duration <span class="cov8" title="1">{
+        if resp != nil </span><span class="cov8" title="1">{
+                if d, ok := retryAfter(resp.Header, now); ok </span><span class="cov8" title="1">{
                         return d
                 }</span>
         }
-        <span class="cov7" title="123">return computeBackoff(attempt, profile)</span>
+        <span class="cov8" title="1">return computeBackoff(attempt, profile)</span>
 }
 
 // retryAfter は、Retry-After ヘッダ（delay-seconds 形式 / HTTP-date 形式）を解釈し待機時間を返します。
 // 解釈できない / 不在の場合は (0, false) を返し、呼び出し側は通常のバックオフへ fallback します。
-func retryAfter(header Header, now time.Time) (time.Duration, bool) <span class="cov7" title="80">{
-        if header == nil </span><span class="cov1" title="1">{
+func retryAfter(header Header, now time.Time) (time.Duration, bool) <span class="cov8" title="1">{
+        if header == nil </span><span class="cov8" title="1">{
                 return 0, false
         }</span>
-        <span class="cov7" title="79">values, ok := header[retryAfterHeader]
-        if !ok || len(values) == 0 </span><span class="cov7" title="70">{
+        <span class="cov8" title="1">values, ok := header[retryAfterHeader]
+        if !ok || len(values) == 0 </span><span class="cov8" title="1">{
                 return 0, false
         }</span>
 
-        <span class="cov4" title="9">raw := strings.TrimSpace(values[0])
-        if raw == "" </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">raw := strings.TrimSpace(values[0])
+        if raw == "" </span><span class="cov8" title="1">{
                 return 0, false
         }</span>
 
         // delay-seconds 形式（非負整数秒）。
-        <span class="cov3" title="8">if secs, err := strconv.Atoi(raw); err == nil </span><span class="cov2" title="4">{
-                if secs &lt; 0 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if secs, err := strconv.Atoi(raw); err == nil </span><span class="cov8" title="1">{
+                if secs &lt; 0 </span><span class="cov8" title="1">{
                         return 0, false
                 }</span>
-                <span class="cov2" title="3">return time.Duration(secs) * time.Second, true</span>
+                <span class="cov8" title="1">return time.Duration(secs) * time.Second, true</span>
         }
 
         // HTTP-date 形式。
-        <span class="cov2" title="4">if at, err := http.ParseTime(raw); err == nil </span><span class="cov2" title="3">{
+        <span class="cov8" title="1">if at, err := http.ParseTime(raw); err == nil </span><span class="cov8" title="1">{
                 return max(0, at.Sub(now)), true
         }</span>
-        <span class="cov1" title="1">return 0, false</span>
+        <span class="cov8" title="1">return 0, false</span>
 }
 </pre>
 		
@@ -11973,28 +11964,28 @@ var ErrInvalidEndpoint = xerrors.Wrap(apperror.ErrInvalidArgument, "invalid outb
 // NewEndpoint は、config からメッセージ送信先エンドポイント URL を解決して返します。
 // 空・不正な URL は relay 起動時点で弾きます（未設定のまま起動すると全 publish が失敗し
 // 気付かぬうちに全メッセージが dead 化するため、サイレント障害を防ぐ）。
-func NewEndpoint(cfg *config.OutboxConfig) (Endpoint, error) <span class="cov6" title="4">{
+func NewEndpoint(cfg *config.OutboxConfig) (Endpoint, error) <span class="cov8" title="1">{
         return parseEndpoint(cfg.Endpoint())
 }</span>
 
 // parseEndpoint は、エンドポイント文字列を検証して Endpoint へ変換します。
-func parseEndpoint(raw string) (Endpoint, error) <span class="cov10" title="12">{
-        if raw == "" </span><span class="cov4" title="3">{
+func parseEndpoint(raw string) (Endpoint, error) <span class="cov8" title="1">{
+        if raw == "" </span><span class="cov8" title="1">{
                 return "", xerrors.Wrap(ErrInvalidEndpoint, "OUTBOX_ENDPOINT must not be empty")
         }</span>
 
-        <span class="cov8" title="9">u, err := url.Parse(raw)
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">u, err := url.Parse(raw)
+        if err != nil </span><span class="cov8" title="1">{
                 return "", xerrors.Join(ErrInvalidEndpoint, xerrors.Wrap(err, "OUTBOX_ENDPOINT is not a valid URL"))
         }</span>
-        <span class="cov8" title="8">if u.Scheme != "http" &amp;&amp; u.Scheme != "https" </span><span class="cov3" title="2">{
+        <span class="cov8" title="1">if u.Scheme != "http" &amp;&amp; u.Scheme != "https" </span><span class="cov8" title="1">{
                 return "", xerrors.Wrap(ErrInvalidEndpoint, "OUTBOX_ENDPOINT scheme must be http or https")
         }</span>
-        <span class="cov7" title="6">if u.Host == "" </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if u.Host == "" </span><span class="cov8" title="1">{
                 return "", xerrors.Wrap(ErrInvalidEndpoint, "OUTBOX_ENDPOINT must include a host")
         }</span>
 
-        <span class="cov6" title="5">return Endpoint(raw), nil</span>
+        <span class="cov8" title="1">return Endpoint(raw), nil</span>
 }
 </pre>
 		
@@ -12028,7 +12019,7 @@ type httpPublisher struct {
 // 二重になる。これを避けるため MaxAttempts=1 で transport retry を無効化する（D10）。
 // traceparent は emit 時に capture した値を headers で明示伝搬するため、ここでの自動 inject は抑止する。
 // 送信先はクラスター外部の受信エンドポイントを想定するため、private/loopback 宛てを拒否する（SSRF 抑止）。
-func NewDownstreamProfile() httpclient.DownstreamProfile <span class="cov5" title="2">{
+func NewDownstreamProfile() httpclient.DownstreamProfile <span class="cov8" title="1">{
         p := httpclient.DefaultProfile()
         p.MaxAttempts = 1
         p.PropagateTrace = false
@@ -12041,7 +12032,7 @@ func New(
         endpoint Endpoint,
         client httpclient.Client,
         tf observability.TracerFactory,
-) boundary.Publisher <span class="cov10" title="4">{
+) boundary.Publisher <span class="cov8" title="1">{
         return &amp;httpPublisher{
                 endpoint: endpoint,
                 client:   client,
@@ -12052,18 +12043,18 @@ func New(
 // Publish は、メッセージを受信エンドポイントへ POST します。
 // message_id を Idempotency-Key として伝搬し、非冪等メソッドだが retry は明示的に無効化します
 // （再送は relay の次 poll が担う）。非 2xx / transport 失敗は substrate が apperror へ写像して返します。
-func (p *httpPublisher) Publish(ctx context.Context, m boundary.Message) error <span class="cov5" title="2">{
+func (p *httpPublisher) Publish(ctx context.Context, m boundary.Message) error <span class="cov8" title="1">{
         ctx, endSpan := p.tracer.Start(ctx)
         defer endSpan()
 
         header := httpclient.Header{"Content-Type": {"application/json"}}
-        for k, v := range m.Headers </span><span class="cov1" title="1">{
+        for k, v := range m.Headers </span><span class="cov8" title="1">{
                 header[k] = []string{v}
         }</span>
 
         // AllowRetry は付与しない（at-least-once は relay の poll ループが担う）。
         // 受信側 dedup 用に IdempotencyKey（message_id）のみ伝搬する。
-        <span class="cov5" title="2">_, err := p.client.Do(ctx, httpclient.NewRequest(
+        <span class="cov8" title="1">_, err := p.client.Do(ctx, httpclient.NewRequest(
                 httpclient.MethodPost(), downstream, string(p.endpoint),
                 httpclient.WithHeader(header),
                 httpclient.WithBody(m.Payload),
@@ -12084,14 +12075,14 @@ import (
 
 // normalizeError は、SQS/AWS のエラーを apperror センチネルへ正規化します。
 // broker 由来のエラーは一時的（リトライ可能）とみなし ErrUnavailable に寄せます。
-func normalizeError(err error) error <span class="cov10" title="22">{
-        if err == nil </span><span class="cov6" title="7">{
+func normalizeError(err error) error <span class="cov8" title="1">{
+        if err == nil </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov8" title="15">if xerrors.Is(err, context.Canceled) </span><span class="cov6" title="7">{
+        <span class="cov8" title="1">if xerrors.Is(err, context.Canceled) </span><span class="cov8" title="1">{
                 return xerrors.Join(apperror.ErrCanceled, err)
         }</span>
-        <span class="cov7" title="8">return xerrors.Join(apperror.ErrUnavailable, err)</span>
+        <span class="cov8" title="1">return xerrors.Join(apperror.ErrUnavailable, err)</span>
 }
 </pre>
 		
@@ -12121,14 +12112,14 @@ type deadLetter struct {
 }
 
 // NewDeadLetter は、DLQ への退避を行う FailureHandler を生成します。
-func NewDeadLetter(api API, dlqURL string, tf observability.TracerFactory) worker.FailureHandler <span class="cov10" title="4">{
+func NewDeadLetter(api API, dlqURL string, tf observability.TracerFactory) worker.FailureHandler <span class="cov8" title="1">{
         return &amp;deadLetter{api: api, dlqURL: dlqURL, tracer: tf.Infra()}
 }</span>
 
 // Fail は、永久失敗メッセージを DLQ へ SendMessage します。
 // 失敗理由は分類カテゴリのみ属性に付与し、cause の詳細は載せません
 // （cause が PII/内部詳細を含みうるため。詳細は engine 側のログに残ります）。
-func (d *deadLetter) Fail(ctx context.Context, m worker.Message, _ error) error <span class="cov8" title="3">{
+func (d *deadLetter) Fail(ctx context.Context, m worker.Message, _ error) error <span class="cov8" title="1">{
         ctx, endSpan := d.tracer.Start(ctx)
         defer endSpan()
 
@@ -12195,26 +12186,26 @@ type consumer struct {
 }
 
 // NewConsumer は、SQS Consumer を生成します。
-func NewConsumer(api API, cfg Config, tf observability.TracerFactory) worker.Consumer <span class="cov10" title="24">{
+func NewConsumer(api API, cfg Config, tf observability.TracerFactory) worker.Consumer <span class="cov8" title="1">{
         return &amp;consumer{api: api, cfg: cfg, tracer: tf.Infra()}
 }</span>
 
 // Receive は、ReceiveMessage で long-poll し、broker 非依存の Message へ変換して返します。
-func (c *consumer) Receive(ctx context.Context, maxMessages int) ([]worker.Message, error) <span class="cov7" title="9">{
+func (c *consumer) Receive(ctx context.Context, maxMessages int) ([]worker.Message, error) <span class="cov8" title="1">{
         ctx, endSpan := c.tracer.Start(ctx)
         defer endSpan()
 
         limit := maxMessages
-        if c.cfg.MaxMessages &gt; 0 &amp;&amp; limit &gt; int(c.cfg.MaxMessages) </span><span class="cov1" title="1">{
+        if c.cfg.MaxMessages &gt; 0 &amp;&amp; limit &gt; int(c.cfg.MaxMessages) </span><span class="cov8" title="1">{
                 limit = int(c.cfg.MaxMessages)
         }</span>
-        <span class="cov7" title="9">if limit &gt; maxSQSBatch </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if limit &gt; maxSQSBatch </span><span class="cov8" title="1">{
                 limit = maxSQSBatch
         }</span>
-        <span class="cov7" title="9">if limit &lt; 1 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if limit &lt; 1 </span><span class="cov8" title="1">{
                 limit = 1
         }</span>
-        <span class="cov7" title="9">n := int32(limit) // limit は 1..maxSQSBatch(10) に丸め済み
+        <span class="cov8" title="1">n := int32(limit) // limit は 1..maxSQSBatch(10) に丸め済み
 
         out, err := c.api.ReceiveMessage(ctx, &amp;sqs.ReceiveMessageInput{
                 QueueUrl:            aws.String(c.cfg.QueueURL),
@@ -12227,19 +12218,19 @@ func (c *consumer) Receive(ctx context.Context, maxMessages int) ([]worker.Messa
                 },
                 MessageAttributeNames: []string{"All"},
         })
-        if err != nil </span><span class="cov2" title="2">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, normalizeError(err)
         }</span>
 
-        <span class="cov6" title="7">msgs := make([]worker.Message, 0, len(out.Messages))
-        for _, m := range out.Messages </span><span class="cov4" title="3">{
+        <span class="cov8" title="1">msgs := make([]worker.Message, 0, len(out.Messages))
+        for _, m := range out.Messages </span><span class="cov8" title="1">{
                 msgs = append(msgs, toMessage(m))
         }</span>
-        <span class="cov6" title="7">return msgs, nil</span>
+        <span class="cov8" title="1">return msgs, nil</span>
 }
 
 // Ack は、DeleteMessage でメッセージを削除します。
-func (c *consumer) Ack(ctx context.Context, m worker.Message) error <span class="cov4" title="3">{
+func (c *consumer) Ack(ctx context.Context, m worker.Message) error <span class="cov8" title="1">{
         ctx, endSpan := c.tracer.Start(ctx)
         defer endSpan()
 
@@ -12251,7 +12242,7 @@ func (c *consumer) Ack(ctx context.Context, m worker.Message) error <span class=
 }</span>
 
 // Nack は、メッセージを即時に再配送へ戻します。
-func (c *consumer) Nack(ctx context.Context, m worker.Message) error <span class="cov4" title="4">{
+func (c *consumer) Nack(ctx context.Context, m worker.Message) error <span class="cov8" title="1">{
         ctx, endSpan := c.tracer.Start(ctx)
         defer endSpan()
 
@@ -12265,12 +12256,12 @@ func (c *consumer) Nack(ctx context.Context, m worker.Message) error <span class
 
 // NackWithBackoff は、最低 d だけ遅延させてからメッセージを再配送へ戻します。
 // d&lt;=0 は Nack（即時）と等価です。
-func (c *consumer) NackWithBackoff(ctx context.Context, m worker.Message, d time.Duration) error <span class="cov5" title="5">{
-        if d &lt;= 0 </span><span class="cov1" title="1">{
+func (c *consumer) NackWithBackoff(ctx context.Context, m worker.Message, d time.Duration) error <span class="cov8" title="1">{
+        if d &lt;= 0 </span><span class="cov8" title="1">{
                 return c.Nack(ctx, m)
         }</span>
 
-        <span class="cov4" title="4">ctx, endSpan := c.tracer.Start(ctx)
+        <span class="cov8" title="1">ctx, endSpan := c.tracer.Start(ctx)
         defer endSpan()
 
         _, err := c.api.ChangeMessageVisibility(ctx, &amp;sqs.ChangeMessageVisibilityInput{
@@ -12282,7 +12273,7 @@ func (c *consumer) NackWithBackoff(ctx context.Context, m worker.Message, d time
 }
 
 // Extend は、可視性タイムアウトを延長します（長時間 handler のハートビート）。
-func (c *consumer) Extend(ctx context.Context, m worker.Message, d time.Duration) error <span class="cov4" title="3">{
+func (c *consumer) Extend(ctx context.Context, m worker.Message, d time.Duration) error <span class="cov8" title="1">{
         ctx, endSpan := c.tracer.Start(ctx)
         defer endSpan()
 
@@ -12297,7 +12288,7 @@ func (c *consumer) Extend(ctx context.Context, m worker.Message, d time.Duration
 // visibilitySeconds は、Duration を SQS の可視性秒数（int32）へ丸めます。
 // サブ秒は切り捨てると 0 秒＝即時再配送になり処理中メッセージが重複配送されるため、
 // 切り上げたうえで 1 秒を下限とします。
-func visibilitySeconds(d time.Duration) int32 <span class="cov6" title="7">{
+func visibilitySeconds(d time.Duration) int32 <span class="cov8" title="1">{
         return max(1, int32(math.Ceil(d.Seconds())))
 }</span>
 
@@ -12305,23 +12296,23 @@ func visibilitySeconds(d time.Duration) int32 <span class="cov6" title="7">{
 //   - MessageAttributes（traceparent 等）→ Attributes
 //   - ReceiptHandle → Attributes の予約キー（engine は解釈しない）
 //   - ApproximateReceiveCount → ReceiveCount / MessageGroupId → PartitionKey
-func toMessage(m types.Message) worker.Message <span class="cov4" title="3">{
+func toMessage(m types.Message) worker.Message <span class="cov8" title="1">{
         attrs := make(map[string]string, len(m.MessageAttributes)+1)
-        for k, v := range m.MessageAttributes </span><span class="cov2" title="2">{
-                if v.StringValue != nil </span><span class="cov1" title="1">{
+        for k, v := range m.MessageAttributes </span><span class="cov8" title="1">{
+                if v.StringValue != nil </span><span class="cov8" title="1">{
                         attrs[k] = *v.StringValue
                 }</span>
         }
-        <span class="cov4" title="3">if m.ReceiptHandle != nil </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if m.ReceiptHandle != nil </span><span class="cov8" title="1">{
                 attrs[worker.AttrReceiptHandle] = *m.ReceiptHandle
         }</span>
 
-        <span class="cov4" title="3">receiveCount := 0
-        if s, ok := m.Attributes[string(types.MessageSystemAttributeNameApproximateReceiveCount)]; ok </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">receiveCount := 0
+        if s, ok := m.Attributes[string(types.MessageSystemAttributeNameApproximateReceiveCount)]; ok </span><span class="cov8" title="1">{
                 receiveCount, _ = strconv.Atoi(s)
         }</span>
 
-        <span class="cov4" title="3">return worker.Message{
+        <span class="cov8" title="1">return worker.Message{
                 ID:           aws.ToString(m.MessageId),
                 Body:         []byte(aws.ToString(m.Body)),
                 Attributes:   attrs,
@@ -12358,35 +12349,35 @@ type statsProvider struct {
 
 // NewQueueStatsProvider は、SQS の滞留量を取得する QueueStatsProvider を生成します。
 // NewConsumer とは別 capability として provide し、既存の Consumer interface 返しを変更しません。
-func NewQueueStatsProvider(api API, cfg Config, tf observability.TracerFactory) worker.QueueStatsProvider <span class="cov7" title="9">{
+func NewQueueStatsProvider(api API, cfg Config, tf observability.TracerFactory) worker.QueueStatsProvider <span class="cov8" title="1">{
         return &amp;statsProvider{api: api, cfg: cfg, tracer: tf.Infra()}
 }</span>
 
 // QueueStats は、source queue と（DLQURL があれば）DLQ の滞留量を取得します。
 // DLQURL が空の場合は DLQ の取得をスキップし、DLQ は nil のままにします。
-func (p *statsProvider) QueueStats(ctx context.Context) (worker.QueueStats, error) <span class="cov7" title="8">{
+func (p *statsProvider) QueueStats(ctx context.Context) (worker.QueueStats, error) <span class="cov8" title="1">{
         ctx, endSpan := p.tracer.Start(ctx)
         defer endSpan()
 
         source, err := p.queueDepth(ctx, p.cfg.QueueURL)
-        if err != nil </span><span class="cov3" title="2">{
+        if err != nil </span><span class="cov8" title="1">{
                 return worker.QueueStats{}, err
         }</span>
-        <span class="cov6" title="6">stats := worker.QueueStats{Source: source}
+        <span class="cov8" title="1">stats := worker.QueueStats{Source: source}
 
-        if p.cfg.DLQURL != "" </span><span class="cov3" title="2">{
+        if p.cfg.DLQURL != "" </span><span class="cov8" title="1">{
                 dlq, err := p.queueDepth(ctx, p.cfg.DLQURL)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return worker.QueueStats{}, err
                 }</span>
-                <span class="cov1" title="1">stats.DLQ = &amp;dlq</span>
+                <span class="cov8" title="1">stats.DLQ = &amp;dlq</span>
         }
 
-        <span class="cov5" title="5">return stats, nil</span>
+        <span class="cov8" title="1">return stats, nil</span>
 }
 
 // queueDepth は、GetQueueAttributes で approximate な滞留量を取得し QueueDepth へ正規化します。
-func (p *statsProvider) queueDepth(ctx context.Context, queueURL string) (worker.QueueDepth, error) <span class="cov7" title="10">{
+func (p *statsProvider) queueDepth(ctx context.Context, queueURL string) (worker.QueueDepth, error) <span class="cov8" title="1">{
         out, err := p.api.GetQueueAttributes(ctx, &amp;sqs.GetQueueAttributesInput{
                 QueueUrl: aws.String(queueURL),
                 AttributeNames: []types.QueueAttributeName{
@@ -12395,11 +12386,11 @@ func (p *statsProvider) queueDepth(ctx context.Context, queueURL string) (worker
                         types.QueueAttributeNameApproximateNumberOfMessagesDelayed,
                 },
         })
-        if err != nil </span><span class="cov4" title="3">{
+        if err != nil </span><span class="cov8" title="1">{
                 return worker.QueueDepth{}, normalizeError(err)
         }</span>
 
-        <span class="cov6" title="7">return worker.QueueDepth{
+        <span class="cov8" title="1">return worker.QueueDepth{
                 Visible:  parseApproxCount(out.Attributes[string(types.QueueAttributeNameApproximateNumberOfMessages)]),
                 InFlight: parseApproxCount(out.Attributes[string(types.QueueAttributeNameApproximateNumberOfMessagesNotVisible)]),
                 Delayed:  parseApproxCount(out.Attributes[string(types.QueueAttributeNameApproximateNumberOfMessagesDelayed)]),
@@ -12408,12 +12399,12 @@ func (p *statsProvider) queueDepth(ctx context.Context, queueURL string) (worker
 
 // parseApproxCount は、SQS の attribute 値を int64 へ変換します。
 // attribute 欠落（空文字）や parse 不能は、滞留傾向の gauge として 0 件扱いにします。
-func parseApproxCount(s string) int64 <span class="cov10" title="21">{
+func parseApproxCount(s string) int64 <span class="cov8" title="1">{
         n, err := strconv.ParseInt(s, 10, 64)
-        if err != nil </span><span class="cov6" title="6">{
+        if err != nil </span><span class="cov8" title="1">{
                 return 0
         }</span>
-        <span class="cov9" title="15">return n</span>
+        <span class="cov8" title="1">return n</span>
 }
 </pre>
 		
@@ -12427,16 +12418,16 @@ import (
 )
 
 // buildDSN は、sslmode と追加クエリパラメータから接続URLを組み立てます。
-func buildDSN(dbCfg *config.DatabaseConfig, extra url.Values) *url.URL <span class="cov10" title="38">{
+func buildDSN(dbCfg *config.DatabaseConfig, extra url.Values) *url.URL <span class="cov8" title="1">{
         q := url.Values{}
         q.Set("sslmode", dbCfg.SSLMode())
-        for key, values := range extra </span><span class="cov9" title="35">{
-                for _, v := range values </span><span class="cov9" title="35">{
+        for key, values := range extra </span><span class="cov8" title="1">{
+                for _, v := range values </span><span class="cov8" title="1">{
                         q.Set(key, v)
                 }</span>
         }
 
-        <span class="cov10" title="38">return &amp;url.URL{
+        <span class="cov8" title="1">return &amp;url.URL{
                 Scheme:   "postgres",
                 User:     url.UserPassword(dbCfg.User(), dbCfg.Password()),
                 Host:     fmt.Sprintf("%s:%d", dbCfg.Host(), dbCfg.Port()),
@@ -12446,30 +12437,30 @@ func buildDSN(dbCfg *config.DatabaseConfig, extra url.Values) *url.URL <span cla
 }
 
 // DSN は、データベースの接続URLを返します。
-func DSN(dbCfg *config.DatabaseConfig) *url.URL <span class="cov3" title="3">{
+func DSN(dbCfg *config.DatabaseConfig) *url.URL <span class="cov8" title="1">{
         return buildDSN(dbCfg, nil)
 }</span>
 
 // DSNWithTimeZone は、データベースの接続URLを返します。タイムゾーン情報をクエリパラメータに追加します。
-func DSNWithTimeZone(dbCfg *config.DatabaseConfig, osCfg *config.OperatingSystemConfig) *url.URL <span class="cov9" title="34">{
+func DSNWithTimeZone(dbCfg *config.DatabaseConfig, osCfg *config.OperatingSystemConfig) *url.URL <span class="cov8" title="1">{
         return buildDSN(dbCfg, url.Values{"timezone": {osCfg.TimeZone()}})
 }</span>
 
 // DSNString は、DSNを文字列形式で返します。
-func DSNString(dbCfg *config.DatabaseConfig) string <span class="cov1" title="1">{
+func DSNString(dbCfg *config.DatabaseConfig) string <span class="cov8" title="1">{
         return DSN(dbCfg).String()
 }</span>
 
 // DSNStringWithoutPassword は、パスワードを含まない接続URL文字列を返します。
 // 資格情報を引数に載せないため、パスワードは PGPASSWORD などで別途渡します。
-func DSNStringWithoutPassword(dbCfg *config.DatabaseConfig) string <span class="cov1" title="1">{
+func DSNStringWithoutPassword(dbCfg *config.DatabaseConfig) string <span class="cov8" title="1">{
         u := DSN(dbCfg)
         u.User = url.User(dbCfg.User())
         return u.String()
 }</span>
 
 // DSNWithTimeZoneString は、DSNWithTimeZoneを文字列形式で返します。
-func DSNWithTimeZoneString(dbCfg *config.DatabaseConfig, osCfg *config.OperatingSystemConfig) string <span class="cov9" title="33">{
+func DSNWithTimeZoneString(dbCfg *config.DatabaseConfig, osCfg *config.OperatingSystemConfig) string <span class="cov8" title="1">{
         return DSNWithTimeZone(dbCfg, osCfg).String()
 }</span>
 </pre>
@@ -12495,12 +12486,12 @@ type DBTX interface {
 }
 
 // New は、context にトランザクションが在ればそれを、無ければ接続プールを DBTX として返します（新規接続は生成しません）。
-func New(ctx context.Context, db DatabaseDriver) DBTX <span class="cov10" title="138">{
+func New(ctx context.Context, db DatabaseDriver) DBTX <span class="cov8" title="1">{
         tx, ok := ctx.Value(txKey{}).(pgx.Tx)
-        if ok </span><span class="cov9" title="105">{
+        if ok </span><span class="cov8" title="1">{
                 return tx
         }</span>
-        <span class="cov7" title="33">return db</span>
+        <span class="cov8" title="1">return db</span>
 }
 </pre>
 		
@@ -12539,7 +12530,7 @@ type dbDriver struct{ pool *pgxpool.Pool }
 // NewDB は Postgres のDB接続を初期化して返します（クエリトレーサーなし）。
 func NewDB(
         dbCfg *config.DatabaseConfig, osCfg *config.OperatingSystemConfig, dbConnCfg *config.DBConnectionConfig,
-) (DatabaseDriver, error) <span class="cov7" title="18">{
+) (DatabaseDriver, error) <span class="cov8" title="1">{
         return newDB(dbCfg, osCfg, dbConnCfg, nil)
 }</span>
 
@@ -12549,7 +12540,7 @@ func NewTracedDB(
         osCfg *config.OperatingSystemConfig,
         dbConnCfg *config.DBConnectionConfig,
         tracer pgx.QueryTracer,
-) (DatabaseDriver, error) <span class="cov6" title="14">{
+) (DatabaseDriver, error) <span class="cov8" title="1">{
         return newDB(dbCfg, osCfg, dbConnCfg, tracer)
 }</span>
 
@@ -12559,13 +12550,13 @@ func newDB(
         osCfg *config.OperatingSystemConfig,
         dbConnCfg *config.DBConnectionConfig,
         tracer pgx.QueryTracer,
-) (DatabaseDriver, error) <span class="cov8" title="32">{
+) (DatabaseDriver, error) <span class="cov8" title="1">{
         poolCfg, err := pgxpool.ParseConfig(DSNWithTimeZoneString(dbCfg, osCfg))
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(err, "failed to parse DB config")
         }</span>
 
-        <span class="cov8" title="31">poolCfg.MaxConns = dbConnCfg.MaxConns()
+        <span class="cov8" title="1">poolCfg.MaxConns = dbConnCfg.MaxConns()
         poolCfg.MinConns = dbConnCfg.MinConns()
         poolCfg.MaxConnLifetime = dbConnCfg.MaxLifetime()
         poolCfg.MaxConnIdleTime = dbConnCfg.MaxIdleTime()
@@ -12573,64 +12564,64 @@ func newDB(
         // SQL 層の backstop。ctx を無視する runaway query / 長時間ロック待ちを Postgres 側で打ち切る。
         applyDBTimeouts(poolCfg, dbCfg.StatementTimeout(), dbCfg.LockTimeout())
 
-        if tracer != nil </span><span class="cov6" title="14">{
+        if tracer != nil </span><span class="cov8" title="1">{
                 poolCfg.ConnConfig.Tracer = tracer
         }</span>
 
-        <span class="cov8" title="31">ctx, cancel := context.WithTimeout(context.Background(), dbCfg.PingTimeout())
+        <span class="cov8" title="1">ctx, cancel := context.WithTimeout(context.Background(), dbCfg.PingTimeout())
         defer cancel()
 
         pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(err, "failed to create DB connection pool")
         }</span>
 
-        <span class="cov8" title="30">if err := pool.Ping(ctx); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err := pool.Ping(ctx); err != nil </span><span class="cov8" title="1">{
                 pool.Close()
                 return nil, xerrors.Wrap(err, "failed to ping DB")
         }</span>
 
-        <span class="cov8" title="29">return &amp;dbDriver{pool: pool}, nil</span>
+        <span class="cov8" title="1">return &amp;dbDriver{pool: pool}, nil</span>
 }
 
 // applyDBTimeouts は、statement_timeout / lock_timeout を接続 RuntimeParams（ミリ秒）として設定します。
 // 0 以下は設定せず Postgres 既定（無制限）のままにします。全コネクションに適用されます。
-func applyDBTimeouts(poolCfg *pgxpool.Config, statementTimeout, lockTimeout time.Duration) <span class="cov8" title="33">{
-        if statementTimeout &gt; 0 </span><span class="cov8" title="32">{
+func applyDBTimeouts(poolCfg *pgxpool.Config, statementTimeout, lockTimeout time.Duration) <span class="cov8" title="1">{
+        if statementTimeout &gt; 0 </span><span class="cov8" title="1">{
                 poolCfg.ConnConfig.RuntimeParams["statement_timeout"] = strconv.FormatInt(statementTimeout.Milliseconds(), 10)
         }</span>
-        <span class="cov8" title="33">if lockTimeout &gt; 0 </span><span class="cov8" title="32">{
+        <span class="cov8" title="1">if lockTimeout &gt; 0 </span><span class="cov8" title="1">{
                 poolCfg.ConnConfig.RuntimeParams["lock_timeout"] = strconv.FormatInt(lockTimeout.Milliseconds(), 10)
         }</span>
 }
 
-func (d *dbDriver) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) <span class="cov6" title="11">{
+func (d *dbDriver) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) <span class="cov8" title="1">{
         return d.pool.Exec(ctx, sql, args...)
 }</span>
 
-func (d *dbDriver) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) <span class="cov6" title="12">{
+func (d *dbDriver) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) <span class="cov8" title="1">{
         return d.pool.Query(ctx, sql, args...)
 }</span>
 
-func (d *dbDriver) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row <span class="cov6" title="14">{
+func (d *dbDriver) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row <span class="cov8" title="1">{
         return d.pool.QueryRow(ctx, sql, args...)
 }</span>
 
-func (d *dbDriver) Begin(ctx context.Context) (pgx.Tx, error) <span class="cov10" title="66">{
+func (d *dbDriver) Begin(ctx context.Context) (pgx.Tx, error) <span class="cov8" title="1">{
         return d.pool.Begin(ctx)
 }</span>
 
-func (d *dbDriver) Ping(ctx context.Context) error <span class="cov3" title="3">{
+func (d *dbDriver) Ping(ctx context.Context) error <span class="cov8" title="1">{
         return d.pool.Ping(ctx)
 }</span>
 
 // Close は pool を閉じます。
-func (d *dbDriver) Close() error <span class="cov6" title="11">{
+func (d *dbDriver) Close() error <span class="cov8" title="1">{
         d.pool.Close()
         return nil
 }</span>
 
-func (d *dbDriver) Stats() *pgxpool.Stat <span class="cov4" title="6">{
+func (d *dbDriver) Stats() *pgxpool.Stat <span class="cov8" title="1">{
         return d.pool.Stat()
 }</span>
 </pre>
@@ -12695,31 +12686,31 @@ type queryNameKey struct{}
 
 // WithQueryName は、メトリクスの query_name ラベルに使う安定名を context に付与します。
 // Repository / QueryService 側で操作名（例: "user.find_by_id"）を明示します。
-func WithQueryName(ctx context.Context, name string) context.Context <span class="cov3" title="5">{
+func WithQueryName(ctx context.Context, name string) context.Context <span class="cov8" title="1">{
         return context.WithValue(ctx, queryNameKey{}, name)
 }</span>
 
 // queryNameFromContext は、context から query_name を取り出します。
 // 未設定または空文字の場合は "unknown" に丸めます。
-func queryNameFromContext(ctx context.Context) string <span class="cov5" title="10">{
+func queryNameFromContext(ctx context.Context) string <span class="cov8" title="1">{
         name, ok := ctx.Value(queryNameKey{}).(string)
-        if !ok || name == "" </span><span class="cov3" title="5">{
+        if !ok || name == "" </span><span class="cov8" title="1">{
                 return queryNameUnknown
         }</span>
-        <span class="cov3" title="5">return name</span>
+        <span class="cov8" title="1">return name</span>
 }
 
 // buildQueryAttrs は、クエリ終了時の情報から QueryAttrs を組み立てます。
 // pgx.ErrNoRows は QueryRow の通常系（not_found）であり、status=success として扱い error には数えません。
-func buildQueryAttrs(ctx context.Context, sql string, duration time.Duration, err error) QueryAttrs <span class="cov4" title="7">{
+func buildQueryAttrs(ctx context.Context, sql string, duration time.Duration, err error) QueryAttrs <span class="cov8" title="1">{
         status := statusSuccess
         errorClass := ""
-        if err != nil &amp;&amp; !xerrors.Is(err, pgx.ErrNoRows) </span><span class="cov2" title="2">{
+        if err != nil &amp;&amp; !xerrors.Is(err, pgx.ErrNoRows) </span><span class="cov8" title="1">{
                 status = statusError
                 errorClass = classifyErrorClass(err)
         }</span>
 
-        <span class="cov4" title="7">return QueryAttrs{
+        <span class="cov8" title="1">return QueryAttrs{
                 QueryName:  queryNameFromContext(ctx),
                 Operation:  classifyOperation(sql),
                 Status:     status,
@@ -12730,67 +12721,67 @@ func buildQueryAttrs(ctx context.Context, sql string, duration time.Duration, er
 
 // classifyOperation は、SQL の先頭トークンのみを見て低カーディナリティな operation へ分類します。
 // SQL 本文・テーブル名は一切ラベルに含めません。先頭コメントや WITH 句は select / other に丸めます。
-func classifyOperation(sql string) string <span class="cov6" title="25">{
+func classifyOperation(sql string) string <span class="cov8" title="1">{
         switch firstSQLToken(sql) </span>{
-        case "select", "with":<span class="cov5" title="10">
+        case "select", "with":<span class="cov8" title="1">
                 return operationSelect</span>
-        case "insert":<span class="cov2" title="2">
+        case "insert":<span class="cov8" title="1">
                 return operationInsert</span>
-        case "update":<span class="cov2" title="3">
+        case "update":<span class="cov8" title="1">
                 return operationUpdate</span>
-        case "delete":<span class="cov1" title="1">
+        case "delete":<span class="cov8" title="1">
                 return operationDelete</span>
-        case "begin", "start":<span class="cov2" title="2">
+        case "begin", "start":<span class="cov8" title="1">
                 return operationBegin</span>
-        case "commit":<span class="cov1" title="1">
+        case "commit":<span class="cov8" title="1">
                 return operationCommit</span>
-        case "rollback":<span class="cov1" title="1">
+        case "rollback":<span class="cov8" title="1">
                 return operationRollback</span>
-        case "copy":<span class="cov1" title="1">
+        case "copy":<span class="cov8" title="1">
                 return operationCopy</span>
-        default:<span class="cov3" title="4">
+        default:<span class="cov8" title="1">
                 return operationOther</span>
         }
 }
 
 // firstSQLToken は、先頭コメントと記号を取り除いた最初のトークンを小文字で返します。
-func firstSQLToken(sql string) string <span class="cov6" title="25">{
+func firstSQLToken(sql string) string <span class="cov8" title="1">{
         sql = stripLeadingSQLComments(sql)
         sql = strings.TrimLeft(sql, " \t\r\n(")
 
-        end := strings.IndexFunc(sql, func(r rune) bool </span><span class="cov10" title="148">{
+        end := strings.IndexFunc(sql, func(r rune) bool </span><span class="cov8" title="1">{
                 switch r </span>{
-                case ' ', '\t', '\r', '\n', '(', ';':<span class="cov6" title="19">
+                case ' ', '\t', '\r', '\n', '(', ';':<span class="cov8" title="1">
                         return true</span>
-                default:<span class="cov9" title="129">
+                default:<span class="cov8" title="1">
                         return false</span>
                 }
         })
-        <span class="cov6" title="25">if end &gt;= 0 </span><span class="cov6" title="19">{
+        <span class="cov8" title="1">if end &gt;= 0 </span><span class="cov8" title="1">{
                 sql = sql[:end]
         }</span>
 
-        <span class="cov6" title="25">return strings.ToLower(sql)</span>
+        <span class="cov8" title="1">return strings.ToLower(sql)</span>
 }
 
 // stripLeadingSQLComments は、SQL 先頭の行コメント(--)・ブロックコメント(/* */)を取り除きます。
-func stripLeadingSQLComments(sql string) string <span class="cov6" title="25">{
-        for </span><span class="cov7" title="28">{
+func stripLeadingSQLComments(sql string) string <span class="cov8" title="1">{
+        for </span><span class="cov8" title="1">{
                 sql = strings.TrimLeft(sql, " \t\r\n")
                 switch </span>{
-                case strings.HasPrefix(sql, "--"):<span class="cov2" title="3">
+                case strings.HasPrefix(sql, "--"):<span class="cov8" title="1">
                         i := strings.IndexByte(sql, '\n')
-                        if i &lt; 0 </span><span class="cov1" title="1">{
+                        if i &lt; 0 </span><span class="cov8" title="1">{
                                 return ""
                         }</span>
-                        <span class="cov2" title="2">sql = sql[i+1:]</span>
-                case strings.HasPrefix(sql, "/*"):<span class="cov2" title="2">
+                        <span class="cov8" title="1">sql = sql[i+1:]</span>
+                case strings.HasPrefix(sql, "/*"):<span class="cov8" title="1">
                         i := strings.Index(sql, "*/")
-                        if i &lt; 0 </span><span class="cov1" title="1">{
+                        if i &lt; 0 </span><span class="cov8" title="1">{
                                 return ""
                         }</span>
-                        <span class="cov1" title="1">sql = sql[i+2:]</span>
-                default:<span class="cov6" title="23">
+                        <span class="cov8" title="1">sql = sql[i+2:]</span>
+                default:<span class="cov8" title="1">
                         return sql</span>
                 }
         }
@@ -12799,39 +12790,39 @@ func stripLeadingSQLComments(sql string) string <span class="cov6" title="25">{
 // classifyErrorClass は、pgerror の判定を用いてエラーを固定 enum へ丸めます。
 // raw error message / SQLSTATE 詳細 / 制約名などはラベルに含めません。
 // pgx.ErrNoRows は呼び出し前に除外して渡すこと（success として扱うため）。
-func classifyErrorClass(err error) string <span class="cov5" title="11">{
+func classifyErrorClass(err error) string <span class="cov8" title="1">{
         switch </span>{
-        case err == nil:<span class="cov1" title="1">
+        case err == nil:<span class="cov8" title="1">
                 return ""</span>
-        case isConstraintViolation(err):<span class="cov2" title="2">
+        case isConstraintViolation(err):<span class="cov8" title="1">
                 return errorClassConstraint</span>
-        case isTimeout(err):<span class="cov2" title="3">
+        case isTimeout(err):<span class="cov8" title="1">
                 return errorClassTimeout</span>
-        case pgerror.IsRetryableTxError(err):<span class="cov2" title="2">
+        case pgerror.IsRetryableTxError(err):<span class="cov8" title="1">
                 return errorClassRetryable</span>
-        case pgerror.IsUnavailable(err):<span class="cov1" title="1">
+        case pgerror.IsUnavailable(err):<span class="cov8" title="1">
                 return errorClassConnection</span>
-        default:<span class="cov2" title="2">
+        default:<span class="cov8" title="1">
                 return errorClassUnknown</span>
         }
 }
 
 // isConstraintViolation は、整合性制約違反(SQLSTATE 23xxx)であるかを判定します。
-func isConstraintViolation(err error) bool <span class="cov5" title="10">{
+func isConstraintViolation(err error) bool <span class="cov8" title="1">{
         var pgErr *pgconn.PgError
         return xerrors.As(err, &amp;pgErr) &amp;&amp; strings.HasPrefix(pgErr.Code, "23")
 }</span>
 
 // isTimeout は、タイムアウト系のエラー（context 期限切れ / lock_timeout 失効 / statement_timeout）であるかを判定します。
 // SQLSTATE 57014(query_canceled) は statement_timeout 失効でも発生するため timeout に分類します。
-func isTimeout(err error) bool <span class="cov4" title="8">{
+func isTimeout(err error) bool <span class="cov8" title="1">{
         return xerrors.Is(err, context.DeadlineExceeded) ||
                 pgerror.IsLockNotAvailable(err) ||
                 isStatementTimeout(err)
 }</span>
 
 // isStatementTimeout は、statement_timeout 失効(SQLSTATE 57014 query_canceled)であるかを判定します。
-func isStatementTimeout(err error) bool <span class="cov4" title="6">{
+func isStatementTimeout(err error) bool <span class="cov8" title="1">{
         var pgErr *pgconn.PgError
         return xerrors.As(err, &amp;pgErr) &amp;&amp; pgErr.Code == "57014"
 }</span>
@@ -12887,7 +12878,7 @@ func NewQueryTracer(
         recorder QueryRecorder,
         logger logging.Logger,
         lf logging.LogFieldBuilder,
-) pgx.QueryTracer <span class="cov10" title="22">{
+) pgx.QueryTracer <span class="cov8" title="1">{
         return &amp;queryTracer{
                 Tracer:        tracer,
                 logger:        logger.Named(queryTracerLayer),
@@ -12901,7 +12892,7 @@ func NewQueryTracer(
 // TraceQueryStart は、クエリ開始の span を開始し、新しい Context を返します。
 func (t *queryTracer) TraceQueryStart(
         ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryStartData,
-) context.Context <span class="cov5" title="4">{
+) context.Context <span class="cov8" title="1">{
         parentSpanID := observability.ExtractTraceContext(ctx).SpanID()
         ctx = t.Tracer.TraceQueryStart(ctx, conn, data)
         return context.WithValue(ctx, queryLogKey{}, queryLogData{
@@ -12915,44 +12906,44 @@ func (t *queryTracer) TraceQueryStart(
 // TraceQueryEnd は、span を終了し、正常終了(Info)・スロー(Warn)・エラー(Error)のログを出力します。
 func (t *queryTracer) TraceQueryEnd(
         ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryEndData,
-) <span class="cov7" title="11">{
+) <span class="cov8" title="1">{
         t.Tracer.TraceQueryEnd(ctx, conn, data)
 
         ld, ok := ctx.Value(queryLogKey{}).(queryLogData)
-        if !ok </span><span class="cov1" title="1">{
+        if !ok </span><span class="cov8" title="1">{
                 return
         }</span>
-        <span class="cov7" title="10">duration := time.Since(ld.start)
+        <span class="cov8" title="1">duration := time.Since(ld.start)
 
         t.recordQueryMetric(ctx, ld.sql, duration, data.Err)
 
         switch </span>{
-        case data.Err != nil:<span class="cov4" title="3">
+        case data.Err != nil:<span class="cov8" title="1">
                 t.logger.Error("DB query failed", t.endFields(ctx, ld, duration, data.Err)...)</span>
-        case t.slowThreshold &gt; 0 &amp;&amp; duration &gt; t.slowThreshold:<span class="cov1" title="1">
+        case t.slowThreshold &gt; 0 &amp;&amp; duration &gt; t.slowThreshold:<span class="cov8" title="1">
                 t.logger.Warn("DB slow query", t.endFields(ctx, ld, duration, nil)...)</span>
-        default:<span class="cov6" title="6">
+        default:<span class="cov8" title="1">
                 t.logger.Info("DB query completed", t.endFields(ctx, ld, duration, nil)...)</span>
         }
 }
 
 // recordQueryMetric は、recorder が設定されている場合にクエリメトリクスを記録します。
-func (t *queryTracer) recordQueryMetric(ctx context.Context, sql string, duration time.Duration, err error) <span class="cov7" title="10">{
-        if t.recorder == nil </span><span class="cov6" title="7">{
+func (t *queryTracer) recordQueryMetric(ctx context.Context, sql string, duration time.Duration, err error) <span class="cov8" title="1">{
+        if t.recorder == nil </span><span class="cov8" title="1">{
                 return
         }</span>
-        <span class="cov4" title="3">t.recorder.Observe(ctx, buildQueryAttrs(ctx, sql, duration, err))</span>
+        <span class="cov8" title="1">t.recorder.Observe(ctx, buildQueryAttrs(ctx, sql, duration, err))</span>
 }
 
 func (t *queryTracer) endFields(
         ctx context.Context, ld queryLogData, duration time.Duration, err error,
-) []*logging.Field <span class="cov7" title="10">{
+) []*logging.Field <span class="cov8" title="1">{
         args := ld.args
-        if t.maskArgs </span><span class="cov1" title="1">{
+        if t.maskArgs </span><span class="cov8" title="1">{
                 args = nil
         }</span>
 
-        <span class="cov7" title="10">tc := observability.ExtractTraceContext(ctx)
+        <span class="cov8" title="1">tc := observability.ExtractTraceContext(ctx)
 
         return t.lf.BuildSQLEndFields(logging.SQLFieldsEndInput{
                 Layer:        queryTracerLayer,
@@ -13017,21 +13008,21 @@ type txManager struct {
 // DB_TX_RETRY_MAX_BACKOFF）から取得します。0 以下の場合は既定値にフォールバックします。
 func NewTransactionManager(
         db DatabaseDriver, dbCfg *config.DatabaseConfig, logger logging.Logger, sleeper clock.Sleeper,
-) tx.Manager <span class="cov8" title="36">{
+) tx.Manager <span class="cov8" title="1">{
         maxAttempts := dbCfg.TxMaxRetries()
-        if maxAttempts &lt;= 0 </span><span class="cov1" title="1">{
+        if maxAttempts &lt;= 0 </span><span class="cov8" title="1">{
                 maxAttempts = defaultTxMaxAttempts
         }</span>
-        <span class="cov8" title="36">initialBackoff := dbCfg.TxRetryBaseBackoff()
-        if initialBackoff &lt;= 0 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">initialBackoff := dbCfg.TxRetryBaseBackoff()
+        if initialBackoff &lt;= 0 </span><span class="cov8" title="1">{
                 initialBackoff = defaultTxBackoffInitial
         }</span>
-        <span class="cov8" title="36">maxBackoff := dbCfg.TxRetryMaxBackoff()
-        if maxBackoff &lt;= 0 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">maxBackoff := dbCfg.TxRetryMaxBackoff()
+        if maxBackoff &lt;= 0 </span><span class="cov8" title="1">{
                 maxBackoff = defaultTxBackoffMax
         }</span>
 
-        <span class="cov8" title="36">return &amp;txManager{
+        <span class="cov8" title="1">return &amp;txManager{
                 db:          db,
                 logger:      logger,
                 sleeper:     sleeper,
@@ -13050,35 +13041,35 @@ func NewTransactionManager(
 // 再試行します（指数 backoff + full jitter、pkg/retry）。**fn は最大 N 回再実行されうる**ため、
 // DB 副作用以外について冪等であること（呼出側責務）。外部副作用は同一 tx 内で outbox row 化すれば
 // rollback と共に巻き戻り retry-safe になります。nested（既存 tx 再利用）経路はリトライ対象外（1 回）。
-func (t *txManager) Do(ctx context.Context, fn func(ctx context.Context) error) error <span class="cov9" title="69">{
-        if _, ok := ctx.Value(txKey{}).(pgx.Tx); ok </span><span class="cov1" title="1">{
+func (t *txManager) Do(ctx context.Context, fn func(ctx context.Context) error) error <span class="cov8" title="1">{
+        if _, ok := ctx.Value(txKey{}).(pgx.Tx); ok </span><span class="cov8" title="1">{
                 return fn(ctx) // nested: savepoint 相当・リトライしない（最外の Do が正規化する）
         }</span>
 
-        <span class="cov9" title="68">err := retry.Do(ctx, t.sleeper,
+        <span class="cov8" title="1">err := retry.Do(ctx, t.sleeper,
                 retry.Policy{MaxAttempts: t.maxAttempts, Backoff: t.backoff.Duration},
                 pgerror.IsRetryableTxError,
-                func(c context.Context) error </span><span class="cov10" title="71">{ return t.doOnce(c, fn) }</span>,
+                func(c context.Context) error </span><span class="cov8" title="1">{ return t.doOnce(c, fn) }</span>,
         )
-        <span class="cov9" title="66">return normalizeTxResult(err)</span>
+        <span class="cov8" title="1">return normalizeTxResult(err)</span>
 }
 
 // normalizeTxResult は、リトライ後の最終エラーを apperror へ正規化します。
 // begin / commit 由来の DB エラー（生 pg / 接続）および context キャンセル・期限超過を
 // apperror へ写像します。fn が返したエラー（apperror や rollback sentinel 等）は
 // そのまま通し、呼出側のエラー判定に干渉しません。
-func normalizeTxResult(err error) error <span class="cov9" title="66">{
-        if err == nil </span><span class="cov2" title="2">{
+func normalizeTxResult(err error) error <span class="cov8" title="1">{
+        if err == nil </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov9" title="64">var pgErr *pgconn.PgError
-        if xerrors.As(err, &amp;pgErr) || pgerror.IsUnavailable(err) </span><span class="cov3" title="4">{
+        <span class="cov8" title="1">var pgErr *pgconn.PgError
+        if xerrors.As(err, &amp;pgErr) || pgerror.IsUnavailable(err) </span><span class="cov8" title="1">{
                 return pgerror.NormalizeError(err)
         }</span>
-        <span class="cov9" title="60">if xerrors.Is(err, context.Canceled) || xerrors.Is(err, context.DeadlineExceeded) </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if xerrors.Is(err, context.Canceled) || xerrors.Is(err, context.DeadlineExceeded) </span><span class="cov8" title="1">{
                 return pgerror.NormalizeError(err)
         }</span>
-        <span class="cov9" title="59">return err</span>
+        <span class="cov8" title="1">return err</span>
 }
 
 // doOnce は、1 回分のトランザクション（begin → fn → commit / rollback）を実行します。
@@ -13087,48 +13078,48 @@ func normalizeTxResult(err error) error <span class="cov9" title="66">{
 // それは xerrors.Join で元の PgError を chain に保持するため、IsRetryableTxError は正規化後でも
 // 生 SQLSTATE（40001/40P01）を errors.As で参照でき、fn 内の serialization failure / deadlock も
 // リトライ対象になります。最終的な apperror への写像は呼出元 Do がリトライ後に 1 度だけ行います。
-func (t *txManager) doOnce(ctx context.Context, fn func(ctx context.Context) error) error <span class="cov10" title="71">{
+func (t *txManager) doOnce(ctx context.Context, fn func(ctx context.Context) error) error <span class="cov8" title="1">{
         tx, err := t.db.Begin(ctx)
-        if err != nil </span><span class="cov5" title="7">{
+        if err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov9" title="64">completed := false
-        defer func(ctx context.Context) </span><span class="cov9" title="64">{
-                if completed </span><span class="cov9" title="62">{
+        <span class="cov8" title="1">completed := false
+        defer func(ctx context.Context) </span><span class="cov8" title="1">{
+                if completed </span><span class="cov8" title="1">{
                         return
                 }</span>
-                <span class="cov2" title="2">if p := recover(); p != nil </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">if p := recover(); p != nil </span><span class="cov8" title="1">{
                         t.rollback(ctx, tx, logging.Any("panic", p))
                         panic(p)</span>
                 }
                 // fn が runtime.Goexit（testify の FailNow 等）で中断した場合の後始末。
-                <span class="cov1" title="1">t.rollback(ctx, tx)</span>
+                <span class="cov8" title="1">t.rollback(ctx, tx)</span>
         }(ctx)
 
-        <span class="cov9" title="64">ctx = withTx(ctx, tx)
+        <span class="cov8" title="1">ctx = withTx(ctx, tx)
 
-        if err := fn(ctx); err != nil </span><span class="cov9" title="59">{
+        if err := fn(ctx); err != nil </span><span class="cov8" title="1">{
                 t.rollback(ctx, tx, logging.Error(logging.OriginalErrorKey, err))
                 completed = true
                 return err
         }</span>
 
-        <span class="cov3" title="3">if err := tx.Commit(ctx); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err := tx.Commit(ctx); err != nil </span><span class="cov8" title="1">{
                 completed = true
                 return err
         }</span>
 
-        <span class="cov2" title="2">completed = true
+        <span class="cov8" title="1">completed = true
         return nil</span>
 }
 
 // rollback はロールバックし、失敗時に fields を併記してログを残します。
-func (t *txManager) rollback(ctx context.Context, tx pgx.Tx, fields ...*logging.Field) <span class="cov9" title="61">{
+func (t *txManager) rollback(ctx context.Context, tx pgx.Tx, fields ...*logging.Field) <span class="cov8" title="1">{
         cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
         defer cancel()
 
-        if pgErr := tx.Rollback(cleanupCtx); pgErr != nil </span><span class="cov1" title="1">{
+        if pgErr := tx.Rollback(cleanupCtx); pgErr != nil </span><span class="cov8" title="1">{
                 logFields := append([]*logging.Field{logging.Error(logging.ErrorKey, pgErr)}, fields...)
                 t.logger.CallerSkip(callerSkipCount).Named("TransactionManager").Error(
                         "Failed to rollback transaction", logFields...,
@@ -13137,7 +13128,7 @@ func (t *txManager) rollback(ctx context.Context, tx pgx.Tx, fields ...*logging.
 }
 
 // withTx は、context.Contextにトランザクションを設定します。
-func withTx(ctx context.Context, tx pgx.Tx) context.Context <span class="cov9" title="66">{
+func withTx(ctx context.Context, tx pgx.Tx) context.Context <span class="cov8" title="1">{
         return context.WithValue(ctx, txKey{}, tx)
 }</span>
 </pre>
@@ -13169,15 +13160,15 @@ type PoolStatsCollector struct {
 }
 
 // New は、PoolStatsCollectorを初期化して返します。
-func New(db driver.DatabaseDriver) *PoolStatsCollector <span class="cov5" title="22">{
-        gauge := func(name, help string, value func(*pgxpool.Stat) float64) poolStatsMetric </span><span class="cov8" title="110">{
+func New(db driver.DatabaseDriver) *PoolStatsCollector <span class="cov8" title="1">{
+        gauge := func(name, help string, value func(*pgxpool.Stat) float64) poolStatsMetric </span><span class="cov8" title="1">{
                 return poolStatsMetric{
                         desc:      prometheus.NewDesc(prometheus.BuildFQName(namespace, "", name), help, nil, nil),
                         valueType: prometheus.GaugeValue,
                         value:     value,
                 }
         }</span>
-        <span class="cov5" title="22">counter := func(name, help string, value func(*pgxpool.Stat) float64) poolStatsMetric </span><span class="cov9" title="176">{
+        <span class="cov8" title="1">counter := func(name, help string, value func(*pgxpool.Stat) float64) poolStatsMetric </span><span class="cov8" title="1">{
                 return poolStatsMetric{
                         desc:      prometheus.NewDesc(prometheus.BuildFQName(namespace, "", name), help, nil, nil),
                         valueType: prometheus.CounterValue,
@@ -13185,75 +13176,75 @@ func New(db driver.DatabaseDriver) *PoolStatsCollector <span class="cov5" title=
                 }
         }</span>
 
-        <span class="cov5" title="22">return &amp;PoolStatsCollector{
+        <span class="cov8" title="1">return &amp;PoolStatsCollector{
                 db: db,
                 metrics: []poolStatsMetric{
                         gauge("acquired_conns", "Number of currently acquired connections in the pool.",
-                                func(s *pgxpool.Stat) float64 </span><span class="cov2" title="2">{ return float64(s.AcquiredConns()) }</span>),
+                                func(s *pgxpool.Stat) float64 </span><span class="cov8" title="1">{ return float64(s.AcquiredConns()) }</span>),
                         gauge("idle_conns", "Number of currently idle connections in the pool.",
-                                func(s *pgxpool.Stat) float64 <span class="cov2" title="2">{ return float64(s.IdleConns()) }</span>),
+                                func(s *pgxpool.Stat) float64 <span class="cov8" title="1">{ return float64(s.IdleConns()) }</span>),
                         gauge("total_conns", "Total number of connections currently in the pool.",
-                                func(s *pgxpool.Stat) float64 <span class="cov2" title="2">{ return float64(s.TotalConns()) }</span>),
+                                func(s *pgxpool.Stat) float64 <span class="cov8" title="1">{ return float64(s.TotalConns()) }</span>),
                         gauge("constructing_conns", "Number of connections currently being constructed.",
-                                func(s *pgxpool.Stat) float64 <span class="cov2" title="2">{ return float64(s.ConstructingConns()) }</span>),
+                                func(s *pgxpool.Stat) float64 <span class="cov8" title="1">{ return float64(s.ConstructingConns()) }</span>),
                         gauge("max_conns", "Maximum number of connections allowed in the pool.",
-                                func(s *pgxpool.Stat) float64 <span class="cov2" title="2">{ return float64(s.MaxConns()) }</span>),
+                                func(s *pgxpool.Stat) float64 <span class="cov8" title="1">{ return float64(s.MaxConns()) }</span>),
 
                         counter("acquire_count_total", "Total number of successful connection acquires from the pool.",
-                                func(s *pgxpool.Stat) float64 <span class="cov2" title="2">{ return float64(s.AcquireCount()) }</span>),
+                                func(s *pgxpool.Stat) float64 <span class="cov8" title="1">{ return float64(s.AcquireCount()) }</span>),
                         counter("acquire_duration_seconds_total", "Total duration of all successful connection acquires.",
-                                func(s *pgxpool.Stat) float64 <span class="cov2" title="2">{ return s.AcquireDuration().Seconds() }</span>),
+                                func(s *pgxpool.Stat) float64 <span class="cov8" title="1">{ return s.AcquireDuration().Seconds() }</span>),
                         counter("canceled_acquire_count_total", "Total number of canceled connection acquires.",
-                                func(s *pgxpool.Stat) float64 <span class="cov2" title="2">{ return float64(s.CanceledAcquireCount()) }</span>),
+                                func(s *pgxpool.Stat) float64 <span class="cov8" title="1">{ return float64(s.CanceledAcquireCount()) }</span>),
                         counter("empty_acquire_count_total", "Total number of acquires that had to create a new connection because the pool was empty.",
-                                func(s *pgxpool.Stat) float64 <span class="cov2" title="2">{ return float64(s.EmptyAcquireCount()) }</span>),
+                                func(s *pgxpool.Stat) float64 <span class="cov8" title="1">{ return float64(s.EmptyAcquireCount()) }</span>),
                         counter("new_conns_count_total", "Total number of new connections created.",
-                                func(s *pgxpool.Stat) float64 <span class="cov2" title="2">{ return float64(s.NewConnsCount()) }</span>),
+                                func(s *pgxpool.Stat) float64 <span class="cov8" title="1">{ return float64(s.NewConnsCount()) }</span>),
                         counter("max_lifetime_destroy_count_total", "Total number of connections destroyed due to max lifetime.",
-                                func(s *pgxpool.Stat) float64 <span class="cov2" title="2">{ return float64(s.MaxLifetimeDestroyCount()) }</span>),
+                                func(s *pgxpool.Stat) float64 <span class="cov8" title="1">{ return float64(s.MaxLifetimeDestroyCount()) }</span>),
                         counter("max_idle_destroy_count_total", "Total number of connections destroyed due to max idle time.",
-                                func(s *pgxpool.Stat) float64 <span class="cov2" title="2">{ return float64(s.MaxIdleDestroyCount()) }</span>),
+                                func(s *pgxpool.Stat) float64 <span class="cov8" title="1">{ return float64(s.MaxIdleDestroyCount()) }</span>),
                         counter(
                                 "empty_acquire_wait_time_seconds_total",
                                 "Total duration of all acquires that had to wait for a connection because the pool was empty.",
-                                func(s *pgxpool.Stat) float64 <span class="cov2" title="2">{ return s.EmptyAcquireWaitTime().Seconds() }</span>,
+                                func(s *pgxpool.Stat) float64 <span class="cov8" title="1">{ return s.EmptyAcquireWaitTime().Seconds() }</span>,
                         ),
                 },
         }
 }
 
 // Describe は、PoolStatsCollectorのメトリクスの説明をPrometheusに提供します。
-func (c *PoolStatsCollector) Describe(ch chan&lt;- *prometheus.Desc) <span class="cov5" title="21">{
-        for _, m := range c.metrics </span><span class="cov10" title="273">{
+func (c *PoolStatsCollector) Describe(ch chan&lt;- *prometheus.Desc) <span class="cov8" title="1">{
+        for _, m := range c.metrics </span><span class="cov8" title="1">{
                 ch &lt;- m.desc
         }</span>
 }
 
 // Collect は、PoolStatsCollectorのメトリクスを収集してPrometheusに提供します。
-func (c *PoolStatsCollector) Collect(ch chan&lt;- prometheus.Metric) <span class="cov2" title="2">{
+func (c *PoolStatsCollector) Collect(ch chan&lt;- prometheus.Metric) <span class="cov8" title="1">{
         stats := c.db.Stats()
-        for _, m := range c.metrics </span><span class="cov6" title="26">{
+        for _, m := range c.metrics </span><span class="cov8" title="1">{
                 ch &lt;- prometheus.MustNewConstMetric(m.desc, m.valueType, m.value(stats))
         }</span>
 }
 
 // NewRegisterer は、既定の Prometheus レジストリを Registerer として返します。
-func NewRegisterer() prometheus.Registerer <span class="cov5" title="16">{
+func NewRegisterer() prometheus.Registerer <span class="cov8" title="1">{
         return prometheus.DefaultRegisterer
 }</span>
 
 // RegisterPoolStatsCollector は、PoolStatsCollectorを指定レジストリに登録します。
 // 既に登録済みの場合はエラーを返さず無視します。
-func RegisterPoolStatsCollector(reg prometheus.Registerer, c *PoolStatsCollector) error <span class="cov5" title="19">{
+func RegisterPoolStatsCollector(reg prometheus.Registerer, c *PoolStatsCollector) error <span class="cov8" title="1">{
         err := reg.Register(c)
-        if err != nil </span><span class="cov5" title="16">{
+        if err != nil </span><span class="cov8" title="1">{
                 var alreadyRegisteredErr prometheus.AlreadyRegisteredError
-                if xerrors.As(err, &amp;alreadyRegisteredErr) </span><span class="cov5" title="15">{
+                if xerrors.As(err, &amp;alreadyRegisteredErr) </span><span class="cov8" title="1">{
                         return nil
                 }</span>
-                <span class="cov1" title="1">return err</span>
+                <span class="cov8" title="1">return err</span>
         }
-        <span class="cov2" title="3">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 </pre>
 		
@@ -13281,7 +13272,7 @@ type queryMetrics struct {
 
 // NewQueryRecorder は、DB クエリメトリクス(rdb_query_duration_seconds / rdb_query_errors_total)を
 // 指定レジストリに登録し、recorder を返します。既に登録済みの場合は既存のコレクタを再利用します。
-func NewQueryRecorder(reg prometheus.Registerer) driver.QueryRecorder <span class="cov8" title="17">{
+func NewQueryRecorder(reg prometheus.Registerer) driver.QueryRecorder <span class="cov8" title="1">{
         duration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
                 Namespace: queryNamespace,
                 Subsystem: querySubsystem,
@@ -13306,32 +13297,32 @@ func NewQueryRecorder(reg prometheus.Registerer) driver.QueryRecorder <span clas
 // Observe は、1 クエリの duration を記録し、エラー時のみ error counter を増分します。
 // QueryAttrs には SQL 本文・bind 値・テーブル名などの高カーディナリティ／秘匿情報が含まれないため、
 // ラベルへ秘匿情報が漏れることはありません。
-func (m *queryMetrics) Observe(_ context.Context, attrs driver.QueryAttrs) <span class="cov5" title="6">{
+func (m *queryMetrics) Observe(_ context.Context, attrs driver.QueryAttrs) <span class="cov8" title="1">{
         m.duration.
                 WithLabelValues(attrs.QueryName, attrs.Operation, attrs.Status).
                 Observe(attrs.Duration.Seconds())
 
         // ErrorClass が非空のときのみエラー（pgx.ErrNoRows を除く失敗）として計上します。
-        if attrs.ErrorClass != "" </span><span class="cov1" title="1">{
+        if attrs.ErrorClass != "" </span><span class="cov8" title="1">{
                 m.errorsTotal.WithLabelValues(attrs.QueryName, attrs.Operation, attrs.ErrorClass).Inc()
         }</span>
 }
 
 // registerOrExisting は、コレクタを登録します。既に同一コレクタが登録済みの場合は、
 // 新規生成したものではなく登録済みのコレクタを返し、複数回初期化されても同じメトリクスへ記録できるようにします。
-func registerOrExisting[T prometheus.Collector](reg prometheus.Registerer, c T) T <span class="cov10" title="35">{
+func registerOrExisting[T prometheus.Collector](reg prometheus.Registerer, c T) T <span class="cov8" title="1">{
         err := reg.Register(c)
-        if err == nil </span><span class="cov6" title="10">{
+        if err == nil </span><span class="cov8" title="1">{
                 return c
         }</span>
 
-        <span class="cov9" title="25">var alreadyRegisteredErr prometheus.AlreadyRegisteredError
-        if xerrors.As(err, &amp;alreadyRegisteredErr) </span><span class="cov9" title="25">{
-                if existing, ok := alreadyRegisteredErr.ExistingCollector.(T); ok </span><span class="cov9" title="24">{
+        <span class="cov8" title="1">var alreadyRegisteredErr prometheus.AlreadyRegisteredError
+        if xerrors.As(err, &amp;alreadyRegisteredErr) </span><span class="cov8" title="1">{
+                if existing, ok := alreadyRegisteredErr.ExistingCollector.(T); ok </span><span class="cov8" title="1">{
                         return existing
                 }</span>
         }
-        <span class="cov1" title="1">return c</span>
+        <span class="cov8" title="1">return c</span>
 }
 </pre>
 		
@@ -13366,79 +13357,79 @@ var sqlstateToAppError = map[string]error{
 
 // NormalizeError は、PostgreSQLのエラーをアプリケーション固有のエラーに変換します。
 // 既に正規化済みの apperror はそのまま返します。
-func NormalizeError(err error) error <span class="cov9" title="59">{
-        if err == nil </span><span class="cov1" title="1">{
+func NormalizeError(err error) error <span class="cov8" title="1">{
+        if err == nil </span><span class="cov8" title="1">{
                 return nil
         }</span>
 
-        <span class="cov9" title="58">if apperror.IsAppError(err) </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if apperror.IsAppError(err) </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov9" title="57">if xerrors.Is(err, pgx.ErrNoRows) </span><span class="cov4" title="5">{
+        <span class="cov8" title="1">if xerrors.Is(err, pgx.ErrNoRows) </span><span class="cov8" title="1">{
                 return xerrors.Join(apperror.ErrNotFound, err)
         }</span>
 
-        <span class="cov9" title="52">var pgErr *pgconn.PgError
-        if xerrors.As(err, &amp;pgErr) </span><span class="cov7" title="26">{
-                if appErr, ok := sqlstateToAppError[pgErr.Code]; ok </span><span class="cov6" title="17">{
+        <span class="cov8" title="1">var pgErr *pgconn.PgError
+        if xerrors.As(err, &amp;pgErr) </span><span class="cov8" title="1">{
+                if appErr, ok := sqlstateToAppError[pgErr.Code]; ok </span><span class="cov8" title="1">{
                         return xerrors.Join(appErr, err)
                 }</span>
         }
 
-        <span class="cov8" title="35">if xerrors.Is(err, context.Canceled) </span><span class="cov7" title="23">{
+        <span class="cov8" title="1">if xerrors.Is(err, context.Canceled) </span><span class="cov8" title="1">{
                 return xerrors.Join(apperror.ErrCanceled, err)
         }</span>
 
-        <span class="cov6" title="12">if IsUnavailable(err) </span><span class="cov3" title="3">{
+        <span class="cov8" title="1">if IsUnavailable(err) </span><span class="cov8" title="1">{
                 return xerrors.Join(apperror.ErrUnavailable, err)
         }</span>
 
-        <span class="cov5" title="9">return xerrors.Join(apperror.ErrInternal, err)</span>
+        <span class="cov8" title="1">return xerrors.Join(apperror.ErrInternal, err)</span>
 }
 
 // NormalizeExecResult は、影響行数を返す書き込み系クエリの結果を正規化します。
 // エラーは NormalizeError と同じ規則で変換し、エラーが無くても影響行数が 0 の場合は
 // 対象が存在しないとみなして ErrNotFound を返します（UPDATE / DELETE のサイレント成功を防ぐ）。
-func NormalizeExecResult(affected int64, err error) error <span class="cov4" title="7">{
-        if err != nil </span><span class="cov2" title="2">{
+func NormalizeExecResult(affected int64, err error) error <span class="cov8" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return NormalizeError(err)
         }</span>
-        <span class="cov4" title="5">if affected == 0 </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if affected == 0 </span><span class="cov8" title="1">{
                 return xerrors.Wrap(apperror.ErrNotFound, "no rows affected")
         }</span>
-        <span class="cov3" title="3">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // IsUnavailable は、DB が利用不可能な状態を示すエラーかを判定します。context.DeadlineExceeded・net.Error・PostgreSQL 接続例外クラス(08xxx) を対象とします。
-func IsUnavailable(err error) bool <span class="cov10" title="84">{
-        if err == nil </span><span class="cov1" title="1">{
+func IsUnavailable(err error) bool <span class="cov8" title="1">{
+        if err == nil </span><span class="cov8" title="1">{
                 return false
         }</span>
 
-        <span class="cov9" title="83">if xerrors.Is(err, context.DeadlineExceeded) </span><span class="cov3" title="4">{
+        <span class="cov8" title="1">if xerrors.Is(err, context.DeadlineExceeded) </span><span class="cov8" title="1">{
                 return true
         }</span>
 
-        <span class="cov9" title="79">var ne net.Error
-        if xerrors.As(err, &amp;ne) </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">var ne net.Error
+        if xerrors.As(err, &amp;ne) </span><span class="cov8" title="1">{
                 return true
         }</span>
 
-        <span class="cov9" title="77">return isPgConnectionError(err)</span>
+        <span class="cov8" title="1">return isPgConnectionError(err)</span>
 }
 
 // isPgConnectionError は、与えられたエラーがPostgreSQLの接続エラーであるかを判定します。
-func isPgConnectionError(err error) bool <span class="cov9" title="80">{
+func isPgConnectionError(err error) bool <span class="cov8" title="1">{
         var pgErr *pgconn.PgError
-        if !xerrors.As(err, &amp;pgErr) </span><span class="cov9" title="65">{
+        if !xerrors.As(err, &amp;pgErr) </span><span class="cov8" title="1">{
                 return false
         }</span>
-        <span class="cov6" title="15">return strings.HasPrefix(pgErr.Code, "08")</span>
+        <span class="cov8" title="1">return strings.HasPrefix(pgErr.Code, "08")</span>
 }
 
 // IsLockNotAvailable は、lock_timeout 失効によるエラーであるかを判定します。
-func IsLockNotAvailable(err error) bool <span class="cov6" title="12">{
+func IsLockNotAvailable(err error) bool <span class="cov8" title="1">{
         var pgErr *pgconn.PgError
         return xerrors.As(err, &amp;pgErr) &amp;&amp; pgErr.Code == "55P03"
 }</span>
@@ -13447,7 +13438,7 @@ func IsLockNotAvailable(err error) bool <span class="cov6" title="12">{
 // 40001 = serialization_failure, 40P01 = deadlock_detected。
 // 写像後の sentinel（両者は ErrUnavailable へ写像される）ではなく生 SQLSTATE で判定し、
 // 接続断など他の ErrUnavailable をリトライ対象に巻き込まないようにします。
-func IsRetryableTxError(err error) bool <span class="cov9" title="76">{
+func IsRetryableTxError(err error) bool <span class="cov8" title="1">{
         var pgErr *pgconn.PgError
         return xerrors.As(err, &amp;pgErr) &amp;&amp; (pgErr.Code == "40001" || pgErr.Code == "40P01")
 }</span>
@@ -13476,7 +13467,7 @@ type service struct {
 func New(
         db driver.DatabaseDriver,
         tf observability.TracerFactory,
-) query.UserSearchQueryService <span class="cov2" title="2">{
+) query.UserSearchQueryService <span class="cov8" title="1">{
         return &amp;service{
                 db:     db,
                 tracer: tf.Infra(),
@@ -13484,20 +13475,20 @@ func New(
 }</span>
 
 // buildLikeTokens は、キーワードを LIKE パターンへ変換します。空の場合は全件マッチの ["%"] を返します。
-func buildLikeTokens(keywords []string) []string <span class="cov9" title="19">{
-        if len(keywords) == 0 </span><span class="cov6" title="7">{
+func buildLikeTokens(keywords []string) []string <span class="cov8" title="1">{
+        if len(keywords) == 0 </span><span class="cov8" title="1">{
                 return []string{"%"}
         }</span>
-        <span class="cov8" title="12">tokens := make([]string, len(keywords))
-        for i, kw := range keywords </span><span class="cov8" title="14">{
+        <span class="cov8" title="1">tokens := make([]string, len(keywords))
+        for i, kw := range keywords </span><span class="cov8" title="1">{
                 escaped := sqlc.EscapeForLike(kw, sqlc.DefaultLikeEscapeChar)
                 tokens[i] = sqlc.WrapContainsLikePattern(escaped)
         }</span>
-        <span class="cov8" title="12">return tokens</span>
+        <span class="cov8" title="1">return tokens</span>
 }
 
 // toUserSearchResult は、sqlc の行から UserSearchResult を構築します。
-func toUserSearchResult(u gen.Users, prefectureName string) *query.UserSearchResult <span class="cov10" title="24">{
+func toUserSearchResult(u gen.Users, prefectureName string) *query.UserSearchResult <span class="cov8" title="1">{
         return &amp;query.UserSearchResult{
                 FirstName:      u.FirstName,
                 LastName:       u.LastName,
@@ -13514,7 +13505,7 @@ func toUserSearchResult(u gen.Users, prefectureName string) *query.UserSearchRes
 }</span>
 
 // FindByFilter は、キーワード検索でユーザーの情報を取得します。
-func (s *service) FindByFilter(ctx context.Context, filter *query.UserSearchFilter, limit, offset int32) (query.UserSearchResults, error) <span class="cov7" title="9">{
+func (s *service) FindByFilter(ctx context.Context, filter *query.UserSearchFilter, limit, offset int32) (query.UserSearchResults, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
@@ -13522,19 +13513,19 @@ func (s *service) FindByFilter(ctx context.Context, filter *query.UserSearchFilt
         db := gen.New(driver.New(ctx, s.db))
 
         switch </span>{
-        case filter.Active == nil:<span class="cov4" title="3">
+        case filter.Active == nil:<span class="cov8" title="1">
                 return fetchSearchAll(ctx, db, &amp;gen.SearchUsersParams{
                         PatternsParam: tokens,
                         LimitParam:    limit,
                         OffsetParam:   offset,
                 })</span>
-        case *filter.Active:<span class="cov4" title="3">
+        case *filter.Active:<span class="cov8" title="1">
                 return fetchSearchActive(ctx, db, &amp;gen.SearchActiveUsersParams{
                         PatternsParam: tokens,
                         LimitParam:    limit,
                         OffsetParam:   offset,
                 })</span>
-        default:<span class="cov4" title="3">
+        default:<span class="cov8" title="1">
                 return fetchSearchDeleted(ctx, db, &amp;gen.SearchDeletedUsersParams{
                         PatternsParam: tokens,
                         LimitParam:    limit,
@@ -13546,50 +13537,50 @@ func (s *service) FindByFilter(ctx context.Context, filter *query.UserSearchFilt
 // fetchSearchAll は、キーワード検索で全てのユーザーを検索します。
 func fetchSearchAll(
         ctx context.Context, db *gen.Queries, searchParams *gen.SearchUsersParams,
-) (query.UserSearchResults, error) <span class="cov4" title="3">{
+) (query.UserSearchResults, error) <span class="cov8" title="1">{
         rows, err := db.SearchUsers(ctx, searchParams)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, pgerror.NormalizeError(err)
         }</span>
-        <span class="cov2" title="2">results := make(query.UserSearchResults, len(rows))
-        for i, row := range rows </span><span class="cov8" title="12">{
+        <span class="cov8" title="1">results := make(query.UserSearchResults, len(rows))
+        for i, row := range rows </span><span class="cov8" title="1">{
                 results[i] = toUserSearchResult(row.Users, row.PrefectureName)
         }</span>
-        <span class="cov2" title="2">return results, nil</span>
+        <span class="cov8" title="1">return results, nil</span>
 }
 
 // fetchSearchActive は、アクティブなユーザーを検索します。
 func fetchSearchActive(
         ctx context.Context, db *gen.Queries, searchParams *gen.SearchActiveUsersParams,
-) (query.UserSearchResults, error) <span class="cov4" title="3">{
+) (query.UserSearchResults, error) <span class="cov8" title="1">{
         rows, err := db.SearchActiveUsers(ctx, searchParams)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, pgerror.NormalizeError(err)
         }</span>
-        <span class="cov2" title="2">results := make(query.UserSearchResults, len(rows))
-        for i, row := range rows </span><span class="cov7" title="9">{
+        <span class="cov8" title="1">results := make(query.UserSearchResults, len(rows))
+        for i, row := range rows </span><span class="cov8" title="1">{
                 results[i] = toUserSearchResult(row.Users, row.PrefectureName)
         }</span>
-        <span class="cov2" title="2">return results, nil</span>
+        <span class="cov8" title="1">return results, nil</span>
 }
 
 // fetchSearchDeleted は、削除されたユーザーを検索します。
 func fetchSearchDeleted(
         ctx context.Context, db *gen.Queries, searchParams *gen.SearchDeletedUsersParams,
-) (query.UserSearchResults, error) <span class="cov4" title="3">{
+) (query.UserSearchResults, error) <span class="cov8" title="1">{
         rows, err := db.SearchDeletedUsers(ctx, searchParams)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, pgerror.NormalizeError(err)
         }</span>
-        <span class="cov2" title="2">results := make(query.UserSearchResults, len(rows))
-        for i, row := range rows </span><span class="cov4" title="3">{
+        <span class="cov8" title="1">results := make(query.UserSearchResults, len(rows))
+        for i, row := range rows </span><span class="cov8" title="1">{
                 results[i] = toUserSearchResult(row.Users, row.PrefectureName)
         }</span>
-        <span class="cov2" title="2">return results, nil</span>
+        <span class="cov8" title="1">return results, nil</span>
 }
 
 // CountByFilter は、キーワード検索でユーザーの総件数を返します。
-func (s *service) CountByFilter(ctx context.Context, filter *query.UserSearchFilter) (int64, error) <span class="cov6" title="7">{
+func (s *service) CountByFilter(ctx context.Context, filter *query.UserSearchFilter) (int64, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
@@ -13602,19 +13593,19 @@ func (s *service) CountByFilter(ctx context.Context, filter *query.UserSearchFil
         )
 
         switch </span>{
-        case filter.Active == nil:<span class="cov4" title="3">
+        case filter.Active == nil:<span class="cov8" title="1">
                 count, err = db.CountSearchUsers(ctx, tokens)</span>
-        case *filter.Active:<span class="cov2" title="2">
+        case *filter.Active:<span class="cov8" title="1">
                 count, err = db.CountSearchActiveUsers(ctx, tokens)</span>
-        default:<span class="cov2" title="2">
+        default:<span class="cov8" title="1">
                 count, err = db.CountSearchDeletedUsers(ctx, tokens)</span>
         }
 
-        <span class="cov6" title="7">if err != nil </span><span class="cov4" title="3">{
+        <span class="cov8" title="1">if err != nil </span><span class="cov8" title="1">{
                 return 0, pgerror.NormalizeError(err)
         }</span>
 
-        <span class="cov4" title="4">return count, nil</span>
+        <span class="cov8" title="1">return count, nil</span>
 }
 </pre>
 		
@@ -13641,7 +13632,7 @@ type repository struct {
 func New(
         db driver.DatabaseDriver,
         tf observability.TracerFactory,
-) prefecture.Repository <span class="cov10" title="7">{
+) prefecture.Repository <span class="cov8" title="1">{
         return &amp;repository{
                 db:     db,
                 tracer: tf.Infra(),
@@ -13649,17 +13640,17 @@ func New(
 }</span>
 
 // FindByID は、IDから都道府県エンティティを取得します。
-func (r *repository) FindByID(ctx context.Context, id uuid.UUID) (*prefecture.Prefecture, error) <span class="cov4" title="2">{
+func (r *repository) FindByID(ctx context.Context, id uuid.UUID) (*prefecture.Prefecture, error) <span class="cov8" title="1">{
         ctx, endSpan := r.tracer.Start(ctx)
         defer endSpan()
 
         db := gen.New(driver.New(ctx, r.db))
         row, err := db.GetPrefectureDomainByID(ctx, id)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, pgerror.NormalizeError(err)
         }</span>
 
-        <span class="cov1" title="1">return prefecture.New(
+        <span class="cov8" title="1">return prefecture.New(
                 row.ID,
                 row.Name,
                 int(row.Code),
@@ -13667,44 +13658,44 @@ func (r *repository) FindByID(ctx context.Context, id uuid.UUID) (*prefecture.Pr
 }
 
 // FindByIDs は、複数IDから都道府県エンティティ一覧を取得します。
-func (r *repository) FindByIDs(ctx context.Context, ids []uuid.UUID) (prefecture.Prefectures, error) <span class="cov6" title="3">{
+func (r *repository) FindByIDs(ctx context.Context, ids []uuid.UUID) (prefecture.Prefectures, error) <span class="cov8" title="1">{
         ctx, endSpan := r.tracer.Start(ctx)
         defer endSpan()
 
         db := gen.New(driver.New(ctx, r.db))
         rows, err := db.GetPrefectureDomainByIDs(ctx, ids)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, pgerror.NormalizeError(err)
         }</span>
 
-        <span class="cov4" title="2">prefectures := make(prefecture.Prefectures, len(rows))
-        for i, row := range rows </span><span class="cov6" title="3">{
+        <span class="cov8" title="1">prefectures := make(prefecture.Prefectures, len(rows))
+        for i, row := range rows </span><span class="cov8" title="1">{
                 prefectureEntity, err := prefecture.New(
                         row.ID,
                         row.Name,
                         int(row.Code),
                 )
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return nil, err
                 }</span>
-                <span class="cov4" title="2">prefectures[i] = prefectureEntity</span>
+                <span class="cov8" title="1">prefectures[i] = prefectureEntity</span>
         }
 
-        <span class="cov1" title="1">return prefectures, nil</span>
+        <span class="cov8" title="1">return prefectures, nil</span>
 }
 
 // FindByName は、都道府県名から都道府県エンティティを取得します。
-func (r *repository) FindByName(ctx context.Context, name string) (*prefecture.Prefecture, error) <span class="cov4" title="2">{
+func (r *repository) FindByName(ctx context.Context, name string) (*prefecture.Prefecture, error) <span class="cov8" title="1">{
         ctx, endSpan := r.tracer.Start(ctx)
         defer endSpan()
 
         db := gen.New(driver.New(ctx, r.db))
         row, err := db.GetPrefectureDomainByName(ctx, name)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, pgerror.NormalizeError(err)
         }</span>
 
-        <span class="cov1" title="1">return prefecture.New(
+        <span class="cov8" title="1">return prefecture.New(
                 row.ID,
                 row.Name,
                 int(row.Code),
@@ -13735,7 +13726,7 @@ type repository struct {
 func New(
         db driver.DatabaseDriver,
         tf observability.TracerFactory,
-) user.Repository <span class="cov5" title="7">{
+) user.Repository <span class="cov8" title="1">{
         return &amp;repository{
                 db:     db,
                 tracer: tf.Infra(),
@@ -13743,24 +13734,24 @@ func New(
 }</span>
 
 // FindByActive は、アクティブ状態に基づいてユーザーの情報を取得します。
-func (r *repository) FindByActive(ctx context.Context, active *bool, limit, offset int32) (user.Users, error) <span class="cov7" title="13">{
+func (r *repository) FindByActive(ctx context.Context, active *bool, limit, offset int32) (user.Users, error) <span class="cov8" title="1">{
         ctx, endSpan := r.tracer.Start(ctx)
         defer endSpan()
 
         db := gen.New(driver.New(ctx, r.db))
 
         switch </span>{
-        case active == nil:<span class="cov5" title="7">
+        case active == nil:<span class="cov8" title="1">
                 return fetchListUsersRows(ctx, db, &amp;gen.ListUsersParams{
                         OffsetParam: offset,
                         LimitParam:  limit,
                 })</span>
-        case *active:<span class="cov3" title="3">
+        case *active:<span class="cov8" title="1">
                 return fetchListUsersRowsByActive(ctx, db, &amp;gen.ListActiveUsersParams{
                         OffsetParam: offset,
                         LimitParam:  limit,
                 })</span>
-        case !*active:<span class="cov3" title="3">
+        case !*active:<span class="cov8" title="1">
                 return fetchListUsersRowsByDeleted(ctx, db, &amp;gen.ListDeletedUsersParams{
                         OffsetParam: offset,
                         LimitParam:  limit,
@@ -13772,33 +13763,33 @@ func (r *repository) FindByActive(ctx context.Context, active *bool, limit, offs
 
 // FindFeed は、未削除ユーザーを (created_at DESC, id DESC) の安定順で keyset ページネーション取得します。
 // after=nil の場合は先頭ページ、それ以外は after が表す境界より後ろ（より過去）の行を返します。
-func (r *repository) FindFeed(ctx context.Context, after *user.FeedCursor, limit int32) (user.Users, error) <span class="cov6" title="9">{
+func (r *repository) FindFeed(ctx context.Context, after *user.FeedCursor, limit int32) (user.Users, error) <span class="cov8" title="1">{
         ctx, endSpan := r.tracer.Start(ctx)
         defer endSpan()
 
         db := gen.New(driver.New(ctx, r.db))
 
-        if after == nil </span><span class="cov4" title="4">{
+        if after == nil </span><span class="cov8" title="1">{
                 rows, err := db.ListUsersFeedFirst(ctx, limit)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return nil, pgerror.NormalizeError(err)
                 }</span>
-                <span class="cov3" title="3">return rowsToUsers(rows, func(r *gen.ListUsersFeedFirstRow) gen.Users </span><span class="cov3" title="3">{ return r.Users }</span>)
+                <span class="cov8" title="1">return rowsToUsers(rows, func(r *gen.ListUsersFeedFirstRow) gen.Users </span><span class="cov8" title="1">{ return r.Users }</span>)
         }
 
-        <span class="cov4" title="5">rows, err := db.ListUsersFeedAfter(ctx, &amp;gen.ListUsersFeedAfterParams{
+        <span class="cov8" title="1">rows, err := db.ListUsersFeedAfter(ctx, &amp;gen.ListUsersFeedAfterParams{
                 AfterCreatedAt: after.CreatedAt(),
                 AfterID:        after.ID(),
                 LimitParam:     limit,
         })
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, pgerror.NormalizeError(err)
         }</span>
-        <span class="cov4" title="4">return rowsToUsers(rows, func(r *gen.ListUsersFeedAfterRow) gen.Users </span><span class="cov6" title="12">{ return r.Users }</span>)
+        <span class="cov8" title="1">return rowsToUsers(rows, func(r *gen.ListUsersFeedAfterRow) gen.Users </span><span class="cov8" title="1">{ return r.Users }</span>)
 }
 
 // rowToUser は、sqlc が返す Users 行をドメインエンティティへ変換します。
-func rowToUser(u gen.Users) (*user.User, error) <span class="cov10" title="46">{
+func rowToUser(u gen.Users) (*user.User, error) <span class="cov8" title="1">{
         return user.New(
                 u.ID,
                 u.FirstName,
@@ -13818,53 +13809,53 @@ func rowToUser(u gen.Users) (*user.User, error) <span class="cov10" title="46">{
 }</span>
 
 // rowsToUsers は、行スライスをドメインエンティティ列へ変換します。
-func rowsToUsers[T any](rows []T, extract func(T) gen.Users) (user.Users, error) <span class="cov7" title="16">{
+func rowsToUsers[T any](rows []T, extract func(T) gen.Users) (user.Users, error) <span class="cov8" title="1">{
         users := make(user.Users, len(rows))
-        for i, row := range rows </span><span class="cov9" title="40">{
+        for i, row := range rows </span><span class="cov8" title="1">{
                 u, err := rowToUser(extract(row))
-                if err != nil </span><span class="cov4" title="5">{
+                if err != nil </span><span class="cov8" title="1">{
                         return nil, err
                 }</span>
-                <span class="cov9" title="35">users[i] = u</span>
+                <span class="cov8" title="1">users[i] = u</span>
         }
-        <span class="cov6" title="11">return users, nil</span>
+        <span class="cov8" title="1">return users, nil</span>
 }
 
 // fetchListUsersRows は、ユーザーの情報を取得します。
 func fetchListUsersRows(
         ctx context.Context, db *gen.Queries, params *gen.ListUsersParams,
-) (user.Users, error) <span class="cov5" title="7">{
+) (user.Users, error) <span class="cov8" title="1">{
         rows, err := db.ListUsers(ctx, params)
-        if err != nil </span><span class="cov2" title="2">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, pgerror.NormalizeError(err)
         }</span>
-        <span class="cov4" title="5">return rowsToUsers(rows, func(r *gen.ListUsersRow) gen.Users </span><span class="cov7" title="13">{ return r.Users }</span>)
+        <span class="cov8" title="1">return rowsToUsers(rows, func(r *gen.ListUsersRow) gen.Users </span><span class="cov8" title="1">{ return r.Users }</span>)
 }
 
 // fetchListUsersRowsByActive は、アクティブ状態に基づいてユーザーの情報を取得します。
 func fetchListUsersRowsByActive(
         ctx context.Context, db *gen.Queries, params *gen.ListActiveUsersParams,
-) (user.Users, error) <span class="cov3" title="3">{
+) (user.Users, error) <span class="cov8" title="1">{
         rows, err := db.ListActiveUsers(ctx, params)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, pgerror.NormalizeError(err)
         }</span>
-        <span class="cov2" title="2">return rowsToUsers(rows, func(r *gen.ListActiveUsersRow) gen.Users </span><span class="cov6" title="9">{ return r.Users }</span>)
+        <span class="cov8" title="1">return rowsToUsers(rows, func(r *gen.ListActiveUsersRow) gen.Users </span><span class="cov8" title="1">{ return r.Users }</span>)
 }
 
 // fetchListUsersRowsByDeleted は、削除されたユーザーの情報を取得します。
 func fetchListUsersRowsByDeleted(
         ctx context.Context, db *gen.Queries, params *gen.ListDeletedUsersParams,
-) (user.Users, error) <span class="cov3" title="3">{
+) (user.Users, error) <span class="cov8" title="1">{
         rows, err := db.ListDeletedUsers(ctx, params)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, pgerror.NormalizeError(err)
         }</span>
-        <span class="cov2" title="2">return rowsToUsers(rows, func(r *gen.ListDeletedUsersRow) gen.Users </span><span class="cov3" title="3">{ return r.Users }</span>)
+        <span class="cov8" title="1">return rowsToUsers(rows, func(r *gen.ListDeletedUsersRow) gen.Users </span><span class="cov8" title="1">{ return r.Users }</span>)
 }
 
 // Create は、ユーザーを作成します。
-func (r *repository) Create(ctx context.Context, u *user.User) error <span class="cov2" title="2">{
+func (r *repository) Create(ctx context.Context, u *user.User) error <span class="cov8" title="1">{
         ctx, endSpan := r.tracer.Start(ctx)
         defer endSpan()
 
@@ -13884,28 +13875,28 @@ func (r *repository) Create(ctx context.Context, u *user.User) error <span class
                 CreatedAt:    u.CreatedAt(),
                 UpdatedAt:    u.UpdatedAt(),
         })
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return pgerror.NormalizeError(err)
         }</span>
-        <span class="cov1" title="1">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // FindByID は、IDから単一ユーザーを取得します。存在しない場合は NotFound に正規化したエラーを返します。
-func (r *repository) FindByID(ctx context.Context, id uuid.UUID) (*user.User, error) <span class="cov5" title="8">{
+func (r *repository) FindByID(ctx context.Context, id uuid.UUID) (*user.User, error) <span class="cov8" title="1">{
         ctx, endSpan := r.tracer.Start(ctx)
         defer endSpan()
 
         db := gen.New(driver.New(ctx, r.db))
         row, err := db.GetUserByID(ctx, id)
-        if err != nil </span><span class="cov2" title="2">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, pgerror.NormalizeError(err)
         }</span>
 
-        <span class="cov5" title="6">return rowToUser(row.Users)</span>
+        <span class="cov8" title="1">return rowToUser(row.Users)</span>
 }
 
 // Update は、ユーザーの mutable フィールドと updatedAt / deletedAt を更新します。
-func (r *repository) Update(ctx context.Context, u *user.User) error <span class="cov4" title="4">{
+func (r *repository) Update(ctx context.Context, u *user.User) error <span class="cov8" title="1">{
         ctx, endSpan := r.tracer.Start(ctx)
         defer endSpan()
 
@@ -13930,7 +13921,7 @@ func (r *repository) Update(ctx context.Context, u *user.User) error <span class
 }</span>
 
 // CountByActive は、アクティブ状態に基づいてユーザーの総件数を返します。
-func (r *repository) CountByActive(ctx context.Context, active *bool) (int64, error) <span class="cov4" title="4">{
+func (r *repository) CountByActive(ctx context.Context, active *bool) (int64, error) <span class="cov8" title="1">{
         ctx, endSpan := r.tracer.Start(ctx)
         defer endSpan()
 
@@ -13942,21 +13933,21 @@ func (r *repository) CountByActive(ctx context.Context, active *bool) (int64, er
         )
 
         switch </span>{
-        case active == nil:<span class="cov1" title="1">
+        case active == nil:<span class="cov8" title="1">
                 count, err = db.CountUsers(ctx)</span>
-        case *active:<span class="cov2" title="2">
+        case *active:<span class="cov8" title="1">
                 count, err = db.CountActiveUsers(ctx)</span>
-        case !*active:<span class="cov1" title="1">
+        case !*active:<span class="cov8" title="1">
                 count, err = db.CountDeletedUsers(ctx)</span>
         default:<span class="cov0" title="0">
                 panic("unreachable: invalid active")</span>
         }
 
-        <span class="cov4" title="4">if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err != nil </span><span class="cov8" title="1">{
                 return 0, pgerror.NormalizeError(err)
         }</span>
 
-        <span class="cov3" title="3">return count, nil</span>
+        <span class="cov8" title="1">return count, nil</span>
 }
 </pre>
 		
@@ -13970,25 +13961,25 @@ const DefaultLikeEscapeChar = "\\"
 
 // WrapPrefixLikePattern は、前方一致（prefix match）用に pattern を作ります。
 // escaped は EscapeForLike 済みの文字列を渡すこと。例: "hoge" -&gt; "hoge%"
-func WrapPrefixLikePattern(escaped string) string <span class="cov1" title="1">{
+func WrapPrefixLikePattern(escaped string) string <span class="cov8" title="1">{
         return escaped + "%"
 }</span>
 
 // WrapSuffixLikePattern は、後方一致（suffix match）用に pattern を作ります。
 // escaped は EscapeForLike 済みの文字列を渡すこと。例: "hoge" -&gt; "%hoge"
-func WrapSuffixLikePattern(escaped string) string <span class="cov1" title="1">{
+func WrapSuffixLikePattern(escaped string) string <span class="cov8" title="1">{
         return "%" + escaped
 }</span>
 
 // WrapContainsLikePattern は、部分一致（contains match）用に pattern を作ります。
 // escaped は EscapeForLike 済みの文字列を渡すこと。例: "hoge" -&gt; "%hoge%"
-func WrapContainsLikePattern(escaped string) string <span class="cov9" title="15">{
+func WrapContainsLikePattern(escaped string) string <span class="cov8" title="1">{
         return "%" + escaped + "%"
 }</span>
 
 // EscapeForLike は、PostgreSQL の LIKE/ILIKE のために
 // % と _ と エスケープ文字自体をエスケープします。
-func EscapeForLike(s, esc string) string <span class="cov10" title="16">{
+func EscapeForLike(s, esc string) string <span class="cov8" title="1">{
         s = strings.ReplaceAll(s, esc, esc+esc)
         s = strings.ReplaceAll(s, "%", esc+"%")
         s = strings.ReplaceAll(s, "_", esc+"_")
@@ -14020,7 +14011,7 @@ type systemQuery struct {
 func New(
         provider driver.DatabaseDriver,
         tf observability.TracerFactory,
-) query.DBSystemQuery <span class="cov10" title="2">{
+) query.DBSystemQuery <span class="cov8" title="1">{
         return &amp;systemQuery{
                 db:     provider,
                 tracer: tf.Infra(),
@@ -14028,17 +14019,17 @@ func New(
 }</span>
 
 // CheckDBHealth は、データベースの健全性をチェックします。
-func (s *systemQuery) CheckDBHealth(ctx context.Context) (query.DBHealth, error) <span class="cov10" title="2">{
+func (s *systemQuery) CheckDBHealth(ctx context.Context) (query.DBHealth, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         start := time.Now()
         db := gen.New(driver.New(ctx, s.db))
         _, err := db.GetDBHealthCheck(ctx)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return query.DBHealth{}, pgerror.NormalizeError(err)
         }</span>
-        <span class="cov1" title="1">respondedAt := time.Now()
+        <span class="cov8" title="1">respondedAt := time.Now()
 
         return query.DBHealth{
                 Ready:       true,
@@ -14078,7 +14069,7 @@ type store struct {
 func New(
         provider driver.DatabaseDriver,
         tf observability.TracerFactory,
-) idempotencybndry.Store <span class="cov9" title="7">{
+) idempotencybndry.Store <span class="cov8" title="1">{
         return &amp;store{
                 db:     provider,
                 tracer: tf.Infra(),
@@ -14088,16 +14079,16 @@ func New(
 // Claim は、claimed 行を作ります。新規に作れたら true、同一 (scope, key) の既存行があれば
 // false を返します。ロック競合タイムアウト時は ErrLockTimeout を返します。
 // 業務 tx 内から呼ぶこと（SET LOCAL lock_timeout がセッションに有効になる）。
-func (s *store) Claim(ctx context.Context, p idempotencybndry.ClaimParams) (bool, error) <span class="cov10" title="8">{
+func (s *store) Claim(ctx context.Context, p idempotencybndry.ClaimParams) (bool, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         ldb := driver.New(ctx, s.db)
-        if _, err := ldb.Exec(ctx, "SET LOCAL lock_timeout = '"+claimLockTimeout+"'"); err != nil </span><span class="cov1" title="1">{
+        if _, err := ldb.Exec(ctx, "SET LOCAL lock_timeout = '"+claimLockTimeout+"'"); err != nil </span><span class="cov8" title="1">{
                 return false, pgerror.NormalizeError(err)
         }</span>
 
-        <span class="cov9" title="7">db := gen.New(ldb)
+        <span class="cov8" title="1">db := gen.New(ldb)
         _, err := db.ClaimIdempotencyKey(ctx, &amp;gen.ClaimIdempotencyKeyParams{
                 Scope:              p.Scope,
                 IdempotencyKey:     p.Key,
@@ -14107,20 +14098,20 @@ func (s *store) Claim(ctx context.Context, p idempotencybndry.ClaimParams) (bool
                 ExpiresAt:          p.ExpiresAt,
         })
         switch </span>{
-        case err == nil:<span class="cov7" title="4">
+        case err == nil:<span class="cov8" title="1">
                 return true, nil</span>
-        case xerrors.Is(err, pgx.ErrNoRows):<span class="cov1" title="1">
+        case xerrors.Is(err, pgx.ErrNoRows):<span class="cov8" title="1">
                 // ON CONFLICT DO NOTHING で 0 行 = 既存キーあり。
                 return false, nil</span>
-        case pgerror.IsLockNotAvailable(err):<span class="cov1" title="1">
+        case pgerror.IsLockNotAvailable(err):<span class="cov8" title="1">
                 return false, idempotencybndry.ErrLockTimeout</span>
-        default:<span class="cov1" title="1">
+        default:<span class="cov8" title="1">
                 return false, pgerror.NormalizeError(err)</span>
         }
 }
 
 // Get は、(scope, key) の保存済み状態を取得します。存在しなければ nil, nil。
-func (s *store) Get(ctx context.Context, scope, key string) (*idempotencybndry.Record, error) <span class="cov7" title="5">{
+func (s *store) Get(ctx context.Context, scope, key string) (*idempotencybndry.Record, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
@@ -14129,14 +14120,14 @@ func (s *store) Get(ctx context.Context, scope, key string) (*idempotencybndry.R
                 Scope:          scope,
                 IdempotencyKey: key,
         })
-        if err != nil </span><span class="cov5" title="3">{
-                if xerrors.Is(err, pgx.ErrNoRows) </span><span class="cov4" title="2">{
+        if err != nil </span><span class="cov8" title="1">{
+                if xerrors.Is(err, pgx.ErrNoRows) </span><span class="cov8" title="1">{
                         return nil, nil //nolint:nilnil // 「存在しない」を nil, nil で表す（呼び出し側が分岐）
                 }</span>
-                <span class="cov1" title="1">return nil, pgerror.NormalizeError(err)</span>
+                <span class="cov8" title="1">return nil, pgerror.NormalizeError(err)</span>
         }
 
-        <span class="cov4" title="2">return &amp;idempotencybndry.Record{
+        <span class="cov8" title="1">return &amp;idempotencybndry.Record{
                 Status:          idempotencybndry.Status(row.Status),
                 ResponseStatus:  row.ResponseStatus,
                 ResponsePayload: row.ResponsePayload,
@@ -14145,7 +14136,7 @@ func (s *store) Get(ctx context.Context, scope, key string) (*idempotencybndry.R
 }
 
 // Complete は、claimed → completed へ遷移し結果を保存します。
-func (s *store) Complete(ctx context.Context, p idempotencybndry.CompleteParams) error <span class="cov5" title="3">{
+func (s *store) Complete(ctx context.Context, p idempotencybndry.CompleteParams) error <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
@@ -14157,18 +14148,18 @@ func (s *store) Complete(ctx context.Context, p idempotencybndry.CompleteParams)
                 ResponseStatus:  &amp;status,
                 ResponsePayload: p.ResponsePayload,
         })
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return pgerror.NormalizeError(err)
         }</span>
-        <span class="cov4" title="2">if affected == 0 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if affected == 0 </span><span class="cov8" title="1">{
                 // 同一 tx で claim 済みの行が complete 対象にならない＝前提崩壊（404 ではなく内部エラー）。
                 return xerrors.Wrap(apperror.ErrInternal, "complete: claimed row not found in the same transaction")
         }</span>
-        <span class="cov1" title="1">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // DeleteExpired は、cutoff より古い行を limit 件まで削除し、削除件数を返します（GC）。
-func (s *store) DeleteExpired(ctx context.Context, cutoff time.Time, limit int32) (int64, error) <span class="cov5" title="3">{
+func (s *store) DeleteExpired(ctx context.Context, cutoff time.Time, limit int32) (int64, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
@@ -14177,10 +14168,10 @@ func (s *store) DeleteExpired(ctx context.Context, cutoff time.Time, limit int32
                 ExpiresAt: cutoff,
                 Limit:     limit,
         })
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return 0, pgerror.NormalizeError(err)
         }</span>
-        <span class="cov4" title="2">return affected, nil</span>
+        <span class="cov8" title="1">return affected, nil</span>
 }
 </pre>
 		
@@ -14211,7 +14202,7 @@ type store struct {
 func New(
         provider driver.DatabaseDriver,
         tf observability.TracerFactory,
-) outboxbndry.Store <span class="cov9" title="10">{
+) outboxbndry.Store <span class="cov8" title="1">{
         return &amp;store{
                 db:     provider,
                 tracer: tf.Infra(),
@@ -14219,16 +14210,16 @@ func New(
 }</span>
 
 // Insert は、業務 tx 内で outbox 行を 1 行 INSERT し、採番された message_id を返します。
-func (s *store) Insert(ctx context.Context, p outboxbndry.EmitParams) (uuid.UUID, error) <span class="cov9" title="9">{
+func (s *store) Insert(ctx context.Context, p outboxbndry.EmitParams) (uuid.UUID, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         headers := p.Headers
-        if len(headers) == 0 </span><span class="cov9" title="9">{
+        if len(headers) == 0 </span><span class="cov8" title="1">{
                 headers = []byte("{}")
         }</span>
 
-        <span class="cov9" title="9">db := gen.New(driver.New(ctx, s.db))
+        <span class="cov8" title="1">db := gen.New(driver.New(ctx, s.db))
         row, err := db.InsertOutbox(ctx, &amp;gen.InsertOutboxParams{
                 AggregateType: p.AggregateType,
                 AggregateID:   p.AggregateID,
@@ -14236,25 +14227,25 @@ func (s *store) Insert(ctx context.Context, p outboxbndry.EmitParams) (uuid.UUID
                 Payload:       p.Payload,
                 Headers:       headers,
         })
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return uuid.UUID{}, pgerror.NormalizeError(err)
         }</span>
-        <span class="cov8" title="8">return row.MessageID, nil</span>
+        <span class="cov8" title="1">return row.MessageID, nil</span>
 }
 
 // ClaimPending は、pending 行を最大 limit 件ロックして返します。並行ワーカーが同一行を取得しません。
-func (s *store) ClaimPending(ctx context.Context, limit int32) ([]outboxbndry.PendingMessage, error) <span class="cov10" title="11">{
+func (s *store) ClaimPending(ctx context.Context, limit int32) ([]outboxbndry.PendingMessage, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         db := gen.New(driver.New(ctx, s.db))
         rows, err := db.ClaimPendingOutbox(ctx, limit)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, pgerror.NormalizeError(err)
         }</span>
 
-        <span class="cov9" title="10">messages := make([]outboxbndry.PendingMessage, 0, len(rows))
-        for _, row := range rows </span><span class="cov9" title="9">{
+        <span class="cov8" title="1">messages := make([]outboxbndry.PendingMessage, 0, len(rows))
+        for _, row := range rows </span><span class="cov8" title="1">{
                 messages = append(messages, outboxbndry.PendingMessage{
                         ID:        row.ID,
                         MessageID: row.MessageID,
@@ -14264,24 +14255,24 @@ func (s *store) ClaimPending(ctx context.Context, limit int32) ([]outboxbndry.Pe
                         Attempts:  row.Attempts,
                 })
         }</span>
-        <span class="cov9" title="10">return messages, nil</span>
+        <span class="cov8" title="1">return messages, nil</span>
 }
 
 // MarkPublished は、publish 成功行を published へ遷移します（既に pending でなければ no-op）。
-func (s *store) MarkPublished(ctx context.Context, id int64) error <span class="cov6" title="4">{
+func (s *store) MarkPublished(ctx context.Context, id int64) error <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         db := gen.New(driver.New(ctx, s.db))
-        if _, err := db.MarkOutboxPublished(ctx, id); err != nil </span><span class="cov1" title="1">{
+        if _, err := db.MarkOutboxPublished(ctx, id); err != nil </span><span class="cov8" title="1">{
                 return pgerror.NormalizeError(err)
         }</span>
-        <span class="cov5" title="3">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // MarkFailed は、attempts を加算し last_error を記録し、加算後の attempts を返します。
 // 既に pending でない（並行処理で遷移済み）場合は 0 を返します。
-func (s *store) MarkFailed(ctx context.Context, id int64, lastErr string) (int32, error) <span class="cov5" title="3">{
+func (s *store) MarkFailed(ctx context.Context, id int64, lastErr string) (int32, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
@@ -14290,42 +14281,42 @@ func (s *store) MarkFailed(ctx context.Context, id int64, lastErr string) (int32
                 ID:        id,
                 LastError: &amp;lastErr,
         })
-        if err != nil </span><span class="cov3" title="2">{
-                if xerrors.Is(err, pgx.ErrNoRows) </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
+                if xerrors.Is(err, pgx.ErrNoRows) </span><span class="cov8" title="1">{
                         return 0, nil
                 }</span>
-                <span class="cov1" title="1">return 0, pgerror.NormalizeError(err)</span>
+                <span class="cov8" title="1">return 0, pgerror.NormalizeError(err)</span>
         }
-        <span class="cov1" title="1">return attempts, nil</span>
+        <span class="cov8" title="1">return attempts, nil</span>
 }
 
 // MarkDead は、行を dead へ遷移します（既に pending でなければ no-op）。
-func (s *store) MarkDead(ctx context.Context, id int64) error <span class="cov6" title="4">{
+func (s *store) MarkDead(ctx context.Context, id int64) error <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         db := gen.New(driver.New(ctx, s.db))
-        if _, err := db.MarkOutboxDead(ctx, id); err != nil </span><span class="cov1" title="1">{
+        if _, err := db.MarkOutboxDead(ctx, id); err != nil </span><span class="cov8" title="1">{
                 return pgerror.NormalizeError(err)
         }</span>
-        <span class="cov5" title="3">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // ReplayDead は、dead 行を pending へ戻し、戻した件数を返します（messageID が nil なら全 dead 行）。
-func (s *store) ReplayDead(ctx context.Context, messageID *uuid.UUID) (int64, error) <span class="cov6" title="4">{
+func (s *store) ReplayDead(ctx context.Context, messageID *uuid.UUID) (int64, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         db := gen.New(driver.New(ctx, s.db))
         affected, err := db.ReplayDeadOutbox(ctx, messageID)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return 0, pgerror.NormalizeError(err)
         }</span>
-        <span class="cov5" title="3">return affected, nil</span>
+        <span class="cov8" title="1">return affected, nil</span>
 }
 
 // DeletePublished は、published_at が cutoff より古い行を limit 件まで削除し、削除件数を返します（GC）。
-func (s *store) DeletePublished(ctx context.Context, cutoff time.Time, limit int32) (int64, error) <span class="cov5" title="3">{
+func (s *store) DeletePublished(ctx context.Context, cutoff time.Time, limit int32) (int64, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
@@ -14334,26 +14325,26 @@ func (s *store) DeletePublished(ctx context.Context, cutoff time.Time, limit int
                 PublishedAt: &amp;cutoff,
                 Limit:       limit,
         })
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return 0, pgerror.NormalizeError(err)
         }</span>
-        <span class="cov3" title="2">return affected, nil</span>
+        <span class="cov8" title="1">return affected, nil</span>
 }
 
 // OldestPendingCreatedAt は、最古 pending 行の created_at を返します（SLI=outbox lag 用）。
-func (s *store) OldestPendingCreatedAt(ctx context.Context) (time.Time, bool, error) <span class="cov5" title="3">{
+func (s *store) OldestPendingCreatedAt(ctx context.Context) (time.Time, bool, error) <span class="cov8" title="1">{
         ctx, endSpan := s.tracer.Start(ctx)
         defer endSpan()
 
         db := gen.New(driver.New(ctx, s.db))
         createdAt, err := db.OldestPendingOutbox(ctx)
-        if err != nil </span><span class="cov3" title="2">{
-                if xerrors.Is(err, pgx.ErrNoRows) </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
+                if xerrors.Is(err, pgx.ErrNoRows) </span><span class="cov8" title="1">{
                         return time.Time{}, false, nil
                 }</span>
-                <span class="cov1" title="1">return time.Time{}, false, pgerror.NormalizeError(err)</span>
+                <span class="cov8" title="1">return time.Time{}, false, pgerror.NormalizeError(err)</span>
         }
-        <span class="cov1" title="1">return createdAt, true, nil</span>
+        <span class="cov8" title="1">return createdAt, true, nil</span>
 }
 </pre>
 		
@@ -14398,13 +14389,13 @@ type testTxRunner struct {
 }
 
 // NewTestDB は、テスト用の共有データベースドライバー（シングルトン）を取得します。
-func NewTestDB(t *testing.T) driver.DatabaseDriver <span class="cov8" title="33">{
+func NewTestDB(t *testing.T) driver.DatabaseDriver <span class="cov8" title="1">{
         t.Helper()
         return getTestDB(t)
 }</span>
 
 // NewTestTransactionRunner は、テスト用のトランザクションランナーを生成します。
-func NewTestTransactionRunner(t *testing.T) TransactionRunner <span class="cov7" title="15">{
+func NewTestTransactionRunner(t *testing.T) TransactionRunner <span class="cov8" title="1">{
         t.Helper()
         testLogger := logging.NewTestLogger(t)
 
@@ -14426,7 +14417,7 @@ func NewTestTransactionRunner(t *testing.T) TransactionRunner <span class="cov7"
 //        txm.WithinTx(func(ctx context.Context) {
 //          // トランザクション内の処理
 //        })
-func (t *testTxRunner) WithinTx(fn func(ctx context.Context)) <span class="cov10" title="55">{
+func (t *testTxRunner) WithinTx(fn func(ctx context.Context)) <span class="cov8" title="1">{
         t.t.Helper()
 
         txLock.Lock()
@@ -14434,22 +14425,22 @@ func (t *testTxRunner) WithinTx(fn func(ctx context.Context)) <span class="cov10
 
         baseCtx := context.Background()
 
-        err := t.inner.Do(baseCtx, func(txCtx context.Context) error </span><span class="cov9" title="54">{
+        err := t.inner.Do(baseCtx, func(txCtx context.Context) error </span><span class="cov8" title="1">{
                 fn(txCtx)
                 return errRollbackForTest
         }</span>)
 
-        <span class="cov10" title="55">if xerrors.Is(err, errRollbackForTest) </span><span class="cov9" title="54">{
+        <span class="cov8" title="1">if xerrors.Is(err, errRollbackForTest) </span><span class="cov8" title="1">{
                 return
         }</span>
-        <span class="cov1" title="1">require.NoError(t.t, err)</span>
+        <span class="cov8" title="1">require.NoError(t.t, err)</span>
 }
 
 // getTestDB は、テスト用の共有データベースドライバーを返します（初回呼び出し時のみ生成）。
-func getTestDB(t *testing.T) driver.DatabaseDriver <span class="cov9" title="48">{
+func getTestDB(t *testing.T) driver.DatabaseDriver <span class="cov8" title="1">{
         t.Helper()
 
-        dbOnce.Do(func() </span><span class="cov5" title="8">{
+        dbOnce.Do(func() </span><span class="cov8" title="1">{
                 cfg := config.MockConfigForTest(t)
                 dbCfg := config.NewDatabaseConfig(cfg)
                 osCfg := config.NewOperatingSystemConfig(cfg)
@@ -14458,7 +14449,7 @@ func getTestDB(t *testing.T) driver.DatabaseDriver <span class="cov9" title="48"
                 testDB, errInit = driver.NewDB(dbCfg, osCfg, dbConnCfg)
         }</span>)
 
-        <span class="cov9" title="48">require.NoError(t, errInit)
+        <span class="cov8" title="1">require.NoError(t, errInit)
         require.NotNil(t, testDB)
 
         return testDB</span>
@@ -14482,29 +14473,29 @@ type bcrypter struct {
 }
 
 // NewBcryptHasher は、BcryptHasherを生成します。
-func NewBcryptHasher(secCfg *config.SecurityConfig) security.Hasher <span class="cov10" title="12">{
+func NewBcryptHasher(secCfg *config.SecurityConfig) security.Hasher <span class="cov8" title="1">{
         return &amp;bcrypter{cost: secCfg.BcryptCost()}
 }</span>
 
 // Hash は、パスワードをハッシュ化します。ハッシュ化に失敗した場合はエラーを返します。
-func (b *bcrypter) Hash(password string) (string, error) <span class="cov6" title="4">{
+func (b *bcrypter) Hash(password string) (string, error) <span class="cov8" title="1">{
         hash, err := bcrypt.GenerateFromPassword([]byte(password), b.cost)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return "", xerrors.Join(apperror.ErrInternal, xerrors.Wrap(err, "bcrypt hash failed"))
         }</span>
-        <span class="cov4" title="3">return string(hash), nil</span>
+        <span class="cov8" title="1">return string(hash), nil</span>
 }
 
 // Compare は、ハッシュとパスワードを照合します。一致すれば (true, nil)、不一致であれば (false, nil) を返します。ハッシュ形式不正などの技術的エラー時のみ (false, error) を返します。
-func (b *bcrypter) Compare(hash, password string) (bool, error) <span class="cov4" title="3">{
+func (b *bcrypter) Compare(hash, password string) (bool, error) <span class="cov8" title="1">{
         err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
-        if err != nil </span><span class="cov3" title="2">{
-                if xerrors.Is(err, bcrypt.ErrMismatchedHashAndPassword) </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
+                if xerrors.Is(err, bcrypt.ErrMismatchedHashAndPassword) </span><span class="cov8" title="1">{
                         return false, nil
                 }</span>
-                <span class="cov1" title="1">return false, xerrors.Join(apperror.ErrInternal, xerrors.Wrap(err, "bcrypt compare failed"))</span>
+                <span class="cov8" title="1">return false, xerrors.Join(apperror.ErrInternal, xerrors.Wrap(err, "bcrypt compare failed"))</span>
         }
-        <span class="cov1" title="1">return true, nil</span>
+        <span class="cov8" title="1">return true, nil</span>
 }
 </pre>
 		
@@ -14521,33 +14512,33 @@ import (
 type systemClock struct{}
 
 // NewClock は、clockを生成します。
-func NewClock() clock.Clock <span class="cov6" title="35">{
+func NewClock() clock.Clock <span class="cov8" title="1">{
         return &amp;systemClock{}
 }</span>
 
 // NewSleeper は、clock.Sleeper の実装を生成します。
-func NewSleeper() clock.Sleeper <span class="cov6" title="36">{
+func NewSleeper() clock.Sleeper <span class="cov8" title="1">{
         return &amp;systemClock{}
 }</span>
 
 // Now は、現在の時刻を返します。
-func (sc *systemClock) Now() time.Time <span class="cov10" title="217">{
+func (sc *systemClock) Now() time.Time <span class="cov8" title="1">{
         return time.Now()
 }</span>
 
 // Sleep は、d 経過まで待機します。ctx が先に done になった場合は ctx.Err() を返します。
-func (sc *systemClock) Sleep(ctx context.Context, d time.Duration) error <span class="cov3" title="4">{
-        if d &lt;= 0 </span><span class="cov2" title="2">{
+func (sc *systemClock) Sleep(ctx context.Context, d time.Duration) error <span class="cov8" title="1">{
+        if d &lt;= 0 </span><span class="cov8" title="1">{
                 return ctx.Err()
         }</span>
 
-        <span class="cov2" title="2">timer := time.NewTimer(d)
+        <span class="cov8" title="1">timer := time.NewTimer(d)
         defer timer.Stop()
 
         select </span>{
-        case &lt;-ctx.Done():<span class="cov1" title="1">
+        case &lt;-ctx.Done():<span class="cov8" title="1">
                 return ctx.Err()</span>
-        case &lt;-timer.C:<span class="cov1" title="1">
+        case &lt;-timer.C:<span class="cov8" title="1">
                 return nil</span>
         }
 }
@@ -14559,7 +14550,7 @@ func (sc *systemClock) Sleep(ctx context.Context, d time.Duration) error <span c
 const sampleEndpoint Endpoint = "https://api.exchangerate.example.com"
 
 // NewEndpoint は、サンプル既定値の Endpoint を返します。
-func NewEndpoint() Endpoint <span class="cov10" title="2">{
+func NewEndpoint() Endpoint <span class="cov8" title="1">{
         return sampleEndpoint
 }</span>
 </pre>
@@ -14600,7 +14591,7 @@ type rateResponse struct {
 
 // NewDownstreamProfile は、外部為替サービス向けの resilient プロファイルを返します。
 // 外部サービスのため trace を伝搬せず、private/loopback 宛て接続を拒否します。
-func NewDownstreamProfile() httpclient.DownstreamProfile <span class="cov6" title="3">{
+func NewDownstreamProfile() httpclient.DownstreamProfile <span class="cov8" title="1">{
         p := httpclient.DefaultProfile()
         p.PropagateTrace = false
         p.AllowPrivateNetwork = false
@@ -14612,7 +14603,7 @@ func New(
         endpoint Endpoint,
         client httpclient.Client,
         tf observability.TracerFactory,
-) boundary.Gateway <span class="cov10" title="7">{
+) boundary.Gateway <span class="cov8" title="1">{
         return &amp;gateway{
                 endpoint: endpoint,
                 client:   client,
@@ -14621,7 +14612,7 @@ func New(
 }</span>
 
 // GetRate は、外部 API から為替レートを取得し、境界 DTO へ変換して返します。
-func (g *gateway) GetRate(ctx context.Context, base, quote string) (*boundary.Rate, error) <span class="cov8" title="5">{
+func (g *gateway) GetRate(ctx context.Context, base, quote string) (*boundary.Rate, error) <span class="cov8" title="1">{
         ctx, endSpan := g.tracer.Start(ctx)
         defer endSpan()
 
@@ -14629,19 +14620,19 @@ func (g *gateway) GetRate(ctx context.Context, base, quote string) (*boundary.Ra
                 g.endpoint, url.QueryEscape(base), url.QueryEscape(quote))
 
         resp, err := g.client.Do(ctx, httpclient.NewRequest(httpclient.MethodGet(), downstream, reqURL))
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err // substrate が apperror sentinel へ写像済み
         }</span>
 
-        <span class="cov7" title="4">var body rateResponse
-        if uerr := json.Unmarshal(resp.Body, &amp;body); uerr != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">var body rateResponse
+        if uerr := json.Unmarshal(resp.Body, &amp;body); uerr != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrUnavailable, "invalid exchangerate response: "+uerr.Error())
         }</span>
-        <span class="cov6" title="3">if body.Rate &lt;= 0 </span><span class="cov4" title="2">{
+        <span class="cov8" title="1">if body.Rate &lt;= 0 </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrUnavailable, "exchangerate response has non-positive rate")
         }</span>
 
-        <span class="cov1" title="1">return &amp;boundary.Rate{Base: base, Quote: quote, Value: body.Rate}, nil</span>
+        <span class="cov8" title="1">return &amp;boundary.Rate{Base: base, Quote: quote, Value: body.Rate}, nil</span>
 }
 </pre>
 		
@@ -14687,7 +14678,7 @@ type Field struct {
 }
 
 // String は、文字列のログフィールドを作成します。
-func String(key fieldKey, v string) *Field <span class="cov10" title="5032">{
+func String(key fieldKey, v string) *Field <span class="cov8" title="1">{
         return &amp;Field{
                 key:         string(key),
                 kind:        fieldString,
@@ -14696,7 +14687,7 @@ func String(key fieldKey, v string) *Field <span class="cov10" title="5032">{
 }</span>
 
 // Int は、整数のログフィールドを作成します。
-func Int(key fieldKey, v int) *Field <span class="cov6" title="284">{
+func Int(key fieldKey, v int) *Field <span class="cov8" title="1">{
         return &amp;Field{
                 key:      string(key),
                 kind:     fieldInt,
@@ -14705,7 +14696,7 @@ func Int(key fieldKey, v int) *Field <span class="cov6" title="284">{
 }</span>
 
 // Strings は、文字列のスライスのログフィールドを作成します。
-func Strings(key fieldKey, v []string) *Field <span class="cov8" title="872">{
+func Strings(key fieldKey, v []string) *Field <span class="cov8" title="1">{
         return &amp;Field{
                 key:          string(key),
                 kind:         fieldStrings,
@@ -14714,7 +14705,7 @@ func Strings(key fieldKey, v []string) *Field <span class="cov8" title="872">{
 }</span>
 
 // Int64 は、64ビット整数のログフィールドを作成します。
-func Int64(key fieldKey, v int64) *Field <span class="cov4" title="37">{
+func Int64(key fieldKey, v int64) *Field <span class="cov8" title="1">{
         return &amp;Field{
                 key:        string(key),
                 kind:       fieldInt64,
@@ -14723,7 +14714,7 @@ func Int64(key fieldKey, v int64) *Field <span class="cov4" title="37">{
 }</span>
 
 // Float64 は、64ビット浮動小数点数のログフィールドを作成します。
-func Float64(key fieldKey, v float64) *Field <span class="cov2" title="6">{
+func Float64(key fieldKey, v float64) *Field <span class="cov8" title="1">{
         return &amp;Field{
                 key:          string(key),
                 kind:         fieldFloat64,
@@ -14732,7 +14723,7 @@ func Float64(key fieldKey, v float64) *Field <span class="cov2" title="6">{
 }</span>
 
 // Bool は、真偽値のログフィールドを作成します。
-func Bool(key fieldKey, v bool) *Field <span class="cov1" title="2">{
+func Bool(key fieldKey, v bool) *Field <span class="cov8" title="1">{
         return &amp;Field{
                 key:       string(key),
                 kind:      fieldBool,
@@ -14741,7 +14732,7 @@ func Bool(key fieldKey, v bool) *Field <span class="cov1" title="2">{
 }</span>
 
 // Time は、時間のログフィールドを作成します。
-func Time(key fieldKey, v time.Time) *Field <span class="cov5" title="67">{
+func Time(key fieldKey, v time.Time) *Field <span class="cov8" title="1">{
         return &amp;Field{
                 key:         string(key),
                 kind:        fieldString,
@@ -14750,7 +14741,7 @@ func Time(key fieldKey, v time.Time) *Field <span class="cov5" title="67">{
 }</span>
 
 // DurationMs は、時間間隔のログフィールドをミリ秒単位で作成します。
-func DurationMs(key fieldKey, v time.Duration) *Field <span class="cov4" title="36">{
+func DurationMs(key fieldKey, v time.Duration) *Field <span class="cov8" title="1">{
         return &amp;Field{
                 key:          string(key),
                 kind:         fieldFloat64,
@@ -14759,7 +14750,7 @@ func DurationMs(key fieldKey, v time.Duration) *Field <span class="cov4" title="
 }</span>
 
 // Error は、エラーのログフィールドを作成します。
-func Error(key fieldKey, err error) *Field <span class="cov7" title="298">{
+func Error(key fieldKey, err error) *Field <span class="cov8" title="1">{
         return &amp;Field{
                 key:        string(key),
                 kind:       fieldError,
@@ -14770,7 +14761,7 @@ func Error(key fieldKey, err error) *Field <span class="cov7" title="298">{
 // Stacktrace は、エラースタックトレースのログフィールドを作成します。
 // JSON ビューア（Grafana / Loki 等）で改行が可読に表示されるよう、
 // 単一文字列ではなく行ごとに分割した []string を保持します。
-func Stacktrace(key fieldKey, err error) *Field <span class="cov3" title="14">{
+func Stacktrace(key fieldKey, err error) *Field <span class="cov8" title="1">{
         return &amp;Field{
                 key:          string(key),
                 kind:         fieldStrings,
@@ -14783,20 +14774,20 @@ func Stacktrace(key fieldKey, err error) *Field <span class="cov3" title="14">{
 // 配列化により行境界とネスト深さが構造として表現されるため、cockroachdb/errors の
 // `%+v` が各行頭に付与するガター（`  | ` の空白・パイプや `\t&lt;file&gt;:&lt;line&gt;` の先頭タブ）は
 // 冗長になる。各行頭の空白・`|`・タブをまとめて除去し、内容だけを残す。
-func SplitStackLines(s string) []string <span class="cov4" title="27">{
+func SplitStackLines(s string) []string <span class="cov8" title="1">{
         trimmed := strings.TrimRight(s, "\n")
-        if trimmed == "" </span><span class="cov1" title="2">{
+        if trimmed == "" </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov4" title="25">lines := strings.Split(trimmed, "\n")
-        for i, line := range lines </span><span class="cov7" title="602">{
+        <span class="cov8" title="1">lines := strings.Split(trimmed, "\n")
+        for i, line := range lines </span><span class="cov8" title="1">{
                 lines[i] = strings.TrimLeft(line, " |\t")
         }</span>
-        <span class="cov4" title="25">return lines</span>
+        <span class="cov8" title="1">return lines</span>
 }
 
 // Any は、任意の型のログフィールドを作成します。
-func Any(key fieldKey, v any) *Field <span class="cov5" title="59">{
+func Any(key fieldKey, v any) *Field <span class="cov8" title="1">{
         return &amp;Field{
                 key:      string(key),
                 kind:     fieldAny,
@@ -14805,7 +14796,7 @@ func Any(key fieldKey, v any) *Field <span class="cov5" title="59">{
 }</span>
 
 // latencyMs は、latency をミリ秒単位の float64 に変換します。
-func latencyMs(latency time.Duration) float64 <span class="cov4" title="37">{
+func latencyMs(latency time.Duration) float64 <span class="cov8" title="1">{
         return float64(latency) / float64(time.Millisecond)
 }</span>
 </pre>
@@ -14897,7 +14888,7 @@ type SQLFieldsEndInput struct {
 func NewLogFields(
         obsCfg *config.ObservabilityConfig,
         osCfg *config.OperatingSystemConfig,
-) LogFieldBuilder <span class="cov10" title="62">{
+) LogFieldBuilder <span class="cov8" title="1">{
         return &amp;logFieldBuilder{
                 obsCfg: obsCfg,
                 osCfg:  osCfg,
@@ -14905,7 +14896,7 @@ func NewLogFields(
 }</span>
 
 // BuildHTTPRequestFields は、HTTPリクエストの情報を含むFieldのスライスを生成します。
-func (l *logFieldBuilder) BuildHTTPRequestFields(req HTTPRequestLogInput) []*Field <span class="cov8" title="26">{
+func (l *logFieldBuilder) BuildHTTPRequestFields(req HTTPRequestLogInput) []*Field <span class="cov8" title="1">{
         fields := append(l.buildEventHeader(req.EventType, req.EventAt),
                 String(MethodKey, req.Method),
                 String(PathKey, req.Path),
@@ -14927,7 +14918,7 @@ func (l *logFieldBuilder) BuildHTTPRequestFields(req HTTPRequestLogInput) []*Fie
 }</span>
 
 // BuildHTTPResponseFields は、HTTPレスポンスの情報を含むFieldのスライスを生成します。
-func (l *logFieldBuilder) BuildHTTPResponseFields(resp HTTPResponseLogInput) []*Field <span class="cov4" title="6">{
+func (l *logFieldBuilder) BuildHTTPResponseFields(resp HTTPResponseLogInput) []*Field <span class="cov8" title="1">{
         fields := append(l.buildEventHeader(EventTypeEnd, resp.EventAt),
                 DurationMs(LatencyKey, resp.Latency),
 
@@ -14943,7 +14934,7 @@ func (l *logFieldBuilder) BuildHTTPResponseFields(resp HTTPResponseLogInput) []*
 }</span>
 
 // BuildSQLEndFields は、SQLの終了時点のログ出力用の Field スライスを構築します。
-func (l *logFieldBuilder) BuildSQLEndFields(sql SQLFieldsEndInput) []*Field <span class="cov6" title="14">{
+func (l *logFieldBuilder) BuildSQLEndFields(sql SQLFieldsEndInput) []*Field <span class="cov8" title="1">{
         compact := l.buildCompactQuery(sql.Query)
 
         fields := append(l.buildEventHeader(EventTypeEnd, sql.EventAt),
@@ -14956,22 +14947,22 @@ func (l *logFieldBuilder) BuildSQLEndFields(sql SQLFieldsEndInput) []*Field <spa
                 DurationMs(LatencyKey, sql.Latency),
         )
 
-        if len(sql.Args) &gt; 0 </span><span class="cov4" title="4">{
+        if len(sql.Args) &gt; 0 </span><span class="cov8" title="1">{
                 fields = append(fields,
                         Int(QueryArgsCountKey, len(sql.Args)),
                 )
         }</span>
 
-        <span class="cov6" title="14">if sql.Err != nil </span><span class="cov4" title="5">{
+        <span class="cov8" title="1">if sql.Err != nil </span><span class="cov8" title="1">{
                 fields = append(fields, Error(InternalErrorKey, sql.Err))
         }</span>
 
-        <span class="cov6" title="14">return l.appendTraceSpanFields(fields, sql.TraceID, sql.SpanID, sql.ParentSpanID)</span>
+        <span class="cov8" title="1">return l.appendTraceSpanFields(fields, sql.TraceID, sql.SpanID, sql.ParentSpanID)</span>
 }
 
 // buildEventHeader は、全イベントログ共通の先頭フィールド
 // （イベント種別・発生時刻・タイムゾーン）を構築する。
-func (l *logFieldBuilder) buildEventHeader(eventType string, at time.Time) []*Field <span class="cov9" title="46">{
+func (l *logFieldBuilder) buildEventHeader(eventType string, at time.Time) []*Field <span class="cov8" title="1">{
         return []*Field{
                 String(EventTypeKey, eventType),
                 Time(EventAtKey, at),
@@ -14985,32 +14976,32 @@ func (l *logFieldBuilder) appendTraceSpanFields(
         traceID string,
         spanID string,
         parentSpanID string,
-) []*Field <span class="cov9" title="53">{
-        if !l.obsCfg.Enabled() || traceID == "" || spanID == "" </span><span class="cov9" title="40">{
+) []*Field <span class="cov8" title="1">{
+        if !l.obsCfg.Enabled() || traceID == "" || spanID == "" </span><span class="cov8" title="1">{
                 return fields
         }</span>
 
-        <span class="cov6" title="13">fields = append(fields,
+        <span class="cov8" title="1">fields = append(fields,
                 String(TraceIDKey, traceID),
                 String(SpanIDKey, spanID),
         )
 
-        if parentSpanID == "" </span><span class="cov6" title="11">{
+        if parentSpanID == "" </span><span class="cov8" title="1">{
                 return fields
         }</span>
 
-        <span class="cov2" title="2">return append(fields,
+        <span class="cov8" title="1">return append(fields,
                 String(ParentSpanIDKey, parentSpanID),
         )</span>
 }
 
 // buildCompactQuery は、SQL クエリを1行の短縮表現に変換します。
-func (*logFieldBuilder) buildCompactQuery(q string) string <span class="cov7" title="16">{
-        if q == "" </span><span class="cov1" title="1">{
+func (*logFieldBuilder) buildCompactQuery(q string) string <span class="cov8" title="1">{
+        if q == "" </span><span class="cov8" title="1">{
                 return ""
         }</span>
 
-        <span class="cov6" title="15">s := strings.ReplaceAll(q, "\n", " ")
+        <span class="cov8" title="1">s := strings.ReplaceAll(q, "\n", " ")
         s = strings.ReplaceAll(s, "\t", " ")
 
         s = strings.Join(strings.Fields(s), " ")
@@ -15036,30 +15027,30 @@ type Level struct {
 }
 
 // LevelDebug は Debug レベルを返します。
-func LevelDebug() Level <span class="cov9" title="24">{ return Level{zapcore.DebugLevel} }</span>
+func LevelDebug() Level <span class="cov8" title="1">{ return Level{zapcore.DebugLevel} }</span>
 
 // LevelInfo は Info レベルを返します。
-func LevelInfo() Level <span class="cov5" title="6">{ return Level{zapcore.InfoLevel} }</span>
+func LevelInfo() Level <span class="cov8" title="1">{ return Level{zapcore.InfoLevel} }</span>
 
 // LevelWarn は Warn レベルを返します。
-func LevelWarn() Level <span class="cov9" title="20">{ return Level{zapcore.WarnLevel} }</span>
+func LevelWarn() Level <span class="cov8" title="1">{ return Level{zapcore.WarnLevel} }</span>
 
 // LevelError は Error レベルを返します。
-func LevelError() Level <span class="cov6" title="9">{ return Level{zapcore.ErrorLevel} }</span>
+func LevelError() Level <span class="cov8" title="1">{ return Level{zapcore.ErrorLevel} }</span>
 
 // ParseLevel は、APP_LOG_LEVEL が受理するレベル文字列を Level に変換します。
 // 受理しない文字列の場合はエラーを返します。
-func ParseLevel(s string) (Level, error) <span class="cov10" title="28">{
+func ParseLevel(s string) (Level, error) <span class="cov8" title="1">{
         switch s </span>{
-        case config.LogLevelDebug:<span class="cov8" title="19">
+        case config.LogLevelDebug:<span class="cov8" title="1">
                 return LevelDebug(), nil</span>
-        case config.LogLevelInfo:<span class="cov3" title="3">
+        case config.LogLevelInfo:<span class="cov8" title="1">
                 return LevelInfo(), nil</span>
-        case config.LogLevelWarn:<span class="cov1" title="1">
+        case config.LogLevelWarn:<span class="cov8" title="1">
                 return LevelWarn(), nil</span>
-        case config.LogLevelError:<span class="cov1" title="1">
+        case config.LogLevelError:<span class="cov8" title="1">
                 return LevelError(), nil</span>
-        default:<span class="cov4" title="4">
+        default:<span class="cov8" title="1">
                 return Level{}, xerrors.New(fmt.Sprintf("unsupported log level: %q", s))</span>
         }
 }
@@ -15107,107 +15098,107 @@ type levelGatedCore struct {
 
 // WithCore は、既存 Logger に追加のログ core を、元 Logger と同じ最小レベルでゲートして
 // Tee した新しい Logger を返します。core が nil の場合は、元の Logger をそのまま返します。
-func WithCore(l Logger, core LogCore) Logger <span class="cov4" title="24">{
-        if core == nil </span><span class="cov4" title="20">{
+func WithCore(l Logger, core LogCore) Logger <span class="cov8" title="1">{
+        if core == nil </span><span class="cov8" title="1">{
                 return l
         }</span>
         // 本パッケージの具象 *logger だけが zap core を内包するため、Tee 対象も *logger に限定する。
         // それ以外の Logger 実装（テスト用 fake 等）は core を持たないので、ゲートできず素通しする。
-        <span class="cov2" title="4">base, ok := l.(*logger)
-        if !ok </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">base, ok := l.(*logger)
+        if !ok </span><span class="cov8" title="1">{
                 return l
         }</span>
-        <span class="cov2" title="3">gated := levelGatedCore{Core: core, min: base.log.Level()}
+        <span class="cov8" title="1">gated := levelGatedCore{Core: core, min: base.log.Level()}
 
         return &amp;logger{
-                log: base.log.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core </span><span class="cov2" title="3">{
+                log: base.log.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core </span><span class="cov8" title="1">{
                         return zapcore.NewTee(c, gated)
                 }</span>)),
         }
 }
 
 // Enabled は、min 以上かつ埋め込み core が有効なレベルのみ true を返します。
-func (c levelGatedCore) Enabled(level zapcore.Level) bool <span class="cov3" title="7">{
+func (c levelGatedCore) Enabled(level zapcore.Level) bool <span class="cov8" title="1">{
         return level &gt;= c.min &amp;&amp; c.Core.Enabled(level)
 }</span>
 
 // Check は、レベルが有効なときのみ自身を CheckedEntry に追加します。
-func (c levelGatedCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry <span class="cov2" title="4">{
-        if c.Enabled(ent.Level) </span><span class="cov2" title="3">{
+func (c levelGatedCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry <span class="cov8" title="1">{
+        if c.Enabled(ent.Level) </span><span class="cov8" title="1">{
                 return ce.AddCore(ent, c)
         }</span>
-        <span class="cov1" title="1">return ce</span>
+        <span class="cov8" title="1">return ce</span>
 }
 
 // With は、フィールドを付与しつつゲートを維持した core を返します。
-func (c levelGatedCore) With(fields []zapcore.Field) zapcore.Core <span class="cov1" title="1">{
+func (c levelGatedCore) With(fields []zapcore.Field) zapcore.Core <span class="cov8" title="1">{
         return levelGatedCore{Core: c.Core.With(fields), min: c.min}
 }</span>
 
 // Named は、新しい名前付きの Logger を返す。
-func (l *logger) Named(name string) Logger <span class="cov7" title="440">{
+func (l *logger) Named(name string) Logger <span class="cov8" title="1">{
         return &amp;logger{
                 log: l.log.Named(name),
         }
 }</span>
 
 // CallerSkip は、コールスタックのスキップ数を設定した新しいLoggerを返す。
-func (l *logger) CallerSkip(skip int) Logger <span class="cov5" title="87">{
+func (l *logger) CallerSkip(skip int) Logger <span class="cov8" title="1">{
         return &amp;logger{
                 log: l.log.WithOptions(zap.AddCallerSkip(skip)),
         }
 }</span>
 
 // Debug はデバッグレベルのログを出力する。
-func (l *logger) Debug(msg string, fields ...*Field) <span class="cov8" title="981">{
+func (l *logger) Debug(msg string, fields ...*Field) <span class="cov8" title="1">{
         l.log.Debug(msg, l.convertFields(fields)...)
 }</span>
 
 // Info は情報レベルのログを出力する。
-func (l *logger) Info(msg string, fields ...*Field) <span class="cov6" title="147">{
+func (l *logger) Info(msg string, fields ...*Field) <span class="cov8" title="1">{
         l.log.Info(msg, l.convertFields(fields)...)
 }</span>
 
 // Warn は警告レベルのログを出力する。
-func (l *logger) Warn(msg string, fields ...*Field) <span class="cov6" title="183">{
+func (l *logger) Warn(msg string, fields ...*Field) <span class="cov8" title="1">{
         l.log.Warn(msg, l.convertFields(fields)...)
 }</span>
 
 // Error はエラーレベルのログを出力する。
-func (l *logger) Error(msg string, fields ...*Field) <span class="cov6" title="117">{
+func (l *logger) Error(msg string, fields ...*Field) <span class="cov8" title="1">{
         l.log.Error(msg, l.convertFields(fields)...)
 }</span>
 
 // convertFields は Field のスライスを zap.Field のスライスに変換する。
-func (l *logger) convertFields(fs []*Field) []zap.Field <span class="cov8" title="1430">{
+func (l *logger) convertFields(fs []*Field) []zap.Field <span class="cov8" title="1">{
         zfs := make([]zap.Field, 0, len(fs))
 
-        for _, f := range fs </span><span class="cov10" title="4326">{
+        for _, f := range fs </span><span class="cov8" title="1">{
                 switch f.kind </span>{
-                case fieldString:<span class="cov9" title="2867">
+                case fieldString:<span class="cov8" title="1">
                         zfs = append(zfs, zap.String(f.key, f.stringValue))</span>
-                case fieldStrings:<span class="cov8" title="873">
+                case fieldStrings:<span class="cov8" title="1">
                         zfs = append(zfs, zap.Strings(f.key, f.stringsValue))</span>
-                case fieldInt:<span class="cov7" title="267">
+                case fieldInt:<span class="cov8" title="1">
                         zfs = append(zfs, zap.Int(f.key, f.intValue))</span>
-                case fieldInt64:<span class="cov4" title="28">
+                case fieldInt64:<span class="cov8" title="1">
                         zfs = append(zfs, zap.Int64(f.key, f.int64Value))</span>
-                case fieldFloat64:<span class="cov4" title="20">
+                case fieldFloat64:<span class="cov8" title="1">
                         zfs = append(zfs, zap.Float64(f.key, f.float64Value))</span>
-                case fieldBool:<span class="cov1" title="1">
+                case fieldBool:<span class="cov8" title="1">
                         zfs = append(zfs, zap.Bool(f.key, f.boolValue))</span>
-                case fieldError:<span class="cov6" title="228">
+                case fieldError:<span class="cov8" title="1">
                         zfs = append(zfs, zap.NamedError(f.key, f.errorValue))</span>
-                case fieldAny:<span class="cov4" title="41">
+                case fieldAny:<span class="cov8" title="1">
                         zfs = append(zfs, zap.Any(f.key, f.anyValue))</span>
-                default:<span class="cov1" title="1">
+                default:<span class="cov8" title="1">
                         // fieldUnknown（ゼロ値）や将来追加され case 漏れした kind が
                         // 到達する位置。バグ検知の余地を残しつつ zap.Any で安全に出力する。
                         zfs = append(zfs, zap.Any(f.key, f.anyValue))</span>
                 }
         }
 
-        <span class="cov8" title="1430">return zfs</span>
+        <span class="cov8" title="1">return zfs</span>
 }
 </pre>
 		
@@ -15230,17 +15221,17 @@ var (
 )
 
 // mustOpenSink は path の WriteSyncer を返します。開けない場合は panic します。
-func mustOpenSink(path string) zapcore.WriteSyncer <span class="cov10" title="128">{
+func mustOpenSink(path string) zapcore.WriteSyncer <span class="cov8" title="1">{
         ws, _, err := zap.Open(path)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 panic("logging: failed to open sink " + path + ": " + err.Error())</span>
         }
-        <span class="cov9" title="127">return ws</span>
+        <span class="cov8" title="1">return ws</span>
 }
 
 // encoderConfig は JSON / console 共通のエンコーダ設定を返します。
 // encodeLevel は呼び出し側が指定します。
-func encoderConfig(encodeLevel zapcore.LevelEncoder) zapcore.EncoderConfig <span class="cov7" title="29">{
+func encoderConfig(encodeLevel zapcore.LevelEncoder) zapcore.EncoderConfig <span class="cov8" title="1">{
         return zapcore.EncoderConfig{
                 TimeKey:       "ts",
                 LevelKey:      "level",
@@ -15258,14 +15249,14 @@ func encoderConfig(encodeLevel zapcore.LevelEncoder) zapcore.EncoderConfig <span
 
 // NewJSONLogger は JSON 構造化ロガーを生成します。
 // level は出力レベル、stacktraceLevel は stacktrace を付与し始めるレベルです。
-func NewJSONLogger(level, stacktraceLevel Level) Logger <span class="cov3" title="3">{
+func NewJSONLogger(level, stacktraceLevel Level) Logger <span class="cov8" title="1">{
         enc := zapcore.NewJSONEncoder(encoderConfig(zapcore.LowercaseLevelEncoder))
         return buildLogger(enc, stdoutSyncer, level.zl, stacktraceLevel.zl, true)
 }</span>
 
 // NewConsoleLogger は人間可読な console ロガーを生成します。
 // level は出力レベル、stacktraceLevel は stacktrace を付与し始めるレベルです。
-func NewConsoleLogger(level, stacktraceLevel Level) Logger <span class="cov6" title="22">{
+func NewConsoleLogger(level, stacktraceLevel Level) Logger <span class="cov8" title="1">{
         enc := zapcore.NewConsoleEncoder(encoderConfig(zapcore.CapitalColorLevelEncoder))
         return buildLogger(enc, stdoutSyncer, level.zl, stacktraceLevel.zl, false)
 }</span>
@@ -15274,12 +15265,12 @@ func NewConsoleLogger(level, stacktraceLevel Level) Logger <span class="cov6" ti
 // jsonArrayStacktrace=true のとき、stacktrace を行配列として出力します。
 func buildLogger(
         enc zapcore.Encoder, ws zapcore.WriteSyncer, level, stacktraceLevel zapcore.Level, jsonArrayStacktrace bool,
-) Logger <span class="cov7" title="29">{
+) Logger <span class="cov8" title="1">{
         core := zapcore.NewCore(enc, ws, zap.NewAtomicLevelAt(level))
-        if jsonArrayStacktrace </span><span class="cov4" title="6">{
+        if jsonArrayStacktrace </span><span class="cov8" title="1">{
                 core = wrapStacktraceCore(core, stacktraceKey)
         }</span>
-        <span class="cov7" title="29">zl := zap.New(core,
+        <span class="cov8" title="1">zl := zap.New(core,
                 zap.AddCaller(),
                 zap.AddStacktrace(stacktraceLevel),
                 zap.ErrorOutput(stderrSyncer),
@@ -15314,31 +15305,31 @@ type stacktraceArrayCore struct {
 
 // wrapStacktraceCore は、与えられた Core を stacktraceArrayCore でラップします。
 // key は出力先キー名（EncoderConfig.StacktraceKey と一致させる）。
-func wrapStacktraceCore(core zapcore.Core, key string) zapcore.Core <span class="cov10" title="11">{
+func wrapStacktraceCore(core zapcore.Core, key string) zapcore.Core <span class="cov8" title="1">{
         return &amp;stacktraceArrayCore{Core: core, key: key}
 }</span>
 
 // With は内側 Core の With を伝播しつつ、自身のラップ属性を維持します。
-func (c *stacktraceArrayCore) With(fs []zapcore.Field) zapcore.Core <span class="cov1" title="1">{
+func (c *stacktraceArrayCore) With(fs []zapcore.Field) zapcore.Core <span class="cov8" title="1">{
         return &amp;stacktraceArrayCore{Core: c.Core.With(fs), key: c.key}
 }</span>
 
 // Check は、レベルが有効な場合に自身を CheckedEntry に登録します。
-func (c *stacktraceArrayCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry <span class="cov8" title="7">{
-        if c.Enabled(ent.Level) </span><span class="cov7" title="6">{
+func (c *stacktraceArrayCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry <span class="cov8" title="1">{
+        if c.Enabled(ent.Level) </span><span class="cov8" title="1">{
                 return ce.AddCore(ent, c)
         }</span>
-        <span class="cov1" title="1">return ce</span>
+        <span class="cov8" title="1">return ce</span>
 }
 
 // Write は、Entry.Stack を行配列に変換した zap.Strings フィールドへ差し替えます。
 // 元の Entry.Stack はクリアして、エンコーダが二重に文字列出力するのを防ぎます。
-func (c *stacktraceArrayCore) Write(ent zapcore.Entry, fs []zapcore.Field) error <span class="cov7" title="6">{
-        if ent.Stack != "" </span><span class="cov3" title="2">{
+func (c *stacktraceArrayCore) Write(ent zapcore.Entry, fs []zapcore.Field) error <span class="cov8" title="1">{
+        if ent.Stack != "" </span><span class="cov8" title="1">{
                 fs = append(fs, zap.Strings(c.key, SplitStackLines(ent.Stack)))
                 ent.Stack = ""
         }</span>
-        <span class="cov7" title="6">return c.Core.Write(ent, fs)</span>
+        <span class="cov8" title="1">return c.Core.Write(ent, fs)</span>
 }
 </pre>
 		
@@ -15356,14 +15347,14 @@ import (
 )
 
 // NewTestLogger は、テスト用のLoggerインスタンスを生成します。
-func NewTestLogger(t *testing.T) Logger <span class="cov10" title="215">{
+func NewTestLogger(t *testing.T) Logger <span class="cov8" title="1">{
         t.Helper()
         return &amp;logger{log: zaptest.NewLogger(t)}
 }</span>
 
 // NewObservedTestLogger は、出力を捕捉できるテスト用 Logger と観測ログを返します。
 // ログレベル・出力有無を検証したいテストで使用します。
-func NewObservedTestLogger(t *testing.T) (Logger, *observer.ObservedLogs) <span class="cov7" title="53">{
+func NewObservedTestLogger(t *testing.T) (Logger, *observer.ObservedLogs) <span class="cov8" title="1">{
         t.Helper()
         core, observed := observer.New(zapcore.DebugLevel)
         return &amp;logger{log: zap.New(core)}, observed
@@ -15371,14 +15362,14 @@ func NewObservedTestLogger(t *testing.T) (Logger, *observer.ObservedLogs) <span 
 
 // NewObservedTestLoggerWithCaller は、caller 情報付きで出力を捕捉できるテスト用 Logger と観測ログを返します。
 // caller（発生源）を検証したいテストで使用します。
-func NewObservedTestLoggerWithCaller(t *testing.T) (Logger, *observer.ObservedLogs) <span class="cov1" title="1">{
+func NewObservedTestLoggerWithCaller(t *testing.T) (Logger, *observer.ObservedLogs) <span class="cov8" title="1">{
         t.Helper()
         core, observed := observer.New(zapcore.DebugLevel)
         return &amp;logger{log: zap.New(core, zap.AddCaller())}, observed
 }</span>
 
 // NewTestLogFieldBuilder は、テスト用のLogFieldBuilderインスタンスを生成します。
-func NewTestLogFieldBuilder(t *testing.T) LogFieldBuilder <span class="cov7" title="41">{
+func NewTestLogFieldBuilder(t *testing.T) LogFieldBuilder <span class="cov8" title="1">{
         t.Helper()
 
         cfg := config.MockConfigForTest(t)
@@ -15397,16 +15388,16 @@ import "runtime"
 const skipCallerFramesForLayerTracer = 2
 
 // getCallerFullName は、本関数の直接呼び出し元のフル関数名を返す（取得失敗時は空文字）。
-func getCallerFullName() string <span class="cov10" title="909">{
+func getCallerFullName() string <span class="cov8" title="1">{
         pc, _, _, ok := runtime.Caller(skipCallerFramesForLayerTracer)
         if !ok </span><span class="cov0" title="0">{
                 return ""
         }</span>
-        <span class="cov10" title="909">fn := runtime.FuncForPC(pc)
+        <span class="cov8" title="1">fn := runtime.FuncForPC(pc)
         if fn == nil </span><span class="cov0" title="0">{
                 return ""
         }</span>
-        <span class="cov10" title="909">return fn.Name()</span>
+        <span class="cov8" title="1">return fn.Name()</span>
 }
 </pre>
 		
@@ -15428,22 +15419,22 @@ type TraceContext struct {
 }
 
 // ShouldLogWithSpan は、o11y モードが有効かつ ctx にアクティブな Span が存在するとき true を返す。span 付きログを出す前提条件チェックに使う。
-func ShouldLogWithSpan(ctx context.Context, obsCfg *config.ObservabilityConfig) bool <span class="cov2" title="4">{
+func ShouldLogWithSpan(ctx context.Context, obsCfg *config.ObservabilityConfig) bool <span class="cov8" title="1">{
         return obsCfg.Enabled() &amp;&amp; trace.SpanFromContext(ctx).SpanContext().IsValid()
 }</span>
 
 // BuildSpanName は、レイヤー名、パッケージ名、関数名からスパン名を構築します。
-func BuildSpanName(layer, pkgName, funcName string) string <span class="cov10" title="567">{
+func BuildSpanName(layer, pkgName, funcName string) string <span class="cov8" title="1">{
         return layer + delimiter + pkgName + delimiter + funcName
 }</span>
 
 // ExtractTraceContext は、現在の span から traceID/spanID を抽出して返します（parentSpanID は設定しません）。
-func ExtractTraceContext(ctx context.Context) *TraceContext <span class="cov8" title="253">{
+func ExtractTraceContext(ctx context.Context) *TraceContext <span class="cov8" title="1">{
         span := trace.SpanFromContext(ctx)
-        if !span.SpanContext().IsValid() </span><span class="cov8" title="236">{
+        if !span.SpanContext().IsValid() </span><span class="cov8" title="1">{
                 return &amp;TraceContext{}
         }</span>
-        <span class="cov5" title="17">spanCtx := span.SpanContext()
+        <span class="cov8" title="1">spanCtx := span.SpanContext()
         return &amp;TraceContext{
                 traceID: spanCtx.TraceID().String(),
                 spanID:  spanCtx.SpanID().String(),
@@ -15456,7 +15447,7 @@ func StartSpanWithParent(
         tracer LayerTracer,
         name string,
         opts ...trace.SpanStartOption,
-) (*TraceContext, context.Context, func()) <span class="cov9" title="566">{
+) (*TraceContext, context.Context, func()) <span class="cov8" title="1">{
         parentSC := trace.SpanFromContext(ctx).SpanContext()
 
         childCtx, span := tracer.tracer.Start(ctx, name, opts...)
@@ -15467,26 +15458,26 @@ func StartSpanWithParent(
                 spanID:  childSC.SpanID().String(),
         }
 
-        if parentSC.IsValid() </span><span class="cov2" title="4">{
+        if parentSC.IsValid() </span><span class="cov8" title="1">{
                 tc.parentSpanID = parentSC.SpanID().String()
         }</span>
 
-        <span class="cov9" title="566">end := func() </span><span class="cov9" title="566">{ span.End() }</span>
-        <span class="cov9" title="566">return tc, childCtx, end</span>
+        <span class="cov8" title="1">end := func() </span><span class="cov8" title="1">{ span.End() }</span>
+        <span class="cov8" title="1">return tc, childCtx, end</span>
 }
 
 // TraceID は、TraceContext から TraceID を取得します。
-func (tc *TraceContext) TraceID() string <span class="cov8" title="253">{
+func (tc *TraceContext) TraceID() string <span class="cov8" title="1">{
         return tc.traceID
 }</span>
 
 // SpanID は、TraceContext から SpanID を取得します。
-func (tc *TraceContext) SpanID() string <span class="cov6" title="49">{
+func (tc *TraceContext) SpanID() string <span class="cov8" title="1">{
         return tc.spanID
 }</span>
 
 // ParentSpanID は、TraceContext から ParentSpanID を取得します。
-func (tc *TraceContext) ParentSpanID() string <span class="cov1" title="2">{
+func (tc *TraceContext) ParentSpanID() string <span class="cov8" title="1">{
         return tc.parentSpanID
 }</span>
 </pre>
@@ -15518,7 +15509,7 @@ type HTTPClientMetrics struct {
 
 // NewHTTPClientMetrics は、注入された MeterProvider から substrate の計装一式を生成します。
 // いずれかの計装生成失敗で error を返します。
-func NewHTTPClientMetrics(mp metric.MeterProvider) (*HTTPClientMetrics, error) <span class="cov8" title="38">{
+func NewHTTPClientMetrics(mp metric.MeterProvider) (*HTTPClientMetrics, error) <span class="cov8" title="1">{
         b := &amp;meterBuilder{m: mp.Meter(httpClientMeterName)}
         hm := &amp;HTTPClientMetrics{
                 requests:     b.counter("httpclient.requests", "完了した外部 HTTP リクエスト数(ステータスクラス別)"),
@@ -15528,14 +15519,14 @@ func NewHTTPClientMetrics(mp metric.MeterProvider) (*HTTPClientMetrics, error) <
                 inFlight:     b.upDownCounter("httpclient.in_flight", "処理中(送信済み・未完了)のリクエスト数"),
                 breakerState: b.gauge("httpclient.breaker_state", "circuit breaker の状態(0:closed 1:half-open 2:open)"),
         }
-        if b.err != nil </span><span class="cov1" title="1">{
+        if b.err != nil </span><span class="cov8" title="1">{
                 return nil, b.err
         }</span>
-        <span class="cov8" title="37">return hm, nil</span>
+        <span class="cov8" title="1">return hm, nil</span>
 }
 
 // RecordRequest は、完了したリクエストを Downstream とステータスクラス別に計上します。
-func (m *HTTPClientMetrics) RecordRequest(ctx context.Context, downstream, statusClass string) <span class="cov7" title="23">{
+func (m *HTTPClientMetrics) RecordRequest(ctx context.Context, downstream, statusClass string) <span class="cov8" title="1">{
         m.requests.Add(ctx, 1, metric.WithAttributes(
                 attribute.String("downstream", downstream),
                 attribute.String("status_class", statusClass),
@@ -15543,7 +15534,7 @@ func (m *HTTPClientMetrics) RecordRequest(ctx context.Context, downstream, statu
 }</span>
 
 // RecordError は、失敗したリクエストを Downstream と理由別に計上します。
-func (m *HTTPClientMetrics) RecordError(ctx context.Context, downstream, reason string) <span class="cov8" title="28">{
+func (m *HTTPClientMetrics) RecordError(ctx context.Context, downstream, reason string) <span class="cov8" title="1">{
         m.errors.Add(ctx, 1, metric.WithAttributes(
                 attribute.String("downstream", downstream),
                 attribute.String("reason", reason),
@@ -15551,35 +15542,35 @@ func (m *HTTPClientMetrics) RecordError(ctx context.Context, downstream, reason 
 }</span>
 
 // RecordRetry は、リトライ回数を Downstream 別に計上します。
-func (m *HTTPClientMetrics) RecordRetry(ctx context.Context, downstream string) <span class="cov8" title="25">{
+func (m *HTTPClientMetrics) RecordRetry(ctx context.Context, downstream string) <span class="cov8" title="1">{
         m.retries.Add(ctx, 1, metric.WithAttributes(attribute.String("downstream", downstream)))
 }</span>
 
 // RecordLatencyMs は、リクエスト全体の所要時間(ミリ秒)を Downstream 別に記録します。
-func (m *HTTPClientMetrics) RecordLatencyMs(ctx context.Context, downstream string, ms float64) <span class="cov8" title="31">{
+func (m *HTTPClientMetrics) RecordLatencyMs(ctx context.Context, downstream string, ms float64) <span class="cov8" title="1">{
         m.latencyMs.Record(ctx, ms, metric.WithAttributes(attribute.String("downstream", downstream)))
 }</span>
 
 // InFlightAdd は、処理中のリクエスト数を Downstream 別に増減します。
-func (m *HTTPClientMetrics) InFlightAdd(ctx context.Context, downstream string, delta int64) <span class="cov10" title="62">{
+func (m *HTTPClientMetrics) InFlightAdd(ctx context.Context, downstream string, delta int64) <span class="cov8" title="1">{
         m.inFlight.Add(ctx, delta, metric.WithAttributes(attribute.String("downstream", downstream)))
 }</span>
 
 // SetBreakerState は、circuit breaker の状態を Downstream 別に記録します（0:closed 1:half-open 2:open）。
-func (m *HTTPClientMetrics) SetBreakerState(ctx context.Context, downstream string, state int64) <span class="cov8" title="31">{
+func (m *HTTPClientMetrics) SetBreakerState(ctx context.Context, downstream string, state int64) <span class="cov8" title="1">{
         m.breakerState.Record(ctx, state, metric.WithAttributes(attribute.String("downstream", downstream)))
 }</span>
 
-func (b *meterBuilder) gauge(name, desc string) metric.Int64Gauge <span class="cov9" title="57">{
-        if b.err != nil </span><span class="cov1" title="1">{
+func (b *meterBuilder) gauge(name, desc string) metric.Int64Gauge <span class="cov8" title="1">{
+        if b.err != nil </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov9" title="56">g, err := b.m.Int64Gauge(name, metric.WithDescription(desc))
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">g, err := b.m.Int64Gauge(name, metric.WithDescription(desc))
+        if err != nil </span><span class="cov8" title="1">{
                 b.err = xerrors.Wrap(err, name)
                 return nil
         }</span>
-        <span class="cov9" title="55">return g</span>
+        <span class="cov8" title="1">return g</span>
 }
 </pre>
 		
@@ -15640,14 +15631,14 @@ type conditionalPropagator struct {
 // HTTP span 生成は自動化し、traceparent/baggage の outgoing inject は ContextWithTracePropagation の
 // フラグに従って外部 downstream への伝搬を抑止できます。private/loopback 宛て接続は
 // ContextWithAllowPrivateNetwork のフラグで制御し、link-local（クラウドメタデータ等）は常に拒否します。
-func NewHTTPClientTransport(tp trace.TracerProvider, propagator propagation.TextMapPropagator) *HTTPClientTransport <span class="cov3" title="4">{
+func NewHTTPClientTransport(tp trace.TracerProvider, propagator propagation.TextMapPropagator) *HTTPClientTransport <span class="cov8" title="1">{
         return newHTTPClientTransport(tp, propagator, guardedDialControl)
 }</span>
 
 // newHTTPClientTransport は、dial control を差し替え可能にした内部コンストラクタです。
 func newHTTPClientTransport(
         tp trace.TracerProvider, propagator propagation.TextMapPropagator, control dialControl,
-) *HTTPClientTransport <span class="cov6" title="31">{
+) *HTTPClientTransport <span class="cov8" title="1">{
         rt := otelhttp.NewTransport(
                 newGuardedBaseTransport(control),
                 otelhttp.WithTracerProvider(tp),
@@ -15658,91 +15649,91 @@ func newHTTPClientTransport(
 }</span>
 
 // RoundTripper は、ラップしている http.RoundTripper を返します。
-func (t *HTTPClientTransport) RoundTripper() http.RoundTripper <span class="cov6" title="31">{
+func (t *HTTPClientTransport) RoundTripper() http.RoundTripper <span class="cov8" title="1">{
         return t.rt
 }</span>
 
 // ContextWithTracePropagation は、この outbound 呼び出しで traceparent/baggage を注入するかを ctx に設定します。
-func ContextWithTracePropagation(ctx context.Context, enabled bool) context.Context <span class="cov6" title="51">{
+func ContextWithTracePropagation(ctx context.Context, enabled bool) context.Context <span class="cov8" title="1">{
         return context.WithValue(ctx, tracePropagationKey{}, enabled)
 }</span>
 
 // ContextWithAllowPrivateNetwork は、この outbound 呼び出しで private/loopback 宛て接続を許可するかを ctx に設定します。
-func ContextWithAllowPrivateNetwork(ctx context.Context, allowed bool) context.Context <span class="cov6" title="52">{
+func ContextWithAllowPrivateNetwork(ctx context.Context, allowed bool) context.Context <span class="cov8" title="1">{
         return context.WithValue(ctx, allowPrivateNetworkKey{}, allowed)
 }</span>
 
 // Inject は、伝搬フラグが明示的に false の場合のみ注入を抑止し、それ以外は内側へ委譲します。
-func (p conditionalPropagator) Inject(ctx context.Context, carrier propagation.TextMapCarrier) <span class="cov6" title="53">{
-        if enabled, ok := ctx.Value(tracePropagationKey{}).(bool); ok &amp;&amp; !enabled </span><span class="cov1" title="1">{
+func (p conditionalPropagator) Inject(ctx context.Context, carrier propagation.TextMapCarrier) <span class="cov8" title="1">{
+        if enabled, ok := ctx.Value(tracePropagationKey{}).(bool); ok &amp;&amp; !enabled </span><span class="cov8" title="1">{
                 return
         }</span>
-        <span class="cov6" title="52">p.inner.Inject(ctx, carrier)</span>
+        <span class="cov8" title="1">p.inner.Inject(ctx, carrier)</span>
 }
 
 // Extract は、内側の propagator へ委譲します。
-func (p conditionalPropagator) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context <span class="cov1" title="1">{
+func (p conditionalPropagator) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context <span class="cov8" title="1">{
         return p.inner.Extract(ctx, carrier)
 }</span>
 
 // Fields は、内側の propagator へ委譲します。
-func (p conditionalPropagator) Fields() []string <span class="cov1" title="1">{
+func (p conditionalPropagator) Fields() []string <span class="cov8" title="1">{
         return p.inner.Fields()
 }</span>
 
 // newGuardedBaseTransport は、指定の dial control を備えた base transport を返します。
-func newGuardedBaseTransport(control dialControl) *http.Transport <span class="cov6" title="31">{
+func newGuardedBaseTransport(control dialControl) *http.Transport <span class="cov8" title="1">{
         base := &amp;http.Transport{}
-        if t, ok := http.DefaultTransport.(*http.Transport); ok </span><span class="cov6" title="31">{
+        if t, ok := http.DefaultTransport.(*http.Transport); ok </span><span class="cov8" title="1">{
                 base = t.Clone()
         }</span>
-        <span class="cov6" title="31">dialer := &amp;net.Dialer{ControlContext: control}
+        <span class="cov8" title="1">dialer := &amp;net.Dialer{ControlContext: control}
         base.DialContext = dialer.DialContext
         return base</span>
 }
 
 // guardedDialControl は、名前解決後の実接続先 IP を検査する SSRF ガードです（DNS rebinding も防ぎます）。
 // link-local / unspecified / bogon予約帯は常に拒否し、loopback / private / CGNAT は ctx フラグで許可されない限り拒否します。
-func guardedDialControl(ctx context.Context, _, address string, _ syscall.RawConn) error <span class="cov5" title="23">{
+func guardedDialControl(ctx context.Context, _, address string, _ syscall.RawConn) error <span class="cov8" title="1">{
         host, _, err := net.SplitHostPort(address)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov5" title="22">ip := net.ParseIP(host)
-        if ip == nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">ip := net.ParseIP(host)
+        if ip == nil </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov5" title="21">if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() </span><span class="cov8" title="1">{
                 return xerrors.New("ssrf guard: blocked address " + host)
         }</span>
         // bogon/予約帯は正当な宛先にならないため allowPrivateNetwork フラグに関わらず常時拒否する。
-        <span class="cov5" title="19">for _, n := range reservedNets </span><span class="cov8" title="112">{
-                if n.Contains(ip) </span><span class="cov3" title="7">{
+        <span class="cov8" title="1">for _, n := range reservedNets </span><span class="cov8" title="1">{
+                if n.Contains(ip) </span><span class="cov8" title="1">{
                         return xerrors.New("ssrf guard: blocked reserved address " + host)
                 }</span>
         }
-        <span class="cov4" title="12">if !allowPrivateNetworkFromContext(ctx) &amp;&amp; (ip.IsLoopback() || ip.IsPrivate() || cgnatNet.Contains(ip)) </span><span class="cov3" title="5">{
+        <span class="cov8" title="1">if !allowPrivateNetworkFromContext(ctx) &amp;&amp; (ip.IsLoopback() || ip.IsPrivate() || cgnatNet.Contains(ip)) </span><span class="cov8" title="1">{
                 return xerrors.New("ssrf guard: blocked private/loopback address " + host)
         }</span>
-        <span class="cov3" title="7">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 
 // mustParseCIDR は、定数 CIDR 文字列を *net.IPNet へ解析します。不正リテラルは起動時 panic です。
-func mustParseCIDR(s string) *net.IPNet <span class="cov10" title="402">{
+func mustParseCIDR(s string) *net.IPNet <span class="cov8" title="1">{
         _, n, err := net.ParseCIDR(s)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 panic(err)</span>
         }
-        <span class="cov9" title="401">return n</span>
+        <span class="cov8" title="1">return n</span>
 }
 
 // permissiveDialControl は、すべての接続を許可する dial control です（テスト用）。
-func permissiveDialControl(context.Context, string, string, syscall.RawConn) error <span class="cov6" title="28">{
+func permissiveDialControl(context.Context, string, string, syscall.RawConn) error <span class="cov8" title="1">{
         return nil
 }</span>
 
 // allowPrivateNetworkFromContext は、ctx の private 許可フラグを返します（未設定は安全側の false）。
-func allowPrivateNetworkFromContext(ctx context.Context) bool <span class="cov4" title="12">{
+func allowPrivateNetworkFromContext(ctx context.Context) bool <span class="cov8" title="1">{
         allowed, ok := ctx.Value(allowPrivateNetworkKey{}).(bool)
         return ok &amp;&amp; allowed
 }</span>
@@ -15776,68 +15767,68 @@ type IdempotencyMetrics struct {
 
 // NewIdempotencyMetrics は、注入された MeterProvider から冪等性計装一式を生成します。
 // いずれかの計装生成失敗で error を返します。
-func NewIdempotencyMetrics(mp metric.MeterProvider) (*IdempotencyMetrics, error) <span class="cov10" title="18">{
+func NewIdempotencyMetrics(mp metric.MeterProvider) (*IdempotencyMetrics, error) <span class="cov8" title="1">{
         b := &amp;meterBuilder{m: mp.Meter(idempotencyMeterName)}
         im := &amp;IdempotencyMetrics{
                 requests:       b.counter("idempotency.requests", "冪等性判定結果数(result=hit/miss/conflict/fingerprint_mismatch 別)"),
                 failures:       b.counter("idempotency.failures", "冪等性の内部失敗数(phase=claim/complete/gc_cleanup 別)"),
                 expiredCleanup: b.counter("idempotency.expired_cleanup", "GC が削除した失効キー件数"),
         }
-        if b.err != nil </span><span class="cov1" title="1">{
+        if b.err != nil </span><span class="cov8" title="1">{
                 return nil, b.err
         }</span>
-        <span class="cov9" title="17">return im, nil</span>
+        <span class="cov8" title="1">return im, nil</span>
 }
 
 // IncHit は、completed 行の再送（replay）を計上します。
-func (m *IdempotencyMetrics) IncHit(ctx context.Context, operationID string) <span class="cov4" title="3">{
+func (m *IdempotencyMetrics) IncHit(ctx context.Context, operationID string) <span class="cov8" title="1">{
         m.incRequest(ctx, operationID, "hit")
 }</span>
 
 // IncMiss は、新規 claim 成立を計上します。
-func (m *IdempotencyMetrics) IncMiss(ctx context.Context, operationID string) <span class="cov3" title="2">{
+func (m *IdempotencyMetrics) IncMiss(ctx context.Context, operationID string) <span class="cov8" title="1">{
         m.incRequest(ctx, operationID, "miss")
 }</span>
 
 // IncConflict は、処理中キーへの並行再送（409）を計上します。
-func (m *IdempotencyMetrics) IncConflict(ctx context.Context, operationID string) <span class="cov3" title="2">{
+func (m *IdempotencyMetrics) IncConflict(ctx context.Context, operationID string) <span class="cov8" title="1">{
         m.incRequest(ctx, operationID, "conflict")
 }</span>
 
 // IncFingerprintMismatch は、同一キー別ボディの再利用（422）を計上します。
-func (m *IdempotencyMetrics) IncFingerprintMismatch(ctx context.Context, operationID string) <span class="cov3" title="2">{
+func (m *IdempotencyMetrics) IncFingerprintMismatch(ctx context.Context, operationID string) <span class="cov8" title="1">{
         m.incRequest(ctx, operationID, "fingerprint_mismatch")
 }</span>
 
 // IncClaimFailure は、ErrLockTimeout 以外の Claim 失敗を計上します。
-func (m *IdempotencyMetrics) IncClaimFailure(ctx context.Context, operationID string) <span class="cov3" title="2">{
+func (m *IdempotencyMetrics) IncClaimFailure(ctx context.Context, operationID string) <span class="cov8" title="1">{
         m.incFailure(ctx, operationID, "claim")
 }</span>
 
 // IncCompleteFailure は、Complete 失敗（結果保存失敗）を計上します。
-func (m *IdempotencyMetrics) IncCompleteFailure(ctx context.Context, operationID string) <span class="cov3" title="2">{
+func (m *IdempotencyMetrics) IncCompleteFailure(ctx context.Context, operationID string) <span class="cov8" title="1">{
         m.incFailure(ctx, operationID, "complete")
 }</span>
 
 // IncExpiredCleanup は、削除に成功した失効キー件数を計上します。
-func (m *IdempotencyMetrics) IncExpiredCleanup(ctx context.Context, count int64) <span class="cov4" title="3">{
+func (m *IdempotencyMetrics) IncExpiredCleanup(ctx context.Context, count int64) <span class="cov8" title="1">{
         m.expiredCleanup.Add(ctx, count,
                 metric.WithAttributes(attribute.String("job", idempotencyGCJob)))
 }</span>
 
 // IncExpiredCleanupFailure は、GC 削除バッチの失敗回数を計上します。
-func (m *IdempotencyMetrics) IncExpiredCleanupFailure(ctx context.Context) <span class="cov3" title="2">{
+func (m *IdempotencyMetrics) IncExpiredCleanupFailure(ctx context.Context) <span class="cov8" title="1">{
         m.incFailure(ctx, "", "gc_cleanup")
 }</span>
 
-func (m *IdempotencyMetrics) incRequest(ctx context.Context, operationID, result string) <span class="cov7" title="9">{
+func (m *IdempotencyMetrics) incRequest(ctx context.Context, operationID, result string) <span class="cov8" title="1">{
         m.requests.Add(ctx, 1, metric.WithAttributes(
                 attribute.String("operation_id", normalizeOperationID(operationID)),
                 attribute.String("result", result),
         ))
 }</span>
 
-func (m *IdempotencyMetrics) incFailure(ctx context.Context, operationID, phase string) <span class="cov6" title="6">{
+func (m *IdempotencyMetrics) incFailure(ctx context.Context, operationID, phase string) <span class="cov8" title="1">{
         m.failures.Add(ctx, 1, metric.WithAttributes(
                 attribute.String("operation_id", normalizeOperationID(operationID)),
                 attribute.String("phase", phase),
@@ -15845,11 +15836,11 @@ func (m *IdempotencyMetrics) incFailure(ctx context.Context, operationID, phase 
 }</span>
 
 // normalizeOperationID は、空の operationID を unknown へ丸めます（空ラベル回避）。
-func normalizeOperationID(operationID string) string <span class="cov9" title="15">{
-        if operationID == "" </span><span class="cov4" title="3">{
+func normalizeOperationID(operationID string) string <span class="cov8" title="1">{
+        if operationID == "" </span><span class="cov8" title="1">{
                 return "unknown"
         }</span>
-        <span class="cov8" title="12">return operationID</span>
+        <span class="cov8" title="1">return operationID</span>
 }
 </pre>
 		
@@ -15892,13 +15883,13 @@ type LayerTracer struct {
 func (lt LayerTracer) Start(
         ctx context.Context,
         opts ...trace.SpanStartOption,
-) (context.Context, func()) <span class="cov9" title="549">{
-        if lt.funcName == "" </span><span class="cov9" title="548">{
+) (context.Context, func()) <span class="cov8" title="1">{
+        if lt.funcName == "" </span><span class="cov8" title="1">{
                 full := getCallerFullName()
                 lt.funcName = fnmeta.ExtractFunctionName(full)
         }</span>
 
-        <span class="cov9" title="549">return lt.startSpan(ctx, "", opts...)</span>
+        <span class="cov8" title="1">return lt.startSpan(ctx, "", opts...)</span>
 }
 
 // StartWithSuffix は、新しい span を開始し、span を含む新しい Context と、span を終了するための endSpan 関数を返す。
@@ -15907,13 +15898,13 @@ func (lt LayerTracer) StartWithSuffix(
         ctx context.Context,
         optionalName string,
         opts ...trace.SpanStartOption,
-) (context.Context, func()) <span class="cov2" title="3">{
-        if lt.funcName == "" </span><span class="cov1" title="1">{
+) (context.Context, func()) <span class="cov8" title="1">{
+        if lt.funcName == "" </span><span class="cov8" title="1">{
                 full := getCallerFullName()
                 lt.funcName = fnmeta.ExtractFunctionName(full)
         }</span>
 
-        <span class="cov2" title="3">return lt.startSpan(ctx, optionalName, opts...)</span>
+        <span class="cov8" title="1">return lt.startSpan(ctx, optionalName, opts...)</span>
 }
 
 // RunWithSpan は、指定された関数 fn を新しい span 内で実行し、結果を返す。
@@ -15931,28 +15922,28 @@ func RunWithSpan[T any](
         layer layerName,
         pkg, funcName string,
         fn func(ctx context.Context) (T, error),
-) (context.Context, T, error) <span class="cov4" title="11">{
+) (context.Context, T, error) <span class="cov8" title="1">{
         spanName := BuildSpanName(string(layer), pkg, funcName)
 
         _, childCtx, end := StartSpanWithParent(parentCtx, lt, spanName)
         defer end()
 
         v, err := fn(childCtx)
-        if err != nil </span><span class="cov1" title="2">{
+        if err != nil </span><span class="cov8" title="1">{
                 var zero T
                 return childCtx, zero, err
         }</span>
 
-        <span class="cov4" title="9">return childCtx, v, nil</span>
+        <span class="cov8" title="1">return childCtx, v, nil</span>
 }
 
 // makeSpanName は、LayerTracer の情報をもとに完全なspan名を生成します。
-func (lt LayerTracer) makeSpanName(optionalName string) string <span class="cov10" title="555">{
+func (lt LayerTracer) makeSpanName(optionalName string) string <span class="cov8" title="1">{
         fullName := BuildSpanName(string(lt.layer), lt.pkgName, lt.funcName)
-        if optionalName != "" </span><span class="cov2" title="4">{
+        if optionalName != "" </span><span class="cov8" title="1">{
                 fullName += delimiter + optionalName
         }</span>
-        <span class="cov10" title="555">return fullName</span>
+        <span class="cov8" title="1">return fullName</span>
 }
 
 // startSpan は、新しい span を開始し、span を含む新しい Context と、span を終了するための endSpan 関数を返す。
@@ -15964,7 +15955,7 @@ func (lt LayerTracer) startSpan(
         parentCtx context.Context,
         optionalName string,
         opts ...trace.SpanStartOption,
-) (context.Context, func()) <span class="cov9" title="553">{
+) (context.Context, func()) <span class="cov8" title="1">{
         spanName := lt.makeSpanName(optionalName)
         _, childCtx, end := StartSpanWithParent(parentCtx, lt, spanName, opts...)
 
@@ -15989,46 +15980,46 @@ import (
 )
 
 // NewLoggerProvider は LoggerProvider を構築して返す。
-func NewLoggerProvider(obsCfg *config.ObservabilityConfig, res *resource.Resource) (*sdklog.LoggerProvider, error) <span class="cov10" title="21">{
+func NewLoggerProvider(obsCfg *config.ObservabilityConfig, res *resource.Resource) (*sdklog.LoggerProvider, error) <span class="cov8" title="1">{
         opts := []sdklog.LoggerProviderOption{sdklog.WithResource(res)}
 
-        if obsCfg.LogsEnabled() </span><span class="cov5" title="4">{
+        if obsCfg.LogsEnabled() </span><span class="cov8" title="1">{
                 exporter, err := newLogExporter(context.Background(), obsCfg)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return nil, xerrors.Wrap(err, "failed to build log exporter")
                 }</span>
-                <span class="cov4" title="3">opts = append(opts, sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter)))</span>
+                <span class="cov8" title="1">opts = append(opts, sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter)))</span>
         }
 
-        <span class="cov9" title="20">return sdklog.NewLoggerProvider(opts...), nil</span>
+        <span class="cov8" title="1">return sdklog.NewLoggerProvider(opts...), nil</span>
 }
 
 // NewLogCore は zap ログを OTLP へ橋渡しする otelzap core を返す。log exporter が無効値のときは nil を返す。
 func NewLogCore(
         obsCfg *config.ObservabilityConfig, appCfg *config.ApplicationConfig, lp *sdklog.LoggerProvider,
-) logging.LogCore <span class="cov9" title="17">{
-        if !obsCfg.LogsEnabled() </span><span class="cov9" title="16">{
+) logging.LogCore <span class="cov8" title="1">{
+        if !obsCfg.LogsEnabled() </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov1" title="1">return otelzap.NewCore(appCfg.Name(), otelzap.WithLoggerProvider(lp))</span>
+        <span class="cov8" title="1">return otelzap.NewCore(appCfg.Name(), otelzap.WithLoggerProvider(lp))</span>
 }
 
 // newLogExporter は OBS_OTLP_PROTOCOL / OBS_OTLP_ENDPOINT から OTLP LogExporter を構築する。
-func newLogExporter(ctx context.Context, obsCfg *config.ObservabilityConfig) (sdklog.Exporter, error) <span class="cov6" title="6">{
+func newLogExporter(ctx context.Context, obsCfg *config.ObservabilityConfig) (sdklog.Exporter, error) <span class="cov8" title="1">{
         switch obsCfg.OTLPProtocol() </span>{
-        case protocolGRPC:<span class="cov3" title="2">
+        case protocolGRPC:<span class="cov8" title="1">
                 var opts []otlploggrpc.Option
-                if ep := obsCfg.OTLPEndpoint(); ep != "" </span><span class="cov1" title="1">{
+                if ep := obsCfg.OTLPEndpoint(); ep != "" </span><span class="cov8" title="1">{
                         opts = append(opts, otlploggrpc.WithEndpointURL(ep))
                 }</span>
-                <span class="cov3" title="2">return otlploggrpc.New(ctx, opts...)</span>
-        case protocolHTTP, "":<span class="cov4" title="3">
+                <span class="cov8" title="1">return otlploggrpc.New(ctx, opts...)</span>
+        case protocolHTTP, "":<span class="cov8" title="1">
                 var opts []otlploghttp.Option
-                if ep := obsCfg.OTLPEndpoint(); ep != "" </span><span class="cov3" title="2">{
+                if ep := obsCfg.OTLPEndpoint(); ep != "" </span><span class="cov8" title="1">{
                         opts = append(opts, otlploghttp.WithEndpointURL(ensureOTLPPath(ep, otlpLogsPath)))
                 }</span>
-                <span class="cov4" title="3">return otlploghttp.New(ctx, opts...)</span>
-        default:<span class="cov1" title="1">
+                <span class="cov8" title="1">return otlploghttp.New(ctx, opts...)</span>
+        default:<span class="cov8" title="1">
                 return nil, errInvalidOTLPProtocol</span>
         }
 }
@@ -16060,7 +16051,7 @@ type Collector struct {
 }
 
 // NewCollector は、ラベル値を結線時に一度だけ解決・正規化して Collector を生成します。
-func NewCollector(appCfg *config.ApplicationConfig, bi system.BuildInfo) *Collector <span class="cov10" title="26">{
+func NewCollector(appCfg *config.ApplicationConfig, bi system.BuildInfo) *Collector <span class="cov8" title="1">{
         return &amp;Collector{
                 desc: prometheus.NewDesc(
                         metricName,
@@ -16087,35 +16078,35 @@ func NewCollector(appCfg *config.ApplicationConfig, bi system.BuildInfo) *Collec
 }</span>
 
 // Describe は、Collector のメトリクスの説明を Prometheus に提供します。
-func (c *Collector) Describe(ch chan&lt;- *prometheus.Desc) <span class="cov10" title="26">{
+func (c *Collector) Describe(ch chan&lt;- *prometheus.Desc) <span class="cov8" title="1">{
         ch &lt;- c.desc
 }</span>
 
 // Collect は、保持済みのラベル値で値 1 の info gauge を emit します。
-func (c *Collector) Collect(ch chan&lt;- prometheus.Metric) <span class="cov4" title="4">{
+func (c *Collector) Collect(ch chan&lt;- prometheus.Metric) <span class="cov8" title="1">{
         ch &lt;- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, 1, c.labelValues...)
 }</span>
 
 // Register は、Collector を Prometheus のデフォルトレジストリに登録します。
 //
 // 重複登録は AlreadyRegisteredError を無視して安全にスキップします。
-func Register(c *Collector) error <span class="cov8" title="18">{
+func Register(c *Collector) error <span class="cov8" title="1">{
         return register(prometheus.DefaultRegisterer, c)
 }</span>
 
 // register は、指定された Registerer に Collector を登録します。
 //
 // 重複登録は AlreadyRegisteredError を無視して安全にスキップします。
-func register(reg prometheus.Registerer, c *Collector) error <span class="cov9" title="22">{
+func register(reg prometheus.Registerer, c *Collector) error <span class="cov8" title="1">{
         err := reg.Register(c)
-        if err != nil </span><span class="cov8" title="16">{
+        if err != nil </span><span class="cov8" title="1">{
                 var alreadyRegisteredErr prometheus.AlreadyRegisteredError
-                if xerrors.As(err, &amp;alreadyRegisteredErr) </span><span class="cov8" title="15">{
+                if xerrors.As(err, &amp;alreadyRegisteredErr) </span><span class="cov8" title="1">{
                         return nil
                 }</span>
-                <span class="cov1" title="1">return err</span>
+                <span class="cov8" title="1">return err</span>
         }
-        <span class="cov5" title="6">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 </pre>
 		
@@ -16139,11 +16130,11 @@ const (
 )
 
 // normalize は、空文字のラベル値を unknownValue に丸めます。
-func normalize(v string) string <span class="cov10" title="156">{
-        if v == "" </span><span class="cov3" title="4">{
+func normalize(v string) string <span class="cov8" title="1">{
+        if v == "" </span><span class="cov8" title="1">{
                 return unknownValue
         }</span>
-        <span class="cov9" title="152">return v</span>
+        <span class="cov8" title="1">return v</span>
 }
 </pre>
 		
@@ -16224,7 +16215,7 @@ type failureKey struct {
 }
 
 // NewStatsCollector は、指定の収集対象から StatsCollector を生成します。
-func NewStatsCollector(targets []Target) *StatsCollector <span class="cov9" title="18">{
+func NewStatsCollector(targets []Target) *StatsCollector <span class="cov8" title="1">{
         return &amp;StatsCollector{
                 targets: targets,
                 depthDesc: prometheus.NewDesc(
@@ -16242,34 +16233,34 @@ func NewStatsCollector(targets []Target) *StatsCollector <span class="cov9" titl
 }</span>
 
 // Describe は、収集器のメトリクス説明を Prometheus に提供します。
-func (c *StatsCollector) Describe(ch chan&lt;- *prometheus.Desc) <span class="cov10" title="19">{
+func (c *StatsCollector) Describe(ch chan&lt;- *prometheus.Desc) <span class="cov8" title="1">{
         ch &lt;- c.depthDesc
         ch &lt;- c.failureDesc
 }</span>
 
 // Collect は、各 target から滞留量を取得して Prometheus に提供します。
 // provider がエラーを返した場合は depth を出さず、収集失敗 counter を増やします。
-func (c *StatsCollector) Collect(ch chan&lt;- prometheus.Metric) <span class="cov7" title="9">{
+func (c *StatsCollector) Collect(ch chan&lt;- prometheus.Metric) <span class="cov8" title="1">{
         ctx, cancel := context.WithTimeout(context.Background(), collectTimeout)
         defer cancel()
-        for _, t := range c.targets </span><span class="cov8" title="10">{
+        for _, t := range c.targets </span><span class="cov8" title="1">{
                 stats, err := t.Provider.QueueStats(ctx)
-                if err != nil </span><span class="cov5" title="4">{
+                if err != nil </span><span class="cov8" title="1">{
                         // QueueStats は source / DLQ いずれの失敗かを区別しないため queue="unknown" とします。
                         c.recordFailure(t.WorkerName, t.Adapter, queueUnknown)
                         continue</span>
                 }
 
-                <span class="cov6" title="6">c.collectDepth(ch, t, queueSource, stats.Source)
-                if stats.DLQ != nil </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">c.collectDepth(ch, t, queueSource, stats.Source)
+                if stats.DLQ != nil </span><span class="cov8" title="1">{
                         c.collectDepth(ch, t, queueDLQ, *stats.DLQ)
                 }</span>
         }
-        <span class="cov7" title="9">c.emitFailures(ch)</span>
+        <span class="cov8" title="1">c.emitFailures(ch)</span>
 }
 
 // collectDepth は、1 queue の滞留量を state 別の gauge として出力します。
-func (c *StatsCollector) collectDepth(ch chan&lt;- prometheus.Metric, t Target, queue string, d worker.QueueDepth) <span class="cov6" title="7">{
+func (c *StatsCollector) collectDepth(ch chan&lt;- prometheus.Metric, t Target, queue string, d worker.QueueDepth) <span class="cov8" title="1">{
         ch &lt;- prometheus.MustNewConstMetric(
                 c.depthDesc, prometheus.GaugeValue, float64(d.Visible), t.WorkerName, t.Adapter, queue, stateVisible)
         ch &lt;- prometheus.MustNewConstMetric(
@@ -16279,17 +16270,17 @@ func (c *StatsCollector) collectDepth(ch chan&lt;- prometheus.Metric, t Target, 
 }</span>
 
 // recordFailure は、収集失敗の累積回数を増やします。
-func (c *StatsCollector) recordFailure(workerName, adapter, queue string) <span class="cov5" title="4">{
+func (c *StatsCollector) recordFailure(workerName, adapter, queue string) <span class="cov8" title="1">{
         c.mu.Lock()
         defer c.mu.Unlock()
         c.failures[failureKey{worker: workerName, adapter: adapter, queue: queue}]++
 }</span>
 
 // emitFailures は、累積した収集失敗回数を counter として出力します。
-func (c *StatsCollector) emitFailures(ch chan&lt;- prometheus.Metric) <span class="cov7" title="9">{
+func (c *StatsCollector) emitFailures(ch chan&lt;- prometheus.Metric) <span class="cov8" title="1">{
         c.mu.Lock()
         defer c.mu.Unlock()
-        for k, v := range c.failures </span><span class="cov5" title="4">{
+        for k, v := range c.failures </span><span class="cov8" title="1">{
                 ch &lt;- prometheus.MustNewConstMetric(
                         c.failureDesc, prometheus.CounterValue, float64(v), k.worker, k.adapter, k.queue)
         }</span>
@@ -16297,16 +16288,16 @@ func (c *StatsCollector) emitFailures(ch chan&lt;- prometheus.Metric) <span clas
 
 // RegisterStatsCollector は、StatsCollector を指定レジストリに登録します。
 // 既に登録済みの場合はエラーを返さず無視します。
-func RegisterStatsCollector(reg prometheus.Registerer, c *StatsCollector) error <span class="cov7" title="9">{
+func RegisterStatsCollector(reg prometheus.Registerer, c *StatsCollector) error <span class="cov8" title="1">{
         err := reg.Register(c)
-        if err != nil </span><span class="cov6" title="6">{
+        if err != nil </span><span class="cov8" title="1">{
                 var alreadyRegisteredErr prometheus.AlreadyRegisteredError
-                if xerrors.As(err, &amp;alreadyRegisteredErr) </span><span class="cov5" title="5">{
+                if xerrors.As(err, &amp;alreadyRegisteredErr) </span><span class="cov8" title="1">{
                         return nil
                 }</span>
-                <span class="cov1" title="1">return err</span>
+                <span class="cov8" title="1">return err</span>
         }
-        <span class="cov4" title="3">return nil</span>
+        <span class="cov8" title="1">return nil</span>
 }
 </pre>
 		
@@ -16330,25 +16321,25 @@ type OutboxMetrics struct {
 }
 
 // NewOutboxMetrics は、注入された MeterProvider から outbox relay の計装一式を生成します。
-func NewOutboxMetrics(mp metric.MeterProvider) (*OutboxMetrics, error) <span class="cov10" title="19">{
+func NewOutboxMetrics(mp metric.MeterProvider) (*OutboxMetrics, error) <span class="cov8" title="1">{
         b := &amp;meterBuilder{m: mp.Meter(outboxMeterName)}
         om := &amp;OutboxMetrics{
                 lagSeconds: b.gauge("outbox.lag_seconds", "最古 pending 行の経過秒数（SLI=outbox lag）"),
                 dead:       b.counter("outbox.dead", "max attempts 到達で dead 化したメッセージ数"),
         }
-        if b.err != nil </span><span class="cov1" title="1">{
+        if b.err != nil </span><span class="cov8" title="1">{
                 return nil, b.err
         }</span>
-        <span class="cov9" title="18">return om, nil</span>
+        <span class="cov8" title="1">return om, nil</span>
 }
 
 // SetLagSeconds は、最古 pending 行の経過秒数（outbox lag）を記録します（pending 無しは 0）。
-func (m *OutboxMetrics) SetLagSeconds(ctx context.Context, seconds int64) <span class="cov3" title="2">{
+func (m *OutboxMetrics) SetLagSeconds(ctx context.Context, seconds int64) <span class="cov8" title="1">{
         m.lagSeconds.Record(ctx, seconds)
 }</span>
 
 // IncDead は、dead 化したメッセージ数を計上します。
-func (m *OutboxMetrics) IncDead(ctx context.Context) <span class="cov3" title="2">{ m.dead.Add(ctx, 1) }</span>
+func (m *OutboxMetrics) IncDead(ctx context.Context) <span class="cov8" title="1">{ m.dead.Add(ctx, 1) }</span>
 </pre>
 		
 		<pre class="file" id="file207" style="display: none">package observability
@@ -16363,7 +16354,7 @@ import (
 //
 // provider を引数で受けることで、グローバル provider の登録順に依存せず span / metric を送出します。
 // 接続情報（DB ユーザー名等）は span 属性に含めません。
-func NewPgxTracer(tp trace.TracerProvider, mp *sdkmetric.MeterProvider) *otelpgx.Tracer <span class="cov10" title="13">{
+func NewPgxTracer(tp trace.TracerProvider, mp *sdkmetric.MeterProvider) *otelpgx.Tracer <span class="cov8" title="1">{
         return otelpgx.NewTracer(
                 otelpgx.WithTracerProvider(tp),
                 otelpgx.WithMeterProvider(mp),
@@ -16387,44 +16378,44 @@ var traceContextPropagator propagation.TextMapPropagator = propagation.TraceCont
 // mapCarrier は、map[string]string を propagation のキャリアとして扱うアダプタです。
 type mapCarrier map[string]string
 
-func (c mapCarrier) Get(key string) string <span class="cov4" title="6">{ return c[key] }</span>
-func (c mapCarrier) Set(key, value string) <span class="cov3" title="4">{ c[key] = value }</span>
-func (c mapCarrier) Keys() []string <span class="cov2" title="2">{
+func (c mapCarrier) Get(key string) string <span class="cov8" title="1">{ return c[key] }</span>
+func (c mapCarrier) Set(key, value string) <span class="cov8" title="1">{ c[key] = value }</span>
+func (c mapCarrier) Keys() []string <span class="cov8" title="1">{
         keys := make([]string, 0, len(c))
-        for k := range c </span><span class="cov2" title="2">{
+        for k := range c </span><span class="cov8" title="1">{
                 keys = append(keys, k)
         }</span>
-        <span class="cov2" title="2">return keys</span>
+        <span class="cov8" title="1">return keys</span>
 }
 
 // ExtractFromCarrier は、attrs（traceparent 等）からグローバル伝播器で trace context を継続します。
 // producer → consumer → handler を 1 trace に繋ぐための公開ヘルパです。
-func ExtractFromCarrier(ctx context.Context, attrs map[string]string) context.Context <span class="cov9" title="183">{
+func ExtractFromCarrier(ctx context.Context, attrs map[string]string) context.Context <span class="cov8" title="1">{
         return extractFromCarrier(ctx, attrs, otel.GetTextMapPropagator())
 }</span>
 
 // extractFromCarrier は、prop から trace context を抽出して ctx に付与します。
-func extractFromCarrier(ctx context.Context, attrs map[string]string, prop propagation.TextMapPropagator) context.Context <span class="cov10" title="186">{
-        if len(attrs) == 0 </span><span class="cov9" title="183">{
+func extractFromCarrier(ctx context.Context, attrs map[string]string, prop propagation.TextMapPropagator) context.Context <span class="cov8" title="1">{
+        if len(attrs) == 0 </span><span class="cov8" title="1">{
                 return ctx
         }</span>
-        <span class="cov2" title="3">return prop.Extract(ctx, mapCarrier(attrs))</span>
+        <span class="cov8" title="1">return prop.Extract(ctx, mapCarrier(attrs))</span>
 }
 
 // InjectTraceContextToCarrier は、現在の ctx の trace context（traceparent 等）のみを attrs へ書き込みます。
 // outbox emit 時に traceparent を headers へ載せ、後続の relay→受信側を起点 trace に繋ぐための公開ヘルパです。
 // グローバル伝播器（Baggage を含みうる）ではなく TraceContext 限定で inject することで、インバウンド由来の
 // 任意 baggage が outbox 経由で外部エンドポイントへ転送される経路を断ちます。
-func InjectTraceContextToCarrier(ctx context.Context, attrs map[string]string) <span class="cov4" title="7">{
+func InjectTraceContextToCarrier(ctx context.Context, attrs map[string]string) <span class="cov8" title="1">{
         injectToCarrier(ctx, attrs, traceContextPropagator)
 }</span>
 
 // injectToCarrier は、prop で ctx の trace context を attrs へ書き込みます。
-func injectToCarrier(ctx context.Context, attrs map[string]string, prop propagation.TextMapPropagator) <span class="cov4" title="9">{
-        if attrs == nil </span><span class="cov1" title="1">{
+func injectToCarrier(ctx context.Context, attrs map[string]string, prop propagation.TextMapPropagator) <span class="cov8" title="1">{
+        if attrs == nil </span><span class="cov8" title="1">{
                 return
         }</span>
-        <span class="cov4" title="8">prop.Inject(ctx, mapCarrier(attrs))</span>
+        <span class="cov8" title="1">prop.Inject(ctx, mapCarrier(attrs))</span>
 }
 </pre>
 		
@@ -16473,17 +16464,17 @@ var errInvalidOTLPProtocol = xerrors.New("invalid OTLP protocol (want http/proto
 // ensureOTLPPath は OTLP HTTP のエンドポイント URL に signal パスが無ければ defaultPath を補う。
 // otlp*http の WithEndpointURL は path 無し（"" / "/"）の URL に既定 path を補わずルートへ送って 404 に
 // なる版があるため、空・ルートのときは defaultPath を明示する。
-func ensureOTLPPath(rawURL, defaultPath string) string <span class="cov6" title="10">{
+func ensureOTLPPath(rawURL, defaultPath string) string <span class="cov8" title="1">{
         u, err := url.Parse(rawURL)
-        if err != nil || (u.Path != "" &amp;&amp; u.Path != "/") </span><span class="cov2" title="2">{
+        if err != nil || (u.Path != "" &amp;&amp; u.Path != "/") </span><span class="cov8" title="1">{
                 return rawURL
         }</span>
-        <span class="cov5" title="8">u.Path = defaultPath
+        <span class="cov8" title="1">u.Path = defaultPath
         return u.String()</span>
 }
 
 // NewResource は service 識別情報を付与した OpenTelemetry リソースを生成する。
-func NewResource(appCfg *config.ApplicationConfig, bi system.BuildInfo) (*resource.Resource, error) <span class="cov8" title="30">{
+func NewResource(appCfg *config.ApplicationConfig, bi system.BuildInfo) (*resource.Resource, error) <span class="cov8" title="1">{
         attrs := resource.NewSchemaless(
                 semconv.ServiceName(appCfg.Name()),
                 semconv.DeploymentEnvironmentName(appCfg.Env()),
@@ -16497,22 +16488,22 @@ func NewResource(appCfg *config.ApplicationConfig, bi system.BuildInfo) (*resour
                 return nil, xerrors.Wrap(err, "failed to merge otel resource")
         }</span>
 
-        <span class="cov8" title="30">return res, nil</span>
+        <span class="cov8" title="1">return res, nil</span>
 }
 
 // NewTracerProvider は TracerProvider と W3C 伝播器をグローバル登録し、構築した TracerProvider を返す。
-func NewTracerProvider(obsCfg *config.ObservabilityConfig, res *resource.Resource) (*sdktrace.TracerProvider, error) <span class="cov7" title="21">{
+func NewTracerProvider(obsCfg *config.ObservabilityConfig, res *resource.Resource) (*sdktrace.TracerProvider, error) <span class="cov8" title="1">{
         opts := []sdktrace.TracerProviderOption{sdktrace.WithResource(res)}
 
-        if obsCfg.TracesEnabled() </span><span class="cov4" title="4">{
+        if obsCfg.TracesEnabled() </span><span class="cov8" title="1">{
                 exporter, err := newSpanExporter(context.Background(), obsCfg)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return nil, xerrors.Wrap(err, "failed to build span exporter")
                 }</span>
-                <span class="cov3" title="3">opts = append(opts, sdktrace.WithBatcher(exporter))</span>
+                <span class="cov8" title="1">opts = append(opts, sdktrace.WithBatcher(exporter))</span>
         }
 
-        <span class="cov7" title="20">tp := sdktrace.NewTracerProvider(opts...)
+        <span class="cov8" title="1">tp := sdktrace.NewTracerProvider(opts...)
 
         otel.SetTracerProvider(tp)
         otel.SetTextMapPropagator(NewTextMapPropagator())
@@ -16521,7 +16512,7 @@ func NewTracerProvider(obsCfg *config.ObservabilityConfig, res *resource.Resourc
 }
 
 // NewTextMapPropagator は、W3C TraceContext + Baggage の複合 propagator を返します。
-func NewTextMapPropagator() propagation.TextMapPropagator <span class="cov10" title="52">{
+func NewTextMapPropagator() propagation.TextMapPropagator <span class="cov8" title="1">{
         return propagation.NewCompositeTextMapPropagator(
                 propagation.TraceContext{},
                 propagation.Baggage{},
@@ -16530,20 +16521,20 @@ func NewTextMapPropagator() propagation.TextMapPropagator <span class="cov10" ti
 
 // NewMeterProvider は MeterProvider をグローバル登録し、構築した MeterProvider を返す。
 // MetricsEnabled が真の場合は Go ランタイムメトリクスの収集 goroutine も開始する。
-func NewMeterProvider(obsCfg *config.ObservabilityConfig, res *resource.Resource) (*sdkmetric.MeterProvider, error) <span class="cov7" title="21">{
+func NewMeterProvider(obsCfg *config.ObservabilityConfig, res *resource.Resource) (*sdkmetric.MeterProvider, error) <span class="cov8" title="1">{
         opts := []sdkmetric.Option{sdkmetric.WithResource(res)}
 
-        if obsCfg.MetricsEnabled() </span><span class="cov4" title="4">{
+        if obsCfg.MetricsEnabled() </span><span class="cov8" title="1">{
                 reader, err := newMetricReader(context.Background(), obsCfg)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return nil, xerrors.Wrap(err, "failed to build metric reader")
                 }</span>
-                <span class="cov3" title="3">opts = append(opts, sdkmetric.WithReader(reader))</span>
+                <span class="cov8" title="1">opts = append(opts, sdkmetric.WithReader(reader))</span>
         }
 
-        <span class="cov7" title="20">mp := sdkmetric.NewMeterProvider(opts...)
+        <span class="cov8" title="1">mp := sdkmetric.NewMeterProvider(opts...)
 
-        if obsCfg.MetricsEnabled() </span><span class="cov3" title="3">{
+        if obsCfg.MetricsEnabled() </span><span class="cov8" title="1">{
                 if err := runtime.Start(runtime.WithMeterProvider(mp)); err != nil </span><span class="cov0" title="0">{
                         // mp は既に PeriodicReader（送出 goroutine）を抱えているため、失敗時は Shutdown して回収する。
                         _ = mp.Shutdown(context.Background())
@@ -16551,66 +16542,66 @@ func NewMeterProvider(obsCfg *config.ObservabilityConfig, res *resource.Resource
                 }</span>
         }
 
-        <span class="cov7" title="20">otel.SetMeterProvider(mp)
+        <span class="cov8" title="1">otel.SetMeterProvider(mp)
 
         return mp, nil</span>
 }
 
 // newSpanExporter は OBS_OTLP_PROTOCOL / OBS_OTLP_ENDPOINT から OTLP SpanExporter を構築する。
 // endpoint 未指定時は OTLP のデフォルト（localhost:4318 / :4317）に従う。
-func newSpanExporter(ctx context.Context, obsCfg *config.ObservabilityConfig) (sdktrace.SpanExporter, error) <span class="cov4" title="4">{
+func newSpanExporter(ctx context.Context, obsCfg *config.ObservabilityConfig) (sdktrace.SpanExporter, error) <span class="cov8" title="1">{
         switch obsCfg.OTLPProtocol() </span>{
-        case protocolGRPC:<span class="cov1" title="1">
+        case protocolGRPC:<span class="cov8" title="1">
                 var opts []otlptracegrpc.Option
-                if ep := obsCfg.OTLPEndpoint(); ep != "" </span><span class="cov1" title="1">{
+                if ep := obsCfg.OTLPEndpoint(); ep != "" </span><span class="cov8" title="1">{
                         opts = append(opts, otlptracegrpc.WithEndpointURL(ep))
                 }</span>
-                <span class="cov1" title="1">return otlptracegrpc.New(ctx, opts...)</span>
-        case protocolHTTP, "":<span class="cov2" title="2">
+                <span class="cov8" title="1">return otlptracegrpc.New(ctx, opts...)</span>
+        case protocolHTTP, "":<span class="cov8" title="1">
                 var opts []otlptracehttp.Option
-                if ep := obsCfg.OTLPEndpoint(); ep != "" </span><span class="cov2" title="2">{
+                if ep := obsCfg.OTLPEndpoint(); ep != "" </span><span class="cov8" title="1">{
                         opts = append(opts, otlptracehttp.WithEndpointURL(ensureOTLPPath(ep, otlpTracesPath)))
                 }</span>
-                <span class="cov2" title="2">return otlptracehttp.New(ctx, opts...)</span>
-        default:<span class="cov1" title="1">
+                <span class="cov8" title="1">return otlptracehttp.New(ctx, opts...)</span>
+        default:<span class="cov8" title="1">
                 return nil, errInvalidOTLPProtocol</span>
         }
 }
 
 // newMetricReader は定期収集型の Reader を返す。
-func newMetricReader(ctx context.Context, obsCfg *config.ObservabilityConfig) (sdkmetric.Reader, error) <span class="cov4" title="4">{
+func newMetricReader(ctx context.Context, obsCfg *config.ObservabilityConfig) (sdkmetric.Reader, error) <span class="cov8" title="1">{
         exporter, err := newMetricExporter(ctx, obsCfg)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov3" title="3">return sdkmetric.NewPeriodicReader(exporter), nil</span>
+        <span class="cov8" title="1">return sdkmetric.NewPeriodicReader(exporter), nil</span>
 }
 
 // newMetricExporter は OBS_OTLP_PROTOCOL / OBS_OTLP_ENDPOINT から OTLP MetricExporter を構築する。
-func newMetricExporter(ctx context.Context, obsCfg *config.ObservabilityConfig) (sdkmetric.Exporter, error) <span class="cov4" title="4">{
+func newMetricExporter(ctx context.Context, obsCfg *config.ObservabilityConfig) (sdkmetric.Exporter, error) <span class="cov8" title="1">{
         switch obsCfg.OTLPProtocol() </span>{
-        case protocolGRPC:<span class="cov1" title="1">
+        case protocolGRPC:<span class="cov8" title="1">
                 var opts []otlpmetricgrpc.Option
-                if ep := obsCfg.OTLPEndpoint(); ep != "" </span><span class="cov1" title="1">{
+                if ep := obsCfg.OTLPEndpoint(); ep != "" </span><span class="cov8" title="1">{
                         opts = append(opts, otlpmetricgrpc.WithEndpointURL(ep))
                 }</span>
-                <span class="cov1" title="1">return otlpmetricgrpc.New(ctx, opts...)</span>
-        case protocolHTTP, "":<span class="cov2" title="2">
+                <span class="cov8" title="1">return otlpmetricgrpc.New(ctx, opts...)</span>
+        case protocolHTTP, "":<span class="cov8" title="1">
                 var opts []otlpmetrichttp.Option
-                if ep := obsCfg.OTLPEndpoint(); ep != "" </span><span class="cov2" title="2">{
+                if ep := obsCfg.OTLPEndpoint(); ep != "" </span><span class="cov8" title="1">{
                         opts = append(opts, otlpmetrichttp.WithEndpointURL(ensureOTLPPath(ep, otlpMetricsPath)))
                 }</span>
-                <span class="cov2" title="2">return otlpmetrichttp.New(ctx, opts...)</span>
-        default:<span class="cov1" title="1">
+                <span class="cov8" title="1">return otlpmetrichttp.New(ctx, opts...)</span>
+        default:<span class="cov8" title="1">
                 return nil, errInvalidOTLPProtocol</span>
         }
 }
 
 // ProvideTracerProvider は具象 TracerProvider を otel の trace.TracerProvider IF として返す。
-func ProvideTracerProvider(tp *sdktrace.TracerProvider) trace.TracerProvider <span class="cov7" title="18">{ return tp }</span>
+func ProvideTracerProvider(tp *sdktrace.TracerProvider) trace.TracerProvider <span class="cov8" title="1">{ return tp }</span>
 
 // ProvideMeterProvider は具象 MeterProvider を otel の metric.MeterProvider IF として返す。
-func ProvideMeterProvider(mp *sdkmetric.MeterProvider) metric.MeterProvider <span class="cov7" title="14">{ return mp }</span>
+func ProvideMeterProvider(mp *sdkmetric.MeterProvider) metric.MeterProvider <span class="cov8" title="1">{ return mp }</span>
 </pre>
 		
 		<pre class="file" id="file210" style="display: none">//go:generate mockgen -source=$GOFILE -destination=mock/mock_$GOFILE.gen.go -package=mock_$GOPACKAGE
@@ -16642,11 +16633,11 @@ type providerShutdowner struct {
 // NewProviderShutdowner は具象プロバイダから後始末ハンドルを構築する。
 func NewProviderShutdowner(
         tp *sdktrace.TracerProvider, mp *sdkmetric.MeterProvider, lp *sdklog.LoggerProvider,
-) ProviderShutdowner <span class="cov10" title="23">{
+) ProviderShutdowner <span class="cov8" title="1">{
         return providerShutdowner{tp: tp, mp: mp, lp: lp}
 }</span>
 
-func (s providerShutdowner) Shutdown(ctx context.Context) error <span class="cov7" title="11">{
+func (s providerShutdowner) Shutdown(ctx context.Context) error <span class="cov8" title="1">{
         return xerrors.Join(s.tp.Shutdown(ctx), s.mp.Shutdown(ctx), s.lp.Shutdown(ctx))
 }</span>
 </pre>
@@ -16670,7 +16661,7 @@ const (
 )
 
 // NewNoopTracerFactory は、テスト用に TracerFactory を無効化して返します。
-func NewNoopTracerFactory(t *testing.T) TracerFactory <span class="cov10" title="265">{
+func NewNoopTracerFactory(t *testing.T) TracerFactory <span class="cov8" title="1">{
         t.Helper()
 
         tp := noop.NewTracerProvider()
@@ -16678,28 +16669,28 @@ func NewNoopTracerFactory(t *testing.T) TracerFactory <span class="cov10" title=
 }</span>
 
 // NewMockControllerLayerTracer は、テスト用のコントローラーレイヤートレーサーを生成します。
-func NewMockControllerLayerTracer(t *testing.T) LayerTracer <span class="cov7" title="44">{
+func NewMockControllerLayerTracer(t *testing.T) LayerTracer <span class="cov8" title="1">{
         t.Helper()
         tf := NewNoopTracerFactory(t)
         return tf.Controller()
 }</span>
 
 // NewMockUsecaseLayerTracer は、テスト用のユースケースレイヤートレーサーを生成します。
-func NewMockUsecaseLayerTracer(t *testing.T) LayerTracer <span class="cov5" title="15">{
+func NewMockUsecaseLayerTracer(t *testing.T) LayerTracer <span class="cov8" title="1">{
         t.Helper()
         tf := NewNoopTracerFactory(t)
         return tf.Usecase()
 }</span>
 
 // NewMockInfraLayerTracer は、テスト用のインフラレイヤートレーサーを生成します。
-func NewMockInfraLayerTracer(t *testing.T) LayerTracer <span class="cov5" title="17">{
+func NewMockInfraLayerTracer(t *testing.T) LayerTracer <span class="cov8" title="1">{
         t.Helper()
         tf := NewNoopTracerFactory(t)
         return tf.Infra()
 }</span>
 
 // NewNoopLayerTracer は、テスト用に LayerTracer を無効化して返します。
-func NewNoopLayerTracer(t *testing.T) LayerTracer <span class="cov1" title="1">{
+func NewNoopLayerTracer(t *testing.T) LayerTracer <span class="cov8" title="1">{
         t.Helper()
         return LayerTracer{
                 tracer:  noop.NewTracerProvider().Tracer(tracer),
@@ -16709,44 +16700,44 @@ func NewNoopLayerTracer(t *testing.T) LayerTracer <span class="cov1" title="1">{
 }</span>
 
 // NewNoopWorkerMetrics は、テスト用に no-op の MeterProvider から WorkerMetrics を生成します。
-func NewNoopWorkerMetrics(t *testing.T) *WorkerMetrics <span class="cov6" title="41">{
+func NewNoopWorkerMetrics(t *testing.T) *WorkerMetrics <span class="cov8" title="1">{
         t.Helper()
         wm, err := NewWorkerMetrics(metricnoop.NewMeterProvider())
         if err != nil </span><span class="cov0" title="0">{
                 t.Fatalf("failed to build noop worker metrics: %v", err)
         }</span>
-        <span class="cov6" title="41">return wm</span>
+        <span class="cov8" title="1">return wm</span>
 }
 
 // NewNoopHTTPClientMetrics は、テスト用に no-op の MeterProvider から HTTPClientMetrics を生成します。
-func NewNoopHTTPClientMetrics(t *testing.T) *HTTPClientMetrics <span class="cov6" title="27">{
+func NewNoopHTTPClientMetrics(t *testing.T) *HTTPClientMetrics <span class="cov8" title="1">{
         t.Helper()
         hm, err := NewHTTPClientMetrics(metricnoop.NewMeterProvider())
         if err != nil </span><span class="cov0" title="0">{
                 t.Fatalf("failed to build noop http client metrics: %v", err)
         }</span>
-        <span class="cov6" title="27">return hm</span>
+        <span class="cov8" title="1">return hm</span>
 }
 
 // NewNoopOutboxMetrics は、テスト用に no-op の MeterProvider から OutboxMetrics を生成します。
-func NewNoopOutboxMetrics(t *testing.T) *OutboxMetrics <span class="cov5" title="14">{
+func NewNoopOutboxMetrics(t *testing.T) *OutboxMetrics <span class="cov8" title="1">{
         t.Helper()
         om, err := NewOutboxMetrics(metricnoop.NewMeterProvider())
         if err != nil </span><span class="cov0" title="0">{
                 t.Fatalf("failed to build noop outbox metrics: %v", err)
         }</span>
-        <span class="cov5" title="14">return om</span>
+        <span class="cov8" title="1">return om</span>
 }
 
 // NewNoopHTTPClientTransport は、テスト用に no-op TracerProvider と実 propagator から HTTPClientTransport を
 // 生成します。SSRF ガードは無効化（loopback/httptest 宛てを許可）します。
-func NewNoopHTTPClientTransport(t *testing.T) *HTTPClientTransport <span class="cov6" title="27">{
+func NewNoopHTTPClientTransport(t *testing.T) *HTTPClientTransport <span class="cov8" title="1">{
         t.Helper()
         return newHTTPClientTransport(noop.NewTracerProvider(), NewTextMapPropagator(), permissiveDialControl)
 }</span>
 
 // NewStubSpanContext は、テスト用のスタブSpanコンテキストを返します。
-func NewStubSpanContext(t *testing.T) (context.Context, func()) <span class="cov5" title="15">{
+func NewStubSpanContext(t *testing.T) (context.Context, func()) <span class="cov8" title="1">{
         t.Helper()
 
         tp := sdktrace.NewTracerProvider()
@@ -16754,7 +16745,7 @@ func NewStubSpanContext(t *testing.T) (context.Context, func()) <span class="cov
 
         ctx, span := tr.Start(context.Background(), span)
 
-        return ctx, func() </span><span class="cov5" title="15">{
+        return ctx, func() </span><span class="cov8" title="1">{
                 span.End()
                 _ = tp.Shutdown(context.Background())
         }</span>
@@ -16786,7 +16777,7 @@ type tracerFactory struct {
 }
 
 // NewTracerFactory は、TracerFactory を初期化して返します。
-func NewTracerFactory(tp trace.TracerProvider) TracerFactory <span class="cov9" title="282">{
+func NewTracerFactory(tp trace.TracerProvider) TracerFactory <span class="cov8" title="1">{
         return &amp;tracerFactory{
                 tp: tp,
         }
@@ -16796,7 +16787,7 @@ func NewTracerFactory(tp trace.TracerProvider) TracerFactory <span class="cov9" 
 // 呼び出し階層に依存するため、共通ヘルパへ括り出すと pkg 解決が 1 段ずれて壊れる。
 
 // Controller は Controller 層用のトレーサーを返します。
-func (t *tracerFactory) Controller() LayerTracer <span class="cov8" title="175">{
+func (t *tracerFactory) Controller() LayerTracer <span class="cov8" title="1">{
         full := getCallerFullName()
         pkg := fnmeta.ExtractPackageName(full)
 
@@ -16804,7 +16795,7 @@ func (t *tracerFactory) Controller() LayerTracer <span class="cov8" title="175">
 }</span>
 
 // Usecase は Usecase 層用のトレーサーを返します。
-func (t *tracerFactory) Usecase() LayerTracer <span class="cov7" title="77">{
+func (t *tracerFactory) Usecase() LayerTracer <span class="cov8" title="1">{
         full := getCallerFullName()
         pkg := fnmeta.ExtractPackageName(full)
 
@@ -16812,7 +16803,7 @@ func (t *tracerFactory) Usecase() LayerTracer <span class="cov7" title="77">{
 }</span>
 
 // Infra は Infrastructure 層用のトレーサーを返します。
-func (t *tracerFactory) Infra() LayerTracer <span class="cov8" title="107">{
+func (t *tracerFactory) Infra() LayerTracer <span class="cov8" title="1">{
         full := getCallerFullName()
         pkg := fnmeta.ExtractPackageName(full)
 
@@ -16820,7 +16811,7 @@ func (t *tracerFactory) Infra() LayerTracer <span class="cov8" title="107">{
 }</span>
 
 // newLayerTracer は LayerTracer を初期化して返します。
-func (t *tracerFactory) newLayerTracer(layer layerName, pkgName string) LayerTracer <span class="cov10" title="360">{
+func (t *tracerFactory) newLayerTracer(layer layerName, pkgName string) LayerTracer <span class="cov8" title="1">{
         return LayerTracer{
                 tracer:  t.tp.Tracer(string(layer) + delimiter + pkgName),
                 layer:   layer,
@@ -16863,7 +16854,7 @@ type meterBuilder struct {
 
 // NewWorkerMetrics は、注入された MeterProvider から worker engine の計装一式を生成します。
 // いずれかの計装生成失敗で error を返します。
-func NewWorkerMetrics(mp metric.MeterProvider) (*WorkerMetrics, error) <span class="cov6" title="50">{
+func NewWorkerMetrics(mp metric.MeterProvider) (*WorkerMetrics, error) <span class="cov8" title="1">{
         b := &amp;meterBuilder{m: mp.Meter(workerMeterName)}
         wm := &amp;WorkerMetrics{
                 received:     b.counter("worker.received", "受信したメッセージ数"),
@@ -16876,73 +16867,73 @@ func NewWorkerMetrics(mp metric.MeterProvider) (*WorkerMetrics, error) <span cla
                 latencyMs:    b.histogram("worker.processing_latency_ms", "Handle の処理時間(ミリ秒)"),
                 inFlight:     b.upDownCounter("worker.in_flight", "処理中(受信済み・未確定)のメッセージ数"),
         }
-        if b.err != nil </span><span class="cov2" title="3">{
+        if b.err != nil </span><span class="cov8" title="1">{
                 return nil, b.err
         }</span>
-        <span class="cov6" title="47">return wm, nil</span>
+        <span class="cov8" title="1">return wm, nil</span>
 }
 
 // Received は、受信したメッセージ数を計上します。
-func (m *WorkerMetrics) Received(ctx context.Context, n int64) <span class="cov8" title="171">{ m.received.Add(ctx, n) }</span>
+func (m *WorkerMetrics) Received(ctx context.Context, n int64) <span class="cov8" title="1">{ m.received.Add(ctx, n) }</span>
 
 // Processed は、正常処理したメッセージ数を計上します。
-func (m *WorkerMetrics) Processed(ctx context.Context) <span class="cov5" title="20">{ m.processed.Add(ctx, 1) }</span>
+func (m *WorkerMetrics) Processed(ctx context.Context) <span class="cov8" title="1">{ m.processed.Add(ctx, 1) }</span>
 
 // Failed は、処理に失敗したメッセージ数を計上します。
-func (m *WorkerMetrics) Failed(ctx context.Context) <span class="cov8" title="158">{ m.failed.Add(ctx, 1) }</span>
+func (m *WorkerMetrics) Failed(ctx context.Context) <span class="cov8" title="1">{ m.failed.Add(ctx, 1) }</span>
 
 // Retried は、Nack して再配送へ戻したメッセージ数を計上します。
-func (m *WorkerMetrics) Retried(ctx context.Context) <span class="cov8" title="156">{ m.retried.Add(ctx, 1) }</span>
+func (m *WorkerMetrics) Retried(ctx context.Context) <span class="cov8" title="1">{ m.retried.Add(ctx, 1) }</span>
 
 // DLQ は、FailureHandler へ退避したメッセージ数を計上します。
-func (m *WorkerMetrics) DLQ(ctx context.Context) <span class="cov1" title="2">{ m.dlq.Add(ctx, 1) }</span>
+func (m *WorkerMetrics) DLQ(ctx context.Context) <span class="cov8" title="1">{ m.dlq.Add(ctx, 1) }</span>
 
 // PollError は、Receive のエラー回数を計上します。
-func (m *WorkerMetrics) PollError(ctx context.Context) <span class="cov2" title="3">{ m.pollErrors.Add(ctx, 1) }</span>
+func (m *WorkerMetrics) PollError(ctx context.Context) <span class="cov8" title="1">{ m.pollErrors.Add(ctx, 1) }</span>
 
 // ExtendError は、Extend(ハートビート)のエラー回数を計上します。
-func (m *WorkerMetrics) ExtendError(ctx context.Context) <span class="cov2" title="3">{ m.extendErrors.Add(ctx, 1) }</span>
+func (m *WorkerMetrics) ExtendError(ctx context.Context) <span class="cov8" title="1">{ m.extendErrors.Add(ctx, 1) }</span>
 
 // RecordLatencyMs は、Handle の処理時間(ミリ秒)を記録します。
-func (m *WorkerMetrics) RecordLatencyMs(ctx context.Context, ms float64) <span class="cov8" title="176">{ m.latencyMs.Record(ctx, ms) }</span>
+func (m *WorkerMetrics) RecordLatencyMs(ctx context.Context, ms float64) <span class="cov8" title="1">{ m.latencyMs.Record(ctx, ms) }</span>
 
 // InFlightAdd は、処理中(受信済み・未確定)のメッセージ数を増減します。
-func (m *WorkerMetrics) InFlightAdd(ctx context.Context, delta int64) <span class="cov9" title="363">{ m.inFlight.Add(ctx, delta) }</span>
+func (m *WorkerMetrics) InFlightAdd(ctx context.Context, delta int64) <span class="cov8" title="1">{ m.inFlight.Add(ctx, delta) }</span>
 
-func (b *meterBuilder) counter(name, desc string) metric.Int64Counter <span class="cov10" title="537">{
-        if b.err != nil </span><span class="cov4" title="11">{
+func (b *meterBuilder) counter(name, desc string) metric.Int64Counter <span class="cov8" title="1">{
+        if b.err != nil </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov9" title="526">c, err := b.m.Int64Counter(name, metric.WithDescription(desc))
-        if err != nil </span><span class="cov2" title="3">{
+        <span class="cov8" title="1">c, err := b.m.Int64Counter(name, metric.WithDescription(desc))
+        if err != nil </span><span class="cov8" title="1">{
                 b.err = xerrors.Wrap(err, name)
                 return nil
         }</span>
-        <span class="cov9" title="523">return c</span>
+        <span class="cov8" title="1">return c</span>
 }
 
-func (b *meterBuilder) histogram(name, desc string) metric.Float64Histogram <span class="cov7" title="88">{
-        if b.err != nil </span><span class="cov1" title="2">{
+func (b *meterBuilder) histogram(name, desc string) metric.Float64Histogram <span class="cov8" title="1">{
+        if b.err != nil </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov7" title="86">h, err := b.m.Float64Histogram(name, metric.WithDescription(desc), metric.WithUnit("ms"))
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">h, err := b.m.Float64Histogram(name, metric.WithDescription(desc), metric.WithUnit("ms"))
+        if err != nil </span><span class="cov8" title="1">{
                 b.err = xerrors.Wrap(err, name)
                 return nil
         }</span>
-        <span class="cov7" title="85">return h</span>
+        <span class="cov8" title="1">return h</span>
 }
 
-func (b *meterBuilder) upDownCounter(name, desc string) metric.Int64UpDownCounter <span class="cov7" title="88">{
-        if b.err != nil </span><span class="cov2" title="3">{
+func (b *meterBuilder) upDownCounter(name, desc string) metric.Int64UpDownCounter <span class="cov8" title="1">{
+        if b.err != nil </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov7" title="85">c, err := b.m.Int64UpDownCounter(name, metric.WithDescription(desc))
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">c, err := b.m.Int64UpDownCounter(name, metric.WithDescription(desc))
+        if err != nil </span><span class="cov8" title="1">{
                 b.err = xerrors.Wrap(err, name)
                 return nil
         }</span>
-        <span class="cov7" title="84">return c</span>
+        <span class="cov8" title="1">return c</span>
 }
 </pre>
 		
@@ -16964,7 +16955,7 @@ type buildInfo struct {
 }
 
 // NewBuildInfo は、ビルド時 ldflags で埋め込まれた Version / Revision / BuildDate パッケージ変数から BuildInfo を生成して返します。
-func NewBuildInfo() BuildInfo <span class="cov9" title="34">{
+func NewBuildInfo() BuildInfo <span class="cov8" title="1">{
         return &amp;buildInfo{
                 version:   Version,
                 revision:  Revision,
@@ -16973,13 +16964,13 @@ func NewBuildInfo() BuildInfo <span class="cov9" title="34">{
 }</span>
 
 // Version はバージョン文字列を返します。
-func (bi *buildInfo) Version() string <span class="cov10" title="51">{ return bi.version }</span>
+func (bi *buildInfo) Version() string <span class="cov8" title="1">{ return bi.version }</span>
 
 // Revision はリビジョン文字列を返します。
-func (bi *buildInfo) Revision() string <span class="cov10" title="51">{ return bi.revision }</span>
+func (bi *buildInfo) Revision() string <span class="cov8" title="1">{ return bi.revision }</span>
 
 // BuildDate はビルド日時文字列を返します。
-func (bi *buildInfo) BuildDate() string <span class="cov10" title="51">{ return bi.buildDate }</span>
+func (bi *buildInfo) BuildDate() string <span class="cov8" title="1">{ return bi.buildDate }</span>
 </pre>
 		
 		<pre class="file" id="file215" style="display: none">// Package auth は認証に関連するインターフェースを提供します。
@@ -17013,57 +17004,57 @@ func New(
         provider string,
         scopes []string,
         claims map[string]any,
-) (*Authn, error) <span class="cov10" title="62">{
+) (*Authn, error) <span class="cov8" title="1">{
         trimmedSubject := strings.TrimSpace(subject)
-        if trimmedSubject == "" </span><span class="cov2" title="2">{
+        if trimmedSubject == "" </span><span class="cov8" title="1">{
                 return nil, ErrUnauthenticatedSubjectMissing
         }</span>
 
-        <span class="cov9" title="60">a := &amp;Authn{
+        <span class="cov8" title="1">a := &amp;Authn{
                 subject:  trimmedSubject,
                 provider: provider,
                 scopes:   slices.Clone(scopes),
                 claims:   maps.Clone(claims),
         }
 
-        if id, err := uuid.Parse(trimmedSubject); err == nil </span><span class="cov8" title="33">{
+        if id, err := uuid.Parse(trimmedSubject); err == nil </span><span class="cov8" title="1">{
                 a.id = &amp;id
         }</span>
 
-        <span class="cov9" title="60">return a, nil</span>
+        <span class="cov8" title="1">return a, nil</span>
 }
 
 // Subject は token の sub を返します。
-func (a *Authn) Subject() string <span class="cov6" title="13">{
+func (a *Authn) Subject() string <span class="cov8" title="1">{
         return a.subject
 }</span>
 
 // HasID は UUIDとして解釈できたかを返します。
-func (a *Authn) HasID() bool <span class="cov2" title="2">{
+func (a *Authn) HasID() bool <span class="cov8" title="1">{
         return a.id != nil
 }</span>
 
 // ID は UUID を返します。
 // UUID として解釈できなかった場合はエラーを返します。
-func (a *Authn) ID() (uuid.UUID, error) <span class="cov6" title="11">{
-        if a.id == nil </span><span class="cov3" title="3">{
+func (a *Authn) ID() (uuid.UUID, error) <span class="cov8" title="1">{
+        if a.id == nil </span><span class="cov8" title="1">{
                 return uuid.UUID{}, ErrSubjectNotUUID
         }</span>
-        <span class="cov5" title="8">return *a.id, nil</span>
+        <span class="cov8" title="1">return *a.id, nil</span>
 }
 
 // Provider は認証プロバイダを返します。
-func (a *Authn) Provider() string <span class="cov4" title="5">{
+func (a *Authn) Provider() string <span class="cov8" title="1">{
         return a.provider
 }</span>
 
 // Scopes はスコープ一覧を返します。
-func (a *Authn) Scopes() []string <span class="cov3" title="3">{
+func (a *Authn) Scopes() []string <span class="cov8" title="1">{
         return slices.Clone(a.scopes)
 }</span>
 
 // Claims はクレーム一覧を返します。
-func (a *Authn) Claims() map[string]any <span class="cov3" title="3">{
+func (a *Authn) Claims() map[string]any <span class="cov8" title="1">{
         return maps.Clone(a.claims)
 }</span>
 </pre>
@@ -17081,19 +17072,19 @@ type Credential struct {
 // トークンが空文字列またはホワイトスペースのみの場合は ErrTokenMissing を返します。
 func NewCredential(
         accessToken string,
-) (*Credential, error) <span class="cov10" title="12">{
+) (*Credential, error) <span class="cov8" title="1">{
         trimmedToken := strings.TrimSpace(accessToken)
-        if trimmedToken == "" </span><span class="cov3" title="2">{
+        if trimmedToken == "" </span><span class="cov8" title="1">{
                 return nil, ErrTokenMissing
         }</span>
 
-        <span class="cov9" title="10">return &amp;Credential{
+        <span class="cov8" title="1">return &amp;Credential{
                 accessToken: trimmedToken,
         }, nil</span>
 }
 
 // AccessToken はアクセストークンを返します。
-func (c *Credential) AccessToken() string <span class="cov4" title="3">{
+func (c *Credential) AccessToken() string <span class="cov8" title="1">{
         return c.accessToken
 }</span>
 </pre>
@@ -17113,7 +17104,7 @@ const (
 type Action string
 
 // String は、Action の文字列表現を返します。
-func (a Action) String() string <span class="cov10" title="3">{ return string(a) }</span>
+func (a Action) String() string <span class="cov8" title="1">{ return string(a) }</span>
 </pre>
 		
 		<pre class="file" id="file218" style="display: none">package authz
@@ -17133,16 +17124,16 @@ type Resource struct {
 // NewResource は、種別と所有者 ID から Resource を生成します。
 // ownerID は防御的にコピーして保持するため、呼出元が渡したポインタの後続変更や
 // スタック寿命に Resource は影響されません（Authorize が非同期実装でも安全）。
-func NewResource(kind string, ownerID *uuid.UUID) *Resource <span class="cov10" title="34">{
+func NewResource(kind string, ownerID *uuid.UUID) *Resource <span class="cov8" title="1">{
         return &amp;Resource{kind: kind, ownerID: ptr.Copy(ownerID)}
 }</span>
 
 // Kind は、リソース種別を返します。
-func (r *Resource) Kind() string <span class="cov3" title="3">{ return r.kind }</span>
+func (r *Resource) Kind() string <span class="cov8" title="1">{ return r.kind }</span>
 
 // OwnerID は、リソース所有者の ID を返します（nil の場合は所有者概念なし）。
 // 内部状態を保護するためコピーを返します。
-func (r *Resource) OwnerID() *uuid.UUID <span class="cov7" title="15">{ return ptr.Copy(r.ownerID) }</span>
+func (r *Resource) OwnerID() *uuid.UUID <span class="cov8" title="1">{ return ptr.Copy(r.ownerID) }</span>
 </pre>
 		
 		<pre class="file" id="file219" style="display: none">package testkit
@@ -17171,12 +17162,12 @@ type StepClock struct {
 }
 
 // NewStepClock は、開始時刻 start から Sleep ごとに step だけ進む StepClock を生成します。
-func NewStepClock(start time.Time, step time.Duration) *StepClock <span class="cov5" title="5">{
+func NewStepClock(start time.Time, step time.Duration) *StepClock <span class="cov8" title="1">{
         return &amp;StepClock{now: start, step: step}
 }</span>
 
 // Now は、現在の（fake）時刻を返します。
-func (c *StepClock) Now() time.Time <span class="cov10" title="23">{
+func (c *StepClock) Now() time.Time <span class="cov8" title="1">{
         c.mu.Lock()
         defer c.mu.Unlock()
         return c.now
@@ -17184,11 +17175,11 @@ func (c *StepClock) Now() time.Time <span class="cov10" title="23">{
 
 // Sleep は、実際には待機しません。呼び出し時点で ctx が既にキャンセル / 期限切れの場合は
 // 現在時刻を前進させずその error を返し、そうでなければ step だけ進めて nil を返します。
-func (c *StepClock) Sleep(ctx context.Context, _ time.Duration) error <span class="cov5" title="5">{
-        if err := ctx.Err(); err != nil </span><span class="cov1" title="1">{
+func (c *StepClock) Sleep(ctx context.Context, _ time.Duration) error <span class="cov8" title="1">{
+        if err := ctx.Err(); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov4" title="4">c.mu.Lock()
+        <span class="cov8" title="1">c.mu.Lock()
         c.now = c.now.Add(c.step)
         c.mu.Unlock()
         return nil</span>
@@ -17209,7 +17200,7 @@ import (
 )
 
 // NewMockClock は、常に now を返すテスト用のクロックを生成します（呼び出し回数は問いません）。
-func NewMockClock(t *testing.T, now time.Time) clock.Clock <span class="cov10" title="62">{
+func NewMockClock(t *testing.T, now time.Time) clock.Clock <span class="cov8" title="1">{
         t.Helper()
         ctrl := gomock.NewController(t)
         clk := mock_clock.NewMockClock(ctrl)
@@ -17218,7 +17209,7 @@ func NewMockClock(t *testing.T, now time.Time) clock.Clock <span class="cov10" t
 }</span>
 
 // NewMockClockOnce は、now を返すテスト用のクロックを生成します（Now が 1 回だけ呼ばれることを検証）。
-func NewMockClockOnce(t *testing.T, now time.Time) clock.Clock <span class="cov8" title="33">{
+func NewMockClockOnce(t *testing.T, now time.Time) clock.Clock <span class="cov8" title="1">{
         t.Helper()
         ctrl := gomock.NewController(t)
         clk := mock_clock.NewMockClock(ctrl)
@@ -17227,7 +17218,7 @@ func NewMockClockOnce(t *testing.T, now time.Time) clock.Clock <span class="cov8
 }</span>
 
 // NewNoopSleeper は、待機せず即座に nil を返すテスト用の sleeper を生成します（呼び出し回数は問いません）。
-func NewNoopSleeper(t *testing.T) clock.Sleeper <span class="cov7" title="23">{
+func NewNoopSleeper(t *testing.T) clock.Sleeper <span class="cov8" title="1">{
         t.Helper()
         ctrl := gomock.NewController(t)
         s := mock_clock.NewMockSleeper(ctrl)
@@ -17257,17 +17248,17 @@ type Manager interface {
 // DoWithResult は、トランザクション内で値を取得するためのヘルパー関数です。
 func DoWithResult[T any](
         ctx context.Context, m Manager, fn func(ctx context.Context) (T, error),
-) (T, error) <span class="cov10" title="19">{
+) (T, error) <span class="cov8" title="1">{
         var result T
-        if err := m.Do(ctx, func(ctx context.Context) error </span><span class="cov10" title="19">{
+        if err := m.Do(ctx, func(ctx context.Context) error </span><span class="cov8" title="1">{
                 var err error
                 result, err = fn(ctx)
                 return err
-        }</span>); err != nil <span class="cov7" title="8">{
+        }</span>); err != nil <span class="cov8" title="1">{
                 var zero T
                 return zero, err
         }</span>
-        <span class="cov8" title="10">return result, nil</span>
+        <span class="cov8" title="1">return result, nil</span>
 }
 </pre>
 		
@@ -17316,7 +17307,7 @@ type Fake struct {
 }
 
 // NewFake は、空の Fake を生成します。
-func NewFake() *Fake <span class="cov6" title="47">{
+func NewFake() *Fake <span class="cov8" title="1">{
         return &amp;Fake{
                 inflight:     make(map[string]worker.Message),
                 delivery:     make(map[string]int),
@@ -17327,19 +17318,19 @@ func NewFake() *Fake <span class="cov6" title="47">{
 }</span>
 
 // Receive は、最大 limit 件を取得します。キューが空の場合は投入 or ctx 完了までブロックします。
-func (f *Fake) Receive(ctx context.Context, limit int) ([]worker.Message, error) <span class="cov9" title="198">{
-        for </span><span class="cov10" title="350">{
+func (f *Fake) Receive(ctx context.Context, limit int) ([]worker.Message, error) <span class="cov8" title="1">{
+        for </span><span class="cov8" title="1">{
                 f.mu.Lock()
-                if len(f.receiveErrs) &gt; 0 </span><span class="cov3" title="4">{
+                if len(f.receiveErrs) &gt; 0 </span><span class="cov8" title="1">{
                         err := f.receiveErrs[0]
                         f.receiveErrs = f.receiveErrs[1:]
                         f.mu.Unlock()
                         return nil, err
                 }</span>
-                <span class="cov9" title="346">if len(f.queue) &gt; 0 </span><span class="cov8" title="178">{
+                <span class="cov8" title="1">if len(f.queue) &gt; 0 </span><span class="cov8" title="1">{
                         n := min(limit, len(f.queue))
                         out := make([]worker.Message, 0, n)
-                        for range n </span><span class="cov9" title="190">{
+                        for range n </span><span class="cov8" title="1">{
                                 m := f.queue[0]
                                 f.queue = f.queue[1:]
                                 f.delivery[m.ID]++
@@ -17347,23 +17338,23 @@ func (f *Fake) Receive(ctx context.Context, limit int) ([]worker.Message, error)
                                 f.inflight[m.ID] = m
                                 out = append(out, m)
                         }</span>
-                        <span class="cov8" title="178">f.mu.Unlock()
+                        <span class="cov8" title="1">f.mu.Unlock()
                         return out, nil</span>
                 }
-                <span class="cov8" title="168">notify := f.notify
+                <span class="cov8" title="1">notify := f.notify
                 f.mu.Unlock()
 
                 select </span>{
-                case &lt;-ctx.Done():<span class="cov5" title="16">
+                case &lt;-ctx.Done():<span class="cov8" title="1">
                         return nil, ctx.Err()</span>
-                case &lt;-notify:<span class="cov8" title="152"></span>
+                case &lt;-notify:<span class="cov8" title="1"></span>
                         // メッセージ投入 or 再配送で起床。ループ先頭で再評価する。
                 }
         }
 }
 
 // Ack は、メッセージを in-flight から除去し、記録します。
-func (f *Fake) Ack(_ context.Context, m worker.Message) error <span class="cov5" title="21">{
+func (f *Fake) Ack(_ context.Context, m worker.Message) error <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         delete(f.inflight, m.ID)
@@ -17372,7 +17363,7 @@ func (f *Fake) Ack(_ context.Context, m worker.Message) error <span class="cov5"
 }</span>
 
 // Nack は、メッセージを即時に再配送（キュー末尾へ戻す）し、記録します。
-func (f *Fake) Nack(_ context.Context, m worker.Message) error <span class="cov1" title="1">{
+func (f *Fake) Nack(_ context.Context, m worker.Message) error <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         f.nackLocked(m)
@@ -17381,7 +17372,7 @@ func (f *Fake) Nack(_ context.Context, m worker.Message) error <span class="cov1
 
 // NackWithBackoff は、要求された遅延 d を記録したうえでメッセージを再配送します。
 // in-memory fake は実時間の遅延は模さず、d の記録のみ行います（テストで NackBackoffOf により検証）。
-func (f *Fake) NackWithBackoff(_ context.Context, m worker.Message, d time.Duration) error <span class="cov8" title="156">{
+func (f *Fake) NackWithBackoff(_ context.Context, m worker.Message, d time.Duration) error <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         f.nackBackoffs[m.ID] = d
@@ -17391,7 +17382,7 @@ func (f *Fake) NackWithBackoff(_ context.Context, m worker.Message, d time.Durat
 
 // Extend は、Extend の呼び出し回数を記録します（可視性の実時間延長は模さない）。
 // SetExtendErr でエラーが設定されている場合はそのエラーを返します。
-func (f *Fake) Extend(_ context.Context, m worker.Message, _ time.Duration) error <span class="cov3" title="7">{
+func (f *Fake) Extend(_ context.Context, m worker.Message, _ time.Duration) error <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         f.extends[m.ID]++
@@ -17399,7 +17390,7 @@ func (f *Fake) Extend(_ context.Context, m worker.Message, _ time.Duration) erro
 }</span>
 
 // Fail は、FailureHandler としての退避を記録します。
-func (f *Fake) Fail(_ context.Context, m worker.Message, cause error) error <span class="cov2" title="2">{
+func (f *Fake) Fail(_ context.Context, m worker.Message, cause error) error <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         f.failed = append(f.failed, FailedRecord{Message: m, Cause: cause})
@@ -17409,7 +17400,7 @@ func (f *Fake) Fail(_ context.Context, m worker.Message, cause error) error <spa
 // --- テスト操作・検証用ヘルパー ---
 
 // Enqueue は、メッセージをキューに投入します。
-func (f *Fake) Enqueue(msgs ...worker.Message) <span class="cov6" title="36">{
+func (f *Fake) Enqueue(msgs ...worker.Message) <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         f.queue = append(f.queue, msgs...)
@@ -17417,7 +17408,7 @@ func (f *Fake) Enqueue(msgs ...worker.Message) <span class="cov6" title="36">{
 }</span>
 
 // FailReceiveOnce は、次回以降の Receive で返すエラーを 1 件キューイングします（複数回呼べば順に消費）。
-func (f *Fake) FailReceiveOnce(err error) <span class="cov3" title="4">{
+func (f *Fake) FailReceiveOnce(err error) <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         f.receiveErrs = append(f.receiveErrs, err)
@@ -17425,35 +17416,35 @@ func (f *Fake) FailReceiveOnce(err error) <span class="cov3" title="4">{
 }</span>
 
 // SetExtendErr は、以降の Extend が常に返すエラーを設定します。
-func (f *Fake) SetExtendErr(err error) <span class="cov2" title="2">{
+func (f *Fake) SetExtendErr(err error) <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         f.extendErr = err
 }</span>
 
 // AckedIDs は、Ack されたメッセージ ID の一覧（呼び出し順）を返します。
-func (f *Fake) AckedIDs() []string <span class="cov7" title="59">{
+func (f *Fake) AckedIDs() []string <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         return append([]string(nil), f.acked...)
 }</span>
 
 // NackedIDs は、Nack されたメッセージ ID の一覧（呼び出し順）を返します。
-func (f *Fake) NackedIDs() []string <span class="cov4" title="11">{
+func (f *Fake) NackedIDs() []string <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         return append([]string(nil), f.nacked...)
 }</span>
 
 // ExtendCount は、指定 ID の Extend 呼び出し回数を返します。
-func (f *Fake) ExtendCount(id string) int <span class="cov4" title="9">{
+func (f *Fake) ExtendCount(id string) int <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         return f.extends[id]
 }</span>
 
 // NackBackoffOf は、指定 ID に対し NackWithBackoff で要求された遅延を返します（未記録は 0）。
-func (f *Fake) NackBackoffOf(id string) time.Duration <span class="cov2" title="2">{
+func (f *Fake) NackBackoffOf(id string) time.Duration <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         return f.nackBackoffs[id]
@@ -17461,7 +17452,7 @@ func (f *Fake) NackBackoffOf(id string) time.Duration <span class="cov2" title="
 
 // NackBackoffApplied は、指定 ID に対し NackWithBackoff が呼ばれたかを返します。
 // full jitter で遅延が 0 になり得るため、遅延値ではなく呼び出し有無で判定します。
-func (f *Fake) NackBackoffApplied(id string) bool <span class="cov3" title="4">{
+func (f *Fake) NackBackoffApplied(id string) bool <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         _, ok := f.nackBackoffs[id]
@@ -17469,28 +17460,28 @@ func (f *Fake) NackBackoffApplied(id string) bool <span class="cov3" title="4">{
 }</span>
 
 // Failed は、Fail の呼び出し記録（呼び出し順）を返します。
-func (f *Fake) Failed() []FailedRecord <span class="cov3" title="4">{
+func (f *Fake) Failed() []FailedRecord <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         return append([]FailedRecord(nil), f.failed...)
 }</span>
 
 // QueueLen は、受信待ちのメッセージ数を返します。
-func (f *Fake) QueueLen() int <span class="cov2" title="2">{
+func (f *Fake) QueueLen() int <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         return len(f.queue)
 }</span>
 
 // InflightLen は、受信済み・未 Ack/Nack のメッセージ数を返します。
-func (f *Fake) InflightLen() int <span class="cov3" title="7">{
+func (f *Fake) InflightLen() int <span class="cov8" title="1">{
         f.mu.Lock()
         defer f.mu.Unlock()
         return len(f.inflight)
 }</span>
 
 // nackLocked は、メッセージを再配送し記録します（呼び出し側で mu ロック済み）。
-func (f *Fake) nackLocked(m worker.Message) <span class="cov8" title="157">{
+func (f *Fake) nackLocked(m worker.Message) <span class="cov8" title="1">{
         delete(f.inflight, m.ID)
         f.nacked = append(f.nacked, m.ID)
         f.queue = append(f.queue, m)
@@ -17498,7 +17489,7 @@ func (f *Fake) nackLocked(m worker.Message) <span class="cov8" title="157">{
 }</span>
 
 // signal は、long-poll 中の Receive を起床させます。呼び出しは mu ロック下で行います。
-func (f *Fake) signal() <span class="cov9" title="197">{
+func (f *Fake) signal() <span class="cov8" title="1">{
         close(f.notify)
         f.notify = make(chan struct{})
 }</span>
@@ -17529,7 +17520,7 @@ type usecase struct {
 }
 
 // New は、為替換算ユースケースを生成します。
-func New(gateway boundary.Gateway, tf observability.TracerFactory) Usecase <span class="cov10" title="4">{
+func New(gateway boundary.Gateway, tf observability.TracerFactory) Usecase <span class="cov8" title="1">{
         return &amp;usecase{
                 gateway: gateway,
                 tracer:  tf.Usecase(),
@@ -17537,15 +17528,15 @@ func New(gateway boundary.Gateway, tf observability.TracerFactory) Usecase <span
 }</span>
 
 // Convert は、amount（base 通貨建て）を quote 通貨へ換算した値を返します。
-func (u *usecase) Convert(ctx context.Context, base, quote string, amount float64) (float64, error) <span class="cov5" title="2">{
+func (u *usecase) Convert(ctx context.Context, base, quote string, amount float64) (float64, error) <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
         rate, err := u.gateway.GetRate(ctx, base, quote)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return 0, err
         }</span>
-        <span class="cov1" title="1">return amount * rate.Value, nil</span>
+        <span class="cov8" title="1">return amount * rate.Value, nil</span>
 }
 </pre>
 		
@@ -17594,7 +17585,7 @@ type Usecase interface {
 }
 
 // New は、システムの健全性チェックに関するユースケースを初期化します。
-func New(dbsq query.DBSystemQuery, tf observability.TracerFactory, clock clock.Clock) Usecase <span class="cov10" title="2">{
+func New(dbsq query.DBSystemQuery, tf observability.TracerFactory, clock clock.Clock) Usecase <span class="cov8" title="1">{
         return &amp;usecase{
                 tracer:        tf.Usecase(),
                 clock:         clock,
@@ -17603,17 +17594,17 @@ func New(dbsq query.DBSystemQuery, tf observability.TracerFactory, clock clock.C
 }</span>
 
 // CheckHealth は、システムの健全性をチェックするユースケースです。
-func (u *usecase) CheckHealth(ctx context.Context) (*DTO, error) <span class="cov10" title="2">{
+func (u *usecase) CheckHealth(ctx context.Context) (*DTO, error) <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
         applTime := u.clock.Now()
         dbHealth, err := u.dbSystemQuery.CheckDBHealth(ctx)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov1" title="1">return &amp;DTO{
+        <span class="cov8" title="1">return &amp;DTO{
                 Status:          Ok,
                 ApplicationTime: applTime,
                 DBHealthCheck:   dbHealth,
@@ -17644,12 +17635,12 @@ type Request struct {
 }
 
 // WithRequest は、冪等性 Request を ctx へ載せます（入り口 middleware が使用）。
-func WithRequest(ctx context.Context, r Request) context.Context <span class="cov9" title="26">{
+func WithRequest(ctx context.Context, r Request) context.Context <span class="cov8" title="1">{
         return context.WithValue(ctx, requestCtxKey{}, r)
 }</span>
 
 // requestFromContext は、ctx から冪等性 Request を取り出します（無ければ ok=false＝非冪等）。
-func requestFromContext(ctx context.Context) (Request, bool) <span class="cov10" title="32">{
+func requestFromContext(ctx context.Context) (Request, bool) <span class="cov8" title="1">{
         r, ok := ctx.Value(requestCtxKey{}).(Request)
         return r, ok
 }</span>
@@ -17670,7 +17661,7 @@ func NewDeps(
         store idempotencybndry.Store,
         clk clock.Clock,
         metrics Metrics,
-) Deps <span class="cov10" title="3">{
+) Deps <span class="cov8" title="1">{
         return Deps{
                 Txm:     txm,
                 Store:   store,
@@ -17719,44 +17710,44 @@ type gcUsecase struct {
 type nopGCMetrics struct{}
 
 // NewGC は、GCUsecase を生成します。metrics が nil の場合はカウンタ操作が no-op になります。
-func NewGC(store idempotencybndry.Store, clk clock.Clock, metrics GCMetrics) GCUsecase <span class="cov10" title="14">{
+func NewGC(store idempotencybndry.Store, clk clock.Clock, metrics GCMetrics) GCUsecase <span class="cov8" title="1">{
         return &amp;gcUsecase{store: store, clock: clk, metricsImpl: metrics}
 }</span>
 
 // SweepExpired は、失効行を batchSize 件ずつ削除し、合計削除件数を返します。
-func (g *gcUsecase) SweepExpired(ctx context.Context, batchSize int32) (int64, error) <span class="cov8" title="8">{
-        if batchSize &lt;= 0 </span><span class="cov3" title="2">{
+func (g *gcUsecase) SweepExpired(ctx context.Context, batchSize int32) (int64, error) <span class="cov8" title="1">{
+        if batchSize &lt;= 0 </span><span class="cov8" title="1">{
                 batchSize = DefaultGCBatchSize
         }</span>
-        <span class="cov8" title="8">cutoff := g.clock.Now()
+        <span class="cov8" title="1">cutoff := g.clock.Now()
 
         var total int64
-        for </span><span class="cov9" title="11">{
+        for </span><span class="cov8" title="1">{
                 deleted, err := g.store.DeleteExpired(ctx, cutoff, batchSize)
-                if err != nil </span><span class="cov4" title="3">{
+                if err != nil </span><span class="cov8" title="1">{
                         g.metrics().IncExpiredCleanupFailure(ctx)
                         return total, err
                 }</span>
-                <span class="cov8" title="8">if deleted &gt; 0 </span><span class="cov7" title="6">{
+                <span class="cov8" title="1">if deleted &gt; 0 </span><span class="cov8" title="1">{
                         g.metrics().IncExpiredCleanup(ctx, deleted)
                 }</span>
-                <span class="cov8" title="8">total += deleted
+                <span class="cov8" title="1">total += deleted
                 // バッチが満たなかった = もう失効行は無い。
-                if deleted &lt; int64(batchSize) </span><span class="cov6" title="5">{
+                if deleted &lt; int64(batchSize) </span><span class="cov8" title="1">{
                         return total, nil
                 }</span>
         }
 }
 
-func (g *gcUsecase) metrics() GCMetrics <span class="cov8" title="9">{
-        if g.metricsImpl == nil </span><span class="cov7" title="6">{
+func (g *gcUsecase) metrics() GCMetrics <span class="cov8" title="1">{
+        if g.metricsImpl == nil </span><span class="cov8" title="1">{
                 return nopGCMetrics{}
         }</span>
-        <span class="cov4" title="3">return g.metricsImpl</span>
+        <span class="cov8" title="1">return g.metricsImpl</span>
 }
 
-func (nopGCMetrics) IncExpiredCleanup(context.Context, int64) {<span class="cov5" title="4">}</span>
-func (nopGCMetrics) IncExpiredCleanupFailure(context.Context) {<span class="cov3" title="2">}</span>
+func (nopGCMetrics) IncExpiredCleanup(context.Context, int64) {<span class="cov8" title="1">}</span>
+func (nopGCMetrics) IncExpiredCleanupFailure(context.Context) {<span class="cov8" title="1">}</span>
 </pre>
 		
 		<pre class="file" id="file228" style="display: none">//go:generate mockgen -source=$GOFILE -destination=mock/mock_$GOFILE.gen.go -package=mock_$GOPACKAGE
@@ -17817,16 +17808,16 @@ func Run[T any](
         deps Deps,
         successStatus int,
         businessFn func(ctx context.Context) (T, error),
-) (T, bool, error) <span class="cov10" title="28">{
+) (T, bool, error) <span class="cov8" title="1">{
         req, ok := requestFromContext(ctx)
-        if !ok || req.Scope == "" </span><span class="cov5" title="5">{
+        if !ok || req.Scope == "" </span><span class="cov8" title="1">{
                 res, err := businessFn(ctx)
                 return res, false, err
         }</span>
 
-        <span class="cov9" title="23">var result T
+        <span class="cov8" title="1">var result T
         var replayed bool
-        err := deps.Txm.Do(ctx, func(ctx context.Context) error </span><span class="cov9" title="23">{
+        err := deps.Txm.Do(ctx, func(ctx context.Context) error </span><span class="cov8" title="1">{
                 claimed, err := deps.Store.Claim(ctx, idempotencybndry.ClaimParams{
                         Scope:       req.Scope,
                         Key:         req.Key,
@@ -17835,100 +17826,100 @@ func Run[T any](
                         Fingerprint: req.Fingerprint,
                         ExpiresAt:   deps.Clock.Now().Add(ttl),
                 })
-                if err != nil </span><span class="cov4" title="4">{
-                        if xerrors.Is(err, idempotencybndry.ErrLockTimeout) </span><span class="cov2" title="2">{
+                if err != nil </span><span class="cov8" title="1">{
+                        if xerrors.Is(err, idempotencybndry.ErrLockTimeout) </span><span class="cov8" title="1">{
                                 deps.metrics().IncConflict(ctx, req.OperationID)
                                 return xerrors.Wrap(apperror.ErrConflict, "idempotency key is being processed, retry later")
                         }</span>
-                        <span class="cov2" title="2">deps.metrics().IncClaimFailure(ctx, req.OperationID)
+                        <span class="cov8" title="1">deps.metrics().IncClaimFailure(ctx, req.OperationID)
                         return err</span>
                 }
 
-                <span class="cov8" title="19">if !claimed </span><span class="cov7" title="10">{
+                <span class="cov8" title="1">if !claimed </span><span class="cov8" title="1">{
                         res, replay, derr := decideExisting[T](ctx, deps, req)
-                        if derr != nil </span><span class="cov6" title="8">{
+                        if derr != nil </span><span class="cov8" title="1">{
                                 return derr
                         }</span>
-                        <span class="cov2" title="2">result, replayed = res, replay
+                        <span class="cov8" title="1">result, replayed = res, replay
                         return nil</span>
                 }
 
                 // 新規 claim 成立。業務処理を同一 tx で実行する（失敗は tx ロールバックで claim ごと解放）。
-                <span class="cov6" title="9">deps.metrics().IncMiss(ctx, req.OperationID)
+                <span class="cov8" title="1">deps.metrics().IncMiss(ctx, req.OperationID)
                 res, err := businessFn(ctx)
-                if err != nil </span><span class="cov2" title="2">{
+                if err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
-                <span class="cov6" title="7">payload, err := json.Marshal(res)
-                if err != nil </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">payload, err := json.Marshal(res)
+                if err != nil </span><span class="cov8" title="1">{
                         return xerrors.Join(apperror.ErrInternal, xerrors.Wrap(err, "failed to encode idempotent response"))
                 }</span>
-                <span class="cov5" title="6">if err := deps.Store.Complete(ctx, idempotencybndry.CompleteParams{
+                <span class="cov8" title="1">if err := deps.Store.Complete(ctx, idempotencybndry.CompleteParams{
                         Scope:           req.Scope,
                         Key:             req.Key,
                         ResponseStatus:  int32(successStatus), //nolint:gosec // HTTP ステータスコードは int32 に収まる
                         ResponsePayload: payload,
-                }); err != nil </span><span class="cov2" title="2">{
+                }); err != nil </span><span class="cov8" title="1">{
                         deps.metrics().IncCompleteFailure(ctx, req.OperationID)
                         return err
                 }</span>
-                <span class="cov4" title="4">result = res
+                <span class="cov8" title="1">result = res
                 return nil</span>
         })
-        <span class="cov9" title="23">if err != nil </span><span class="cov8" title="17">{
+        <span class="cov8" title="1">if err != nil </span><span class="cov8" title="1">{
                 var zero T
                 return zero, false, err
         }</span>
-        <span class="cov5" title="6">return result, replayed, nil</span>
+        <span class="cov8" title="1">return result, replayed, nil</span>
 }
 
 // decideExisting は、既存キー（claim 衝突）に対して replay / 409 / 422 を判定します。
 func decideExisting[T any](
         ctx context.Context, deps Deps, req Request,
-) (T, bool, error) <span class="cov7" title="10">{
+) (T, bool, error) <span class="cov8" title="1">{
         var zero T
         rec, err := deps.Store.Get(ctx, req.Scope, req.Key)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return zero, false, err
         }</span>
-        <span class="cov6" title="9">if rec == nil </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if rec == nil </span><span class="cov8" title="1">{
                 // claim 衝突直後に行が消えた稀なレース。後で再試行させる。
                 deps.metrics().IncConflict(ctx, req.OperationID)
                 return zero, false, xerrors.Wrap(apperror.ErrConflict, "idempotency key state unavailable, retry later")
         }</span>
 
-        <span class="cov6" title="7">if !bytes.Equal(rec.Fingerprint, req.Fingerprint) </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if !bytes.Equal(rec.Fingerprint, req.Fingerprint) </span><span class="cov8" title="1">{
                 deps.metrics().IncFingerprintMismatch(ctx, req.OperationID)
                 return zero, false, xerrors.Wrap(apperror.ErrValidation, "idempotency key reused with a different request")
         }</span>
 
-        <span class="cov5" title="5">if rec.Status != idempotencybndry.StatusCompleted </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">if rec.Status != idempotencybndry.StatusCompleted </span><span class="cov8" title="1">{
                 deps.metrics().IncConflict(ctx, req.OperationID)
                 return zero, false, xerrors.Wrap(apperror.ErrConflict, "idempotency key is being processed, retry later")
         }</span>
 
         // completed → 保存済み DTO を復元して replay。
-        <span class="cov3" title="3">var result T
-        if err := json.Unmarshal(rec.ResponsePayload, &amp;result); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">var result T
+        if err := json.Unmarshal(rec.ResponsePayload, &amp;result); err != nil </span><span class="cov8" title="1">{
                 return zero, false, xerrors.Join(apperror.ErrInternal, xerrors.Wrap(err, "failed to decode stored idempotent response"))
         }</span>
-        <span class="cov2" title="2">deps.metrics().IncHit(ctx, req.OperationID)
+        <span class="cov8" title="1">deps.metrics().IncHit(ctx, req.OperationID)
         return result, true, nil</span>
 }
 
-func (d Deps) metrics() Metrics <span class="cov9" title="23">{
-        if d.Metrics == nil </span><span class="cov7" title="13">{
+func (d Deps) metrics() Metrics <span class="cov8" title="1">{
+        if d.Metrics == nil </span><span class="cov8" title="1">{
                 return nopMetrics{}
         }</span>
-        <span class="cov7" title="10">return d.Metrics</span>
+        <span class="cov8" title="1">return d.Metrics</span>
 }
 
-func (nopMetrics) IncHit(context.Context, string)                 {<span class="cov1" title="1">}</span>
-func (nopMetrics) IncMiss(context.Context, string)                {<span class="cov5" title="6">}</span>
-func (nopMetrics) IncConflict(context.Context, string)            {<span class="cov3" title="3">}</span>
-func (nopMetrics) IncFingerprintMismatch(context.Context, string) {<span class="cov1" title="1">}</span>
-func (nopMetrics) IncClaimFailure(context.Context, string)        {<span class="cov1" title="1">}</span>
-func (nopMetrics) IncCompleteFailure(context.Context, string)     {<span class="cov1" title="1">}</span>
+func (nopMetrics) IncHit(context.Context, string)                 {<span class="cov8" title="1">}</span>
+func (nopMetrics) IncMiss(context.Context, string)                {<span class="cov8" title="1">}</span>
+func (nopMetrics) IncConflict(context.Context, string)            {<span class="cov8" title="1">}</span>
+func (nopMetrics) IncFingerprintMismatch(context.Context, string) {<span class="cov8" title="1">}</span>
+func (nopMetrics) IncClaimFailure(context.Context, string)        {<span class="cov8" title="1">}</span>
+func (nopMetrics) IncCompleteFailure(context.Context, string)     {<span class="cov8" title="1">}</span>
 </pre>
 		
 		<pre class="file" id="file229" style="display: none">//go:generate mockgen -source=$GOFILE -destination=mock/mock_$GOFILE.gen.go -package=mock_$GOPACKAGE
@@ -17976,13 +17967,13 @@ type emitUsecase struct {
 }
 
 // NewEmit は、EmitUsecase を生成します。
-func NewEmit(store outboxbndry.Store, tf observability.TracerFactory) EmitUsecase <span class="cov10" title="6">{
+func NewEmit(store outboxbndry.Store, tf observability.TracerFactory) EmitUsecase <span class="cov8" title="1">{
         return &amp;emitUsecase{store: store, tracer: tf.Usecase()}
 }</span>
 
 // Emit は、業務 tx 内で outbox 行を 1 行 INSERT し、採番された message_id を返します。
 // 現在の ctx の traceparent を headers へ capture し、後続の relay→受信側を起点 trace に繋ぎます。
-func (u *emitUsecase) Emit(ctx context.Context, in EmitInput) (uuid.UUID, error) <span class="cov9" title="5">{
+func (u *emitUsecase) Emit(ctx context.Context, in EmitInput) (uuid.UUID, error) <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
@@ -17992,15 +17983,15 @@ func (u *emitUsecase) Emit(ctx context.Context, in EmitInput) (uuid.UUID, error)
         observability.InjectTraceContextToCarrier(ctx, headers)
 
         var headerBytes []byte
-        if len(headers) &gt; 0 </span><span class="cov6" title="3">{
+        if len(headers) &gt; 0 </span><span class="cov8" title="1">{
                 b, err := json.Marshal(headers)
                 if err != nil </span><span class="cov0" title="0">{
                         return uuid.UUID{}, xerrors.Join(apperror.ErrInternal, xerrors.Wrap(err, "failed to encode outbox headers"))
                 }</span>
-                <span class="cov6" title="3">headerBytes = b</span>
+                <span class="cov8" title="1">headerBytes = b</span>
         }
 
-        <span class="cov9" title="5">return u.store.Insert(ctx, outboxbndry.EmitParams{
+        <span class="cov8" title="1">return u.store.Insert(ctx, outboxbndry.EmitParams{
                 AggregateType: in.AggregateType,
                 AggregateID:   in.AggregateID,
                 EventType:     in.EventType,
@@ -18042,26 +18033,26 @@ type gcUsecase struct {
 }
 
 // NewGC は、GCUsecase を生成します。
-func NewGC(store outboxbndry.Store, clk clock.Clock) GCUsecase <span class="cov10" title="10">{
+func NewGC(store outboxbndry.Store, clk clock.Clock) GCUsecase <span class="cov8" title="1">{
         return &amp;gcUsecase{store: store, clock: clk, retention: DefaultRetention}
 }</span>
 
 // SweepPublished は、retention より古い published 行を batchSize 件ずつ削除し、合計削除件数を返します。
-func (g *gcUsecase) SweepPublished(ctx context.Context, batchSize int32) (int64, error) <span class="cov6" title="4">{
-        if batchSize &lt;= 0 </span><span class="cov1" title="1">{
+func (g *gcUsecase) SweepPublished(ctx context.Context, batchSize int32) (int64, error) <span class="cov8" title="1">{
+        if batchSize &lt;= 0 </span><span class="cov8" title="1">{
                 batchSize = DefaultGCBatchSize
         }</span>
-        <span class="cov6" title="4">cutoff := g.clock.Now().Add(-g.retention)
+        <span class="cov8" title="1">cutoff := g.clock.Now().Add(-g.retention)
 
         var total int64
-        for </span><span class="cov8" title="6">{
+        for </span><span class="cov8" title="1">{
                 deleted, err := g.store.DeletePublished(ctx, cutoff, batchSize)
-                if err != nil </span><span class="cov3" title="2">{
+                if err != nil </span><span class="cov8" title="1">{
                         return total, err
                 }</span>
-                <span class="cov6" title="4">total += deleted
+                <span class="cov8" title="1">total += deleted
                 // バッチが満たなかった = もう対象行は無い。
-                if deleted &lt; int64(batchSize) </span><span class="cov3" title="2">{
+                if deleted &lt; int64(batchSize) </span><span class="cov8" title="1">{
                         return total, nil
                 }</span>
         }
@@ -18140,7 +18131,7 @@ func NewRelay(
         clk clock.Clock,
         log logging.Logger,
         tf observability.TracerFactory,
-) RelayUsecase <span class="cov10" title="19">{
+) RelayUsecase <span class="cov8" title="1">{
         return &amp;relayUsecase{
                 txm:         txm,
                 store:       store,
@@ -18155,77 +18146,77 @@ func NewRelay(
 
 // RecordLag は、最古 pending 行の経過時間（outbox lag）を SLI メトリクスへ記録します。
 // pending 行が無ければ 0 を記録します。
-func (u *relayUsecase) RecordLag(ctx context.Context) error <span class="cov5" title="4">{
+func (u *relayUsecase) RecordLag(ctx context.Context) error <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
         createdAt, ok, err := u.store.OldestPendingCreatedAt(ctx)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov4" title="3">var lag time.Duration
-        if ok </span><span class="cov3" title="2">{
-                if lag = u.clock.Now().Sub(createdAt); lag &lt; 0 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">var lag time.Duration
+        if ok </span><span class="cov8" title="1">{
+                if lag = u.clock.Now().Sub(createdAt); lag &lt; 0 </span><span class="cov8" title="1">{
                         lag = 0
                 }</span>
         }
-        <span class="cov4" title="3">u.metrics.SetLagSeconds(ctx, int64(lag.Seconds()))
+        <span class="cov8" title="1">u.metrics.SetLagSeconds(ctx, int64(lag.Seconds()))
         return nil</span>
 }
 
 // RelayBatch は、最大 batchSize 件の pending 行を 1 tx で claim → publish → mark し、結果を返します。
-func (u *relayUsecase) RelayBatch(ctx context.Context, batchSize int32) (RelayResult, error) <span class="cov8" title="13">{
+func (u *relayUsecase) RelayBatch(ctx context.Context, batchSize int32) (RelayResult, error) <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
-        if batchSize &lt;= 0 </span><span class="cov1" title="1">{
+        if batchSize &lt;= 0 </span><span class="cov8" title="1">{
                 batchSize = DefaultBatchSize
         }</span>
 
         // claim〜mark を同一 tx 内で完結させることで、多インスタンス間での二重 publish を防ぐ。
-        <span class="cov8" title="13">return tx.DoWithResult(ctx, u.txm, func(ctx context.Context) (RelayResult, error) </span><span class="cov8" title="13">{
+        <span class="cov8" title="1">return tx.DoWithResult(ctx, u.txm, func(ctx context.Context) (RelayResult, error) </span><span class="cov8" title="1">{
                 msgs, err := u.store.ClaimPending(ctx, batchSize)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return RelayResult{}, err
                 }</span>
-                <span class="cov8" title="12">res := RelayResult{Claimed: len(msgs)}
-                for i := range msgs </span><span class="cov8" title="12">{
+                <span class="cov8" title="1">res := RelayResult{Claimed: len(msgs)}
+                for i := range msgs </span><span class="cov8" title="1">{
                         published, derr := u.deliver(ctx, msgs[i])
-                        if derr != nil </span><span class="cov5" title="4">{
+                        if derr != nil </span><span class="cov8" title="1">{
                                 return RelayResult{}, derr
                         }</span>
-                        <span class="cov7" title="8">if published </span><span class="cov5" title="5">{
+                        <span class="cov8" title="1">if published </span><span class="cov8" title="1">{
                                 res.Published++
                         }</span>
                 }
-                <span class="cov7" title="8">return res, nil</span>
+                <span class="cov8" title="1">return res, nil</span>
         })
 }
 
 // deliver は、1 件を publish し、結果に応じて published / failed / dead をマークします。
 // publish 成功なら published=true を返します。publish 失敗は tx を巻き戻さず（次 poll の再送に委ねる）
 // published=false・error=nil を返し、DB マークの失敗のみエラーを返します。
-func (u *relayUsecase) deliver(ctx context.Context, m outboxbndry.PendingMessage) (bool, error) <span class="cov8" title="12">{
+func (u *relayUsecase) deliver(ctx context.Context, m outboxbndry.PendingMessage) (bool, error) <span class="cov8" title="1">{
         perr := u.publisher.Publish(ctx, publisher.Message{
                 MessageID: m.MessageID,
                 EventType: m.EventType,
                 Payload:   m.Payload,
                 Headers:   decodeHeaders(m.Headers),
         })
-        if perr == nil </span><span class="cov6" title="7">{
+        if perr == nil </span><span class="cov8" title="1">{
                 return true, u.store.MarkPublished(ctx, m.ID)
         }</span>
 
-        <span class="cov5" title="5">attempts, ferr := u.store.MarkFailed(ctx, m.ID, perr.Error())
-        if ferr != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">attempts, ferr := u.store.MarkFailed(ctx, m.ID, perr.Error())
+        if ferr != nil </span><span class="cov8" title="1">{
                 return false, ferr
         }</span>
-        <span class="cov5" title="4">if attempts &gt;= u.maxAttempts </span><span class="cov3" title="2">{
-                if derr := u.store.MarkDead(ctx, m.ID); derr != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if attempts &gt;= u.maxAttempts </span><span class="cov8" title="1">{
+                if derr := u.store.MarkDead(ctx, m.ID); derr != nil </span><span class="cov8" title="1">{
                         return false, derr
                 }</span>
-                <span class="cov1" title="1">u.metrics.IncDead(ctx)
+                <span class="cov8" title="1">u.metrics.IncDead(ctx)
                 u.logging.Named(relayLoggerName).Warn(
                         "outbox message marked dead after reaching max attempts",
                         logging.String(logging.MessageIDKey, m.MessageID.String()),
@@ -18233,19 +18224,19 @@ func (u *relayUsecase) deliver(ctx context.Context, m outboxbndry.PendingMessage
                         logging.Error(logging.JobErrorKey, perr),
                 )</span>
         }
-        <span class="cov4" title="3">return false, nil</span>
+        <span class="cov8" title="1">return false, nil</span>
 }
 
 // decodeHeaders は、保存済みヘッダ JSON を map へ復元します。壊れていても publish は継続するため nil を返します。
-func decodeHeaders(b []byte) map[string]string <span class="cov8" title="12">{
-        if len(b) == 0 </span><span class="cov8" title="10">{
+func decodeHeaders(b []byte) map[string]string <span class="cov8" title="1">{
+        if len(b) == 0 </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov3" title="2">var h map[string]string
-        if err := json.Unmarshal(b, &amp;h); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">var h map[string]string
+        if err := json.Unmarshal(b, &amp;h); err != nil </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov1" title="1">return h</span>
+        <span class="cov8" title="1">return h</span>
 }
 </pre>
 		
@@ -18274,12 +18265,12 @@ type replayUsecase struct {
 }
 
 // NewReplay は、ReplayUsecase を生成します。
-func NewReplay(store outboxbndry.Store, tf observability.TracerFactory) ReplayUsecase <span class="cov10" title="6">{
+func NewReplay(store outboxbndry.Store, tf observability.TracerFactory) ReplayUsecase <span class="cov8" title="1">{
         return &amp;replayUsecase{store: store, tracer: tf.Usecase()}
 }</span>
 
 // ReplayDead は、dead 行を pending へ戻し、戻した件数を返します。
-func (u *replayUsecase) ReplayDead(ctx context.Context, messageID *uuid.UUID) (int64, error) <span class="cov7" title="4">{
+func (u *replayUsecase) ReplayDead(ctx context.Context, messageID *uuid.UUID) (int64, error) <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
@@ -18302,21 +18293,21 @@ import (
 )
 
 // ExpectedDBError は、データベースエラーを表すテスト用のエラーを生成します。
-func ExpectedDBError() error <span class="cov8" title="14">{
+func ExpectedDBError() error <span class="cov8" title="1">{
         return xerrors.New("database error")
 }</span>
 
 // NewMockTransactionManager は、テスト用のトランザクションマネージャーを生成します。
-func NewMockTransactionManager(t *testing.T) tx.Manager <span class="cov6" title="7">{
+func NewMockTransactionManager(t *testing.T) tx.Manager <span class="cov8" title="1">{
         t.Helper()
         ctrl := gomock.NewController(t)
         mockTx := mock_tx.NewMockManager(ctrl)
         mockTx.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(
-                func(ctx context.Context, fn func(ctx context.Context) error) error </span><span class="cov10" title="28">{
+                func(ctx context.Context, fn func(ctx context.Context) error) error </span><span class="cov8" title="1">{
                         return fn(ctx)
                 }</span>,
         ).AnyTimes()
-        <span class="cov6" title="7">return mockTx</span>
+        <span class="cov8" title="1">return mockTx</span>
 }
 </pre>
 		
@@ -18351,47 +18342,47 @@ type Cursor struct {
 //        first[limit] の補完・クランプ規約は offset 版（NewPageFrom1Based）と共通で、
 //        0以下または nil の場合は defaultPerPage、maxPerPage を超える場合は maxPerPage を使用します。
 //        keyset はページ番号を持たないため、offset 版のような最大ページ数エラーは発生しません。
-func NewCursor(after *string, first *int) (*Cursor, error) <span class="cov10" title="31">{
+func NewCursor(after *string, first *int) (*Cursor, error) <span class="cov8" title="1">{
         limit := defaultPerPage
-        if first != nil &amp;&amp; *first &gt; 0 </span><span class="cov7" title="12">{
+        if first != nil &amp;&amp; *first &gt; 0 </span><span class="cov8" title="1">{
                 limit = *first
         }</span>
-        <span class="cov10" title="31">if limit &gt; maxPerPage </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if limit &gt; maxPerPage </span><span class="cov8" title="1">{
                 limit = maxPerPage
         }</span>
 
-        <span class="cov10" title="31">keys, err := decodeCursor(after)
-        if err != nil </span><span class="cov4" title="4">{
+        <span class="cov8" title="1">keys, err := decodeCursor(after)
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov9" title="27">return &amp;Cursor{
+        <span class="cov8" title="1">return &amp;Cursor{
                 limit: limit,
                 keys:  keys,
         }, nil</span>
 }
 
 // Limit は、ページの取得上限を返します。
-func (c Cursor) Limit() int <span class="cov6" title="9">{ return c.limit }</span>
+func (c Cursor) Limit() int <span class="cov8" title="1">{ return c.limit }</span>
 
 // Limit32 は、ページの取得上限をint32型で返します。
-func (c Cursor) Limit32() int32 <span class="cov6" title="7">{
+func (c Cursor) Limit32() int32 <span class="cov8" title="1">{
         limit := min(c.limit, maxPerPage)
         //nolint:gosec // G115: maxPerPage(int32範囲内の定数)でクランプ済みのためオーバーフローしません
         return int32(limit)
 }</span>
 
 // HasCursor は、カーソルが指定されている（＝先頭ページではない）場合に true を返します。
-func (c Cursor) HasCursor() bool <span class="cov8" title="19">{ return len(c.keys) &gt; 0 }</span>
+func (c Cursor) HasCursor() bool <span class="cov8" title="1">{ return len(c.keys) &gt; 0 }</span>
 
 // Keys は、直前ページ末尾行のソートキー（タプル）のコピーを返します。
 //
 //        先頭ページの場合は空スライスを返します。呼び出し元はこの値を keyset 比較の境界として解釈します。
-func (c Cursor) Keys() []string <span class="cov8" title="18">{
-        if len(c.keys) == 0 </span><span class="cov3" title="3">{
+func (c Cursor) Keys() []string <span class="cov8" title="1">{
+        if len(c.keys) == 0 </span><span class="cov8" title="1">{
                 return []string{}
         }</span>
-        <span class="cov8" title="15">out := make([]string, len(c.keys))
+        <span class="cov8" title="1">out := make([]string, len(c.keys))
         copy(out, c.keys)
         return out</span>
 }
@@ -18400,40 +18391,40 @@ func (c Cursor) Keys() []string <span class="cov8" title="18">{
 //
 //        クエリ層が「現在ページ末尾行」のソートキー（文字列化済み）を渡して次ページ用カーソルを生成します。
 //        キーが1つも渡されない場合は、先頭ページを表す空文字を返します。
-func EncodeCursor(keys ...string) string <span class="cov8" title="16">{
-        if len(keys) == 0 </span><span class="cov1" title="1">{
+func EncodeCursor(keys ...string) string <span class="cov8" title="1">{
+        if len(keys) == 0 </span><span class="cov8" title="1">{
                 return ""
         }</span>
-        <span class="cov8" title="15">b, err := json.Marshal(keys)
+        <span class="cov8" title="1">b, err := json.Marshal(keys)
         if err != nil </span><span class="cov0" title="0">{
                 return ""
         }</span>
-        <span class="cov8" title="15">return base64.RawURLEncoding.EncodeToString(b)</span>
+        <span class="cov8" title="1">return base64.RawURLEncoding.EncodeToString(b)</span>
 }
 
 // decodeCursor は、不透明カーソル文字列をソートキーのタプルへ復号します。
 //
 //        nil または空文字は先頭ページとみなし、nil を返します。
 //        base64/JSON の形式不正、または空タプルの場合は apperror.ErrInvalidArgument を返します。
-func decodeCursor(after *string) ([]string, error) <span class="cov10" title="31">{
-        if after == nil || *after == "" </span><span class="cov7" title="14">{
+func decodeCursor(after *string) ([]string, error) <span class="cov8" title="1">{
+        if after == nil || *after == "" </span><span class="cov8" title="1">{
                 return nil, nil
         }</span>
 
-        <span class="cov8" title="17">raw, err := base64.RawURLEncoding.DecodeString(*after)
-        if err != nil </span><span class="cov2" title="2">{
+        <span class="cov8" title="1">raw, err := base64.RawURLEncoding.DecodeString(*after)
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrInvalidArgument, fmt.Sprintf("invalid cursor encoding: %v", err))
         }</span>
 
-        <span class="cov8" title="15">var keys []string
-        if err := json.Unmarshal(raw, &amp;keys); err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">var keys []string
+        if err := json.Unmarshal(raw, &amp;keys); err != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrInvalidArgument, fmt.Sprintf("invalid cursor payload: %v", err))
         }</span>
-        <span class="cov7" title="14">if len(keys) == 0 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if len(keys) == 0 </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrInvalidArgument, "invalid cursor: empty keyset")
         }</span>
 
-        <span class="cov7" title="13">return keys, nil</span>
+        <span class="cov8" title="1">return keys, nil</span>
 }
 </pre>
 		
@@ -18471,44 +18462,44 @@ type Page struct {
 //        ページ番号が1未満の場合は1に、1ページあたりの件数が0以下の場合はデフォルト値を使用します。
 //        page[offsetの係数]は最小値1で、maxPage を超える場合はエラーを返します。
 //        perPage[limit]は、0以下の場合はdefaultPerPage値：最大値をmaxPerPageまで許容します。
-func NewPageFrom1Based(page, perPage *int) (*Page, error) <span class="cov10" title="35">{
+func NewPageFrom1Based(page, perPage *int) (*Page, error) <span class="cov8" title="1">{
         limit := defaultPerPage
-        if perPage != nil &amp;&amp; *perPage &gt; 0 </span><span class="cov9" title="25">{
+        if perPage != nil &amp;&amp; *perPage &gt; 0 </span><span class="cov8" title="1">{
                 limit = *perPage
         }</span>
-        <span class="cov10" title="35">if limit &gt; maxPerPage </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if limit &gt; maxPerPage </span><span class="cov8" title="1">{
                 limit = maxPerPage
         }</span>
 
-        <span class="cov10" title="35">pg := minPage
-        if page != nil &amp;&amp; *page &gt; 0 </span><span class="cov9" title="25">{
+        <span class="cov8" title="1">pg := minPage
+        if page != nil &amp;&amp; *page &gt; 0 </span><span class="cov8" title="1">{
                 pg = *page
         }</span>
-        <span class="cov10" title="35">if pg &gt; maxPage </span><span class="cov3" title="3">{
+        <span class="cov8" title="1">if pg &gt; maxPage </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrInvalidArgument, fmt.Sprintf("invalid page number: %d, max page is %d", pg, maxPage))
         }</span>
 
-        <span class="cov9" title="32">return &amp;Page{
+        <span class="cov8" title="1">return &amp;Page{
                 limit:  limit,
                 offset: (pg - 1) * limit,
         }, nil</span>
 }
 
 // Limit は、ページの取得上限を返します。
-func (p Page) Limit() int <span class="cov7" title="14">{ return p.limit }</span>
+func (p Page) Limit() int <span class="cov8" title="1">{ return p.limit }</span>
 
 // Limit32 は、ページの取得上限をint32型で返します。
-func (p Page) Limit32() int32 <span class="cov9" title="26">{
+func (p Page) Limit32() int32 <span class="cov8" title="1">{
         limit := min(p.limit, maxPerPage)
         //nolint:gosec // G115: maxPerPage(int32範囲内の定数)でクランプ済みのためオーバーフローしません
         return int32(limit)
 }</span>
 
 // Offset は、ページのオフセットを返します。
-func (p Page) Offset() int <span class="cov7" title="14">{ return p.offset }</span>
+func (p Page) Offset() int <span class="cov8" title="1">{ return p.offset }</span>
 
 // Offset32 は、ページのオフセットをint32型で返します。
-func (p Page) Offset32() int32 <span class="cov9" title="26">{
+func (p Page) Offset32() int32 <span class="cov8" title="1">{
         offset := min(p.offset, maxOffset)
         //nolint:gosec // G115: maxOffset(int32範囲内の定数)でクランプ済みのためオーバーフローしません
         return int32(offset)
@@ -18534,54 +18525,54 @@ const (
 // 重複排除・上限（maxTokens 件）適用後のトークン列を返します。
 // keyword が nil または空文字の場合は空スライスを返します。
 // maxTokens が 0 以下の場合は DefaultMaxTokens を使用します。
-func ParseSearchTokens(keyword *string, maxTokens int) []string <span class="cov4" title="16">{
-        if keyword == nil || *keyword == "" </span><span class="cov1" title="2">{
+func ParseSearchTokens(keyword *string, maxTokens int) []string <span class="cov8" title="1">{
+        if keyword == nil || *keyword == "" </span><span class="cov8" title="1">{
                 return []string{}
         }</span>
-        <span class="cov4" title="14">if maxTokens &lt;= 0 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if maxTokens &lt;= 0 </span><span class="cov8" title="1">{
                 maxTokens = DefaultMaxTokens
         }</span>
 
-        <span class="cov4" title="14">k := *keyword
+        <span class="cov8" title="1">k := *keyword
         rs := []rune(k)
-        if len(rs) &gt; MaxKeywordLength </span><span class="cov1" title="1">{
+        if len(rs) &gt; MaxKeywordLength </span><span class="cov8" title="1">{
                 k = string(rs[:MaxKeywordLength])
         }</span>
 
-        <span class="cov4" title="14">raw := splitIntoTerms(k)
+        <span class="cov8" title="1">raw := splitIntoTerms(k)
         unique := dedupePreserveOrder(raw)
 
         return limit(unique, maxTokens)</span>
 }
 
 // splitIntoTerms は、キーワード文字列を '_' または空白で分割します。
-func splitIntoTerms(keyword string) []string <span class="cov4" title="17">{
-        return strings.FieldsFunc(keyword, func(r rune) bool </span><span class="cov10" title="1726">{
+func splitIntoTerms(keyword string) []string <span class="cov8" title="1">{
+        return strings.FieldsFunc(keyword, func(r rune) bool </span><span class="cov8" title="1">{
                 return r == '_' || unicode.IsSpace(r)
         }</span>)
 }
 
 // dedupePreserveOrder は、配列の要素の重複を排除し、元の順序を保持します。
-func dedupePreserveOrder(ss []string) []string <span class="cov4" title="16">{
+func dedupePreserveOrder(ss []string) []string <span class="cov8" title="1">{
         seen := make(map[string]struct{}, len(ss))
         out := make([]string, 0, len(ss))
 
-        for _, t := range ss </span><span class="cov6" title="71">{
-                if _, ok := seen[t]; ok </span><span class="cov2" title="3">{
+        for _, t := range ss </span><span class="cov8" title="1">{
+                if _, ok := seen[t]; ok </span><span class="cov8" title="1">{
                         continue</span>
                 }
-                <span class="cov6" title="68">seen[t] = struct{}{}
+                <span class="cov8" title="1">seen[t] = struct{}{}
                 out = append(out, t)</span>
         }
-        <span class="cov4" title="16">return out</span>
+        <span class="cov8" title="1">return out</span>
 }
 
 // limit は、配列の要素数を上限までに制限します。
-func limit(ss []string, maxVal int) []string <span class="cov4" title="16">{
-        if len(ss) &lt;= maxVal </span><span class="cov4" title="13">{
+func limit(ss []string, maxVal int) []string <span class="cov8" title="1">{
+        if len(ss) &lt;= maxVal </span><span class="cov8" title="1">{
                 return ss
         }</span>
-        <span class="cov2" title="3">return ss[:maxVal]</span>
+        <span class="cov8" title="1">return ss[:maxVal]</span>
 }
 </pre>
 		
@@ -18602,32 +18593,32 @@ const feedCursorKeyCount = 2
 
 // decodeFeedCursor は、cursor の不透明キー列を keyset 境界（FeedCursor）へ解釈します。
 // 先頭ページ（カーソル無し）の場合は nil を返します。キーの個数・型が不正な場合は ErrInvalidArgument を返します。
-func decodeFeedCursor(cursor *paging.Cursor) (*user.FeedCursor, error) <span class="cov10" title="14">{
-        if !cursor.HasCursor() </span><span class="cov6" title="5">{
+func decodeFeedCursor(cursor *paging.Cursor) (*user.FeedCursor, error) <span class="cov8" title="1">{
+        if !cursor.HasCursor() </span><span class="cov8" title="1">{
                 return nil, nil //nolint:nilnil // 先頭ページは境界なし（nil）を正常値として返す
         }</span>
 
-        <span class="cov8" title="9">keys := cursor.Keys()
-        if len(keys) != feedCursorKeyCount </span><span class="cov3" title="2">{
+        <span class="cov8" title="1">keys := cursor.Keys()
+        if len(keys) != feedCursorKeyCount </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrInvalidArgument, "invalid cursor: expected 2 keys")
         }</span>
 
-        <span class="cov7" title="7">createdAt, err := time.Parse(time.RFC3339Nano, keys[0])
-        if err != nil </span><span class="cov3" title="2">{
+        <span class="cov8" title="1">createdAt, err := time.Parse(time.RFC3339Nano, keys[0])
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrInvalidArgument, "invalid cursor: created_at is not RFC3339Nano")
         }</span>
 
-        <span class="cov6" title="5">id, err := uuid.Parse(keys[1])
-        if err != nil </span><span class="cov3" title="2">{
+        <span class="cov8" title="1">id, err := uuid.Parse(keys[1])
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrInvalidArgument, "invalid cursor: id is not a valid UUID")
         }</span>
 
-        <span class="cov4" title="3">fc := user.NewFeedCursor(createdAt, id)
+        <span class="cov8" title="1">fc := user.NewFeedCursor(createdAt, id)
         return &amp;fc, nil</span>
 }
 
 // encodeFeedCursor は、現在ページ末尾行のソートキー（created_at, id）から次ページ用の不透明カーソルを生成します。
-func encodeFeedCursor(last *user.User) string <span class="cov3" title="2">{
+func encodeFeedCursor(last *user.User) string <span class="cov8" title="1">{
         return paging.EncodeCursor(last.CreatedAt().Format(time.RFC3339Nano), last.ID().String())
 }</span>
 </pre>
@@ -18680,7 +18671,7 @@ type Usecase interface {
 func New(
         tf observability.TracerFactory,
         userQueryService query.UserSearchQueryService,
-) Usecase <span class="cov3" title="2">{
+) Usecase <span class="cov8" title="1">{
         return &amp;usecase{
                 tracer: tf.Usecase(),
                 userQS: userQueryService,
@@ -18688,47 +18679,47 @@ func New(
 }</span>
 
 // ListUsersByKeyword は、キーワードに基づいてユーザー一覧を取得します。
-func (u *usecase) ListUsersByKeyword(ctx context.Context, filter *SearchParams, page *paging.Page) (query.UserSearchResults, error) <span class="cov9" title="8">{
-        if filter == nil || page == nil </span><span class="cov5" title="3">{
+func (u *usecase) ListUsersByKeyword(ctx context.Context, filter *SearchParams, page *paging.Page) (query.UserSearchResults, error) <span class="cov8" title="1">{
+        if filter == nil || page == nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrInvalidArgument, "filter and page must not be nil")
         }</span>
 
-        <span class="cov7" title="5">ctx, endSpan := u.tracer.Start(ctx)
+        <span class="cov8" title="1">ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
         return u.userQS.FindByFilter(ctx, u.toFilter(filter), page.Limit32(), page.Offset32())</span>
 }
 
 // CountUsersByKeyword は、キーワードに基づいてユーザーの総件数を返すユースケースです。
-func (u *usecase) CountUsersByKeyword(ctx context.Context, filter *SearchParams) (int64, error) <span class="cov7" title="5">{
-        if filter == nil </span><span class="cov1" title="1">{
+func (u *usecase) CountUsersByKeyword(ctx context.Context, filter *SearchParams) (int64, error) <span class="cov8" title="1">{
+        if filter == nil </span><span class="cov8" title="1">{
                 return 0, xerrors.Wrap(apperror.ErrInvalidArgument, "filter must not be nil")
         }</span>
 
-        <span class="cov6" title="4">ctx, endSpan := u.tracer.Start(ctx)
+        <span class="cov8" title="1">ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
         return u.userQS.CountByFilter(ctx, u.toFilter(filter))</span>
 }
 
 // ListUsersByKeywordWithTotal は、検索一覧と総件数をまとめて取得します。
-func (u *usecase) ListUsersByKeywordWithTotal(ctx context.Context, filter *SearchParams, page *paging.Page) (*UserSearchListView, error) <span class="cov6" title="4">{
+func (u *usecase) ListUsersByKeywordWithTotal(ctx context.Context, filter *SearchParams, page *paging.Page) (*UserSearchListView, error) <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
         items, err := u.ListUsersByKeyword(ctx, filter, page)
-        if err != nil </span><span class="cov3" title="2">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov3" title="2">total, err := u.CountUsersByKeyword(ctx, filter)
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">total, err := u.CountUsersByKeyword(ctx, filter)
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov1" title="1">return &amp;UserSearchListView{Items: items, Total: total}, nil</span>
+        <span class="cov8" title="1">return &amp;UserSearchListView{Items: items, Total: total}, nil</span>
 }
 
 // toFilter は、SearchParams から検索フィルタを構築します。
-func (u *usecase) toFilter(p *SearchParams) *query.UserSearchFilter <span class="cov10" title="9">{
+func (u *usecase) toFilter(p *SearchParams) *query.UserSearchFilter <span class="cov8" title="1">{
         return &amp;query.UserSearchFilter{
                 Active:   p.Active,
                 Keywords: search.ParseSearchTokens(p.Keyword, search.DefaultMaxTokens),
@@ -18873,7 +18864,7 @@ func New(
         authorizer authz.Authorizer,
         userRepo user.Repository,
         prefectureRepo prefecture.Repository,
-) Usecase <span class="cov6" title="7">{
+) Usecase <span class="cov8" title="1">{
         return &amp;usecase{
                 tracer:     tf.Usecase(),
                 txm:        txm,
@@ -18885,48 +18876,48 @@ func New(
         }
 }</span>
 
-func (u *usecase) ListUsers(ctx context.Context, active *bool, page *paging.Page) ([]UserView, error) <span class="cov7" title="9">{
-        if page == nil </span><span class="cov2" title="2">{
+func (u *usecase) ListUsers(ctx context.Context, active *bool, page *paging.Page) ([]UserView, error) <span class="cov8" title="1">{
+        if page == nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrInvalidArgument, "page must not be nil")
         }</span>
 
-        <span class="cov6" title="7">ctx, endSpan := u.tracer.Start(ctx)
+        <span class="cov8" title="1">ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
         us, err := u.userRepo.FindByActive(ctx, active, page.Limit32(), page.Offset32())
-        if err != nil </span><span class="cov2" title="2">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov5" title="5">return u.toUserViews(ctx, us)</span>
+        <span class="cov8" title="1">return u.toUserViews(ctx, us)</span>
 }
 
 // CreateUser は、ユーザーを作成するユースケースです。
-func (u *usecase) CreateUser(ctx context.Context, dto *CreateParamsDTO) (UserView, error) <span class="cov6" title="6">{
+func (u *usecase) CreateUser(ctx context.Context, dto *CreateParamsDTO) (UserView, error) <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
         now := u.clock.Now()
         rawPassword, err := user.NewRawPassword(dto.RawPassword)
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return UserView{}, err
         }</span>
 
-        <span class="cov5" title="5">passwordHash, err := u.encrypter.Hash(rawPassword.Value())
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">passwordHash, err := u.encrypter.Hash(rawPassword.Value())
+        if err != nil </span><span class="cov8" title="1">{
                 return UserView{}, err
         }</span>
 
-        <span class="cov4" title="4">var (
+        <span class="cov8" title="1">var (
                 userEntity *user.User
                 pftName    string
         )
-        err = u.txm.Do(ctx, func(ctx context.Context) error </span><span class="cov4" title="4">{
+        err = u.txm.Do(ctx, func(ctx context.Context) error </span><span class="cov8" title="1">{
                 pftDomain, err := u.pftRepo.FindByName(ctx, dto.PrefectureName)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
-                <span class="cov4" title="3">pftName = pftDomain.Name()
+                <span class="cov8" title="1">pftName = pftDomain.Name()
 
                 userEntity, err = user.New(
                         dto.UserID,
@@ -18944,133 +18935,133 @@ func (u *usecase) CreateUser(ctx context.Context, dto *CreateParamsDTO) (UserVie
                         now,
                         nil,
                 )
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
 
-                <span class="cov2" title="2">return u.userRepo.Create(ctx, userEntity)</span>
+                <span class="cov8" title="1">return u.userRepo.Create(ctx, userEntity)</span>
         })
-        <span class="cov4" title="4">if err != nil </span><span class="cov4" title="3">{
+        <span class="cov8" title="1">if err != nil </span><span class="cov8" title="1">{
                 return UserView{}, err
         }</span>
 
-        <span class="cov1" title="1">return toUserView(userEntity, pftName), nil</span>
+        <span class="cov8" title="1">return toUserView(userEntity, pftName), nil</span>
 }
 
 // CountUsers は、ユーザーの総件数を返すユースケースです。
-func (u *usecase) CountUsers(ctx context.Context, active *bool) (int64, error) <span class="cov4" title="4">{
+func (u *usecase) CountUsers(ctx context.Context, active *bool) (int64, error) <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
         return u.userRepo.CountByActive(ctx, active)
 }</span>
 
 // ListUsersWithTotal は、ユーザー一覧と総件数をまとめて取得します。
-func (u *usecase) ListUsersWithTotal(ctx context.Context, active *bool, page *paging.Page) (*UserListView, error) <span class="cov4" title="4">{
+func (u *usecase) ListUsersWithTotal(ctx context.Context, active *bool, page *paging.Page) (*UserListView, error) <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
         items, err := u.ListUsers(ctx, active, page)
-        if err != nil </span><span class="cov2" title="2">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov2" title="2">total, err := u.CountUsers(ctx, active)
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">total, err := u.CountUsers(ctx, active)
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov1" title="1">return &amp;UserListView{Items: items, Total: total}, nil</span>
+        <span class="cov8" title="1">return &amp;UserListView{Items: items, Total: total}, nil</span>
 }
 
 // ListUsersFeed は、未削除ユーザーを作成日時の降順（cursor ページネーション）で取得します。
-func (u *usecase) ListUsersFeed(ctx context.Context, cursor *paging.Cursor) (*UserFeedView, error) <span class="cov7" title="9">{
-        if cursor == nil </span><span class="cov1" title="1">{
+func (u *usecase) ListUsersFeed(ctx context.Context, cursor *paging.Cursor) (*UserFeedView, error) <span class="cov8" title="1">{
+        if cursor == nil </span><span class="cov8" title="1">{
                 return nil, xerrors.Wrap(apperror.ErrInvalidArgument, "cursor must not be nil")
         }</span>
 
-        <span class="cov6" title="8">ctx, endSpan := u.tracer.Start(ctx)
+        <span class="cov8" title="1">ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
         after, err := decodeFeedCursor(cursor)
-        if err != nil </span><span class="cov4" title="3">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov5" title="5">us, err := u.userRepo.FindFeed(ctx, after, cursor.Limit32()+1)
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">us, err := u.userRepo.FindFeed(ctx, after, cursor.Limit32()+1)
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov4" title="4">limit := cursor.Limit()
+        <span class="cov8" title="1">limit := cursor.Limit()
         hasNext := len(us) &gt; limit
-        if hasNext </span><span class="cov1" title="1">{
+        if hasNext </span><span class="cov8" title="1">{
                 us = us[:limit]
         }</span>
 
-        <span class="cov4" title="4">items, err := u.toUserViews(ctx, us)
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">items, err := u.toUserViews(ctx, us)
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov4" title="3">var nextCursor *string
-        if hasNext &amp;&amp; len(us) &gt; 0 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">var nextCursor *string
+        if hasNext &amp;&amp; len(us) &gt; 0 </span><span class="cov8" title="1">{
                 encoded := encodeFeedCursor(us[len(us)-1])
                 nextCursor = &amp;encoded
         }</span>
 
-        <span class="cov4" title="3">return &amp;UserFeedView{Items: items, NextCursor: nextCursor}, nil</span>
+        <span class="cov8" title="1">return &amp;UserFeedView{Items: items, NextCursor: nextCursor}, nil</span>
 }
 
 // GetUser は、IDから単一ユーザーを取得するユースケースです。
-func (u *usecase) GetUser(ctx context.Context, authn *authbd.Authn, id uuid.UUID) (UserView, error) <span class="cov5" title="5">{
+func (u *usecase) GetUser(ctx context.Context, authn *authbd.Authn, id uuid.UUID) (UserView, error) <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
-        if err := u.authorizeUserAccess(ctx, authn, authz.ActionUserGet, id); err != nil </span><span class="cov1" title="1">{
+        if err := u.authorizeUserAccess(ctx, authn, authz.ActionUserGet, id); err != nil </span><span class="cov8" title="1">{
                 return UserView{}, err
         }</span>
 
-        <span class="cov4" title="4">userEntity, err := u.userRepo.FindByID(ctx, id)
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">userEntity, err := u.userRepo.FindByID(ctx, id)
+        if err != nil </span><span class="cov8" title="1">{
                 return UserView{}, err
         }</span>
 
-        <span class="cov4" title="3">pftDomain, err := u.pftRepo.FindByID(ctx, userEntity.PrefectureID())
-        if err != nil </span><span class="cov2" title="2">{
-                if xerrors.Is(err, apperror.ErrNotFound) </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">pftDomain, err := u.pftRepo.FindByID(ctx, userEntity.PrefectureID())
+        if err != nil </span><span class="cov8" title="1">{
+                if xerrors.Is(err, apperror.ErrNotFound) </span><span class="cov8" title="1">{
                         return UserView{}, errOrphanPrefecture
                 }</span>
-                <span class="cov1" title="1">return UserView{}, err</span>
+                <span class="cov8" title="1">return UserView{}, err</span>
         }
 
-        <span class="cov1" title="1">return toUserView(userEntity, pftDomain.Name()), nil</span>
+        <span class="cov8" title="1">return toUserView(userEntity, pftDomain.Name()), nil</span>
 }
 
 // UpdateUser は、ユーザーのプロフィールを全更新します（パスワードは含みません）。
-func (u *usecase) UpdateUser(ctx context.Context, authn *authbd.Authn, id uuid.UUID, dto *UpdateProfileParams) (UserView, error) <span class="cov6" title="6">{
+func (u *usecase) UpdateUser(ctx context.Context, authn *authbd.Authn, id uuid.UUID, dto *UpdateProfileParams) (UserView, error) <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
-        if err := u.authorizeUserAccess(ctx, authn, authz.ActionUserUpdate, id); err != nil </span><span class="cov1" title="1">{
+        if err := u.authorizeUserAccess(ctx, authn, authz.ActionUserUpdate, id); err != nil </span><span class="cov8" title="1">{
                 return UserView{}, err
         }</span>
 
-        <span class="cov5" title="5">now := u.clock.Now()
+        <span class="cov8" title="1">now := u.clock.Now()
 
         var (
                 userEntity *user.User
                 pftName    string
         )
-        err := u.txm.Do(ctx, func(ctx context.Context) error </span><span class="cov5" title="5">{
+        err := u.txm.Do(ctx, func(ctx context.Context) error </span><span class="cov8" title="1">{
                 var err error
                 userEntity, err = u.userRepo.FindByID(ctx, id)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
 
-                <span class="cov4" title="4">pftDomain, err := u.pftRepo.FindByName(ctx, dto.PrefectureName)
-                if err != nil </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">pftDomain, err := u.pftRepo.FindByName(ctx, dto.PrefectureName)
+                if err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
-                <span class="cov4" title="3">pftName = pftDomain.Name()
+                <span class="cov8" title="1">pftName = pftDomain.Name()
 
                 if err = userEntity.UpdateProfile(
                         dto.FirstName,
@@ -19083,99 +19074,99 @@ func (u *usecase) UpdateUser(ctx context.Context, authn *authbd.Authn, id uuid.U
                         dto.Building,
                         dto.PostalCode,
                         now,
-                ); err != nil </span><span class="cov1" title="1">{
+                ); err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
 
-                <span class="cov2" title="2">return u.userRepo.Update(ctx, userEntity)</span>
+                <span class="cov8" title="1">return u.userRepo.Update(ctx, userEntity)</span>
         })
-        <span class="cov5" title="5">if err != nil </span><span class="cov4" title="4">{
+        <span class="cov8" title="1">if err != nil </span><span class="cov8" title="1">{
                 return UserView{}, err
         }</span>
 
-        <span class="cov1" title="1">return toUserView(userEntity, pftName), nil</span>
+        <span class="cov8" title="1">return toUserView(userEntity, pftName), nil</span>
 }
 
 // ChangePassword は、現在のパスワードを照合したうえでユーザーのパスワードを変更するユースケースです。
-func (u *usecase) ChangePassword(ctx context.Context, id uuid.UUID, currentPassword, newPassword string) error <span class="cov7" title="9">{
+func (u *usecase) ChangePassword(ctx context.Context, id uuid.UUID, currentPassword, newPassword string) error <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
         now := u.clock.Now()
         // 現パスワードも newPassword と同じ長さ制約で検証する（bcrypt の 72 バイト切り詰めを避け、入力の対称性を保つ）。
-        if _, err := user.NewRawPassword(currentPassword); err != nil </span><span class="cov1" title="1">{
+        if _, err := user.NewRawPassword(currentPassword); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov6" title="8">rawNew, err := user.NewRawPassword(newPassword)
-        if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">rawNew, err := user.NewRawPassword(newPassword)
+        if err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov6" title="7">return u.txm.Do(ctx, func(ctx context.Context) error </span><span class="cov6" title="7">{
+        <span class="cov8" title="1">return u.txm.Do(ctx, func(ctx context.Context) error </span><span class="cov8" title="1">{
                 userEntity, err := u.userRepo.FindByID(ctx, id)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
 
-                <span class="cov6" title="6">matched, err := u.encrypter.Compare(userEntity.PasswordHash(), currentPassword)
-                if err != nil </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">matched, err := u.encrypter.Compare(userEntity.PasswordHash(), currentPassword)
+                if err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
-                <span class="cov5" title="5">if !matched </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">if !matched </span><span class="cov8" title="1">{
                         return user.ErrCurrentPasswordMismatch
                 }</span>
 
-                <span class="cov4" title="4">newHash, err := u.encrypter.Hash(rawNew.Value())
-                if err != nil </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">newHash, err := u.encrypter.Hash(rawNew.Value())
+                if err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
 
-                <span class="cov4" title="3">if err = userEntity.ChangePassword(newHash, now); err != nil </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">if err = userEntity.ChangePassword(newHash, now); err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
 
-                <span class="cov2" title="2">return u.userRepo.Update(ctx, userEntity)</span>
+                <span class="cov8" title="1">return u.userRepo.Update(ctx, userEntity)</span>
         })
 }
 
 // UpdateUserPartially は、ユーザーを部分更新します（パスワードは更新しません）。
 // 指定フィールドのみ更新し、未指定/null は据え置く（クリアは非対応。クリアは全更新用の UpdateUser を使う）。password は更新しない。
-func (u *usecase) UpdateUserPartially(ctx context.Context, authn *authbd.Authn, id uuid.UUID, dto *PatchParamsDTO) (UserView, error) <span class="cov6" title="8">{
+func (u *usecase) UpdateUserPartially(ctx context.Context, authn *authbd.Authn, id uuid.UUID, dto *PatchParamsDTO) (UserView, error) <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
-        if err := u.authorizeUserAccess(ctx, authn, authz.ActionUserUpdate, id); err != nil </span><span class="cov1" title="1">{
+        if err := u.authorizeUserAccess(ctx, authn, authz.ActionUserUpdate, id); err != nil </span><span class="cov8" title="1">{
                 return UserView{}, err
         }</span>
 
-        <span class="cov6" title="7">now := u.clock.Now()
+        <span class="cov8" title="1">now := u.clock.Now()
 
         var (
                 userEntity *user.User
                 pftName    string
         )
-        err := u.txm.Do(ctx, func(ctx context.Context) error </span><span class="cov6" title="7">{
+        err := u.txm.Do(ctx, func(ctx context.Context) error </span><span class="cov8" title="1">{
                 var err error
                 userEntity, err = u.userRepo.FindByID(ctx, id)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
 
-                <span class="cov6" title="6">prefectureID := userEntity.PrefectureID()
+                <span class="cov8" title="1">prefectureID := userEntity.PrefectureID()
                 pftDomain, err := u.resolvePatchPrefecture(ctx, dto.PrefectureName, prefectureID)
-                if err != nil </span><span class="cov4" title="3">{
+                if err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
-                <span class="cov4" title="3">prefectureID = pftDomain.ID()
+                <span class="cov8" title="1">prefectureID = pftDomain.ID()
                 pftName = pftDomain.Name()
 
                 // provided なフィールドのみ現在値に上書きしたフルセットを構築
                 building := userEntity.Building()
-                if dto.Building != nil </span><span class="cov1" title="1">{
+                if dto.Building != nil </span><span class="cov8" title="1">{
                         building = dto.Building
                 }</span>
 
-                <span class="cov4" title="3">if err = userEntity.UpdateProfile(
+                <span class="cov8" title="1">if err = userEntity.UpdateProfile(
                         ptr.Deref(dto.FirstName, userEntity.FirstName()),
                         ptr.Deref(dto.LastName, userEntity.LastName()),
                         ptr.Deref(dto.Email, userEntity.Email()),
@@ -19186,106 +19177,106 @@ func (u *usecase) UpdateUserPartially(ctx context.Context, authn *authbd.Authn, 
                         building,
                         ptr.Deref(dto.PostalCode, userEntity.PostalCode()),
                         now,
-                ); err != nil </span><span class="cov1" title="1">{
+                ); err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
-                <span class="cov2" title="2">return u.userRepo.Update(ctx, userEntity)</span>
+                <span class="cov8" title="1">return u.userRepo.Update(ctx, userEntity)</span>
         })
-        <span class="cov6" title="7">if err != nil </span><span class="cov5" title="5">{
+        <span class="cov8" title="1">if err != nil </span><span class="cov8" title="1">{
                 return UserView{}, err
         }</span>
 
-        <span class="cov2" title="2">return toUserView(userEntity, pftName), nil</span>
+        <span class="cov8" title="1">return toUserView(userEntity, pftName), nil</span>
 }
 
 // DeleteUser は、ユーザーを論理削除します。
-func (u *usecase) DeleteUser(ctx context.Context, authn *authbd.Authn, id uuid.UUID) error <span class="cov5" title="5">{
+func (u *usecase) DeleteUser(ctx context.Context, authn *authbd.Authn, id uuid.UUID) error <span class="cov8" title="1">{
         ctx, endSpan := u.tracer.Start(ctx)
         defer endSpan()
 
-        if err := u.authorizeUserAccess(ctx, authn, authz.ActionUserDelete, id); err != nil </span><span class="cov2" title="2">{
+        if err := u.authorizeUserAccess(ctx, authn, authz.ActionUserDelete, id); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
 
-        <span class="cov4" title="3">now := u.clock.Now()
-        return u.txm.Do(ctx, func(ctx context.Context) error </span><span class="cov4" title="3">{
+        <span class="cov8" title="1">now := u.clock.Now()
+        return u.txm.Do(ctx, func(ctx context.Context) error </span><span class="cov8" title="1">{
                 userEntity, err := u.userRepo.FindByID(ctx, id)
-                if err != nil </span><span class="cov1" title="1">{
+                if err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
-                <span class="cov2" title="2">if err = userEntity.MarkAsDeleted(now); err != nil </span><span class="cov1" title="1">{
+                <span class="cov8" title="1">if err = userEntity.MarkAsDeleted(now); err != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
-                <span class="cov1" title="1">return u.userRepo.Update(ctx, userEntity)</span>
+                <span class="cov8" title="1">return u.userRepo.Update(ctx, userEntity)</span>
         })
 }
 
 // authorizeUserAccess は、認証主体 authn が対象ユーザー（所有者 = id）への action を実行してよいか判定します。
 // リソースの所有者を対象ユーザー（id）とすることで、所有権モデルでは呼出元が自分自身のみを操作できます。
 // authn が nil の場合は、認可判定以前に呼出元を特定できないため apperror.ErrUnauthenticated を返します。
-func (u *usecase) authorizeUserAccess(ctx context.Context, authn *authbd.Authn, action authz.Action, id uuid.UUID) error <span class="cov10" title="24">{
-        if authn == nil </span><span class="cov1" title="1">{
+func (u *usecase) authorizeUserAccess(ctx context.Context, authn *authbd.Authn, action authz.Action, id uuid.UUID) error <span class="cov8" title="1">{
+        if authn == nil </span><span class="cov8" title="1">{
                 return apperror.ErrUnauthenticated
         }</span>
-        <span class="cov9" title="23">return u.authorizer.Authorize(ctx, authn, action, authz.NewResource("user", &amp;id))</span>
+        <span class="cov8" title="1">return u.authorizer.Authorize(ctx, authn, action, authz.NewResource("user", &amp;id))</span>
 }
 
 // toUserViews は、ユーザーエンティティ列を UserView の DTO 列へ変換します。
 // いずれかのユーザーが参照する都道府県を解決できない場合は参照整合性破れ（errOrphanPrefecture）を返します。
-func (u *usecase) toUserViews(ctx context.Context, us user.Users) ([]UserView, error) <span class="cov7" title="9">{
+func (u *usecase) toUserViews(ctx context.Context, us user.Users) ([]UserView, error) <span class="cov8" title="1">{
         _, prefectureMap, err := observability.RunWithSpan(
-                ctx, u.tracer, "usecase", "user", "prefectureMap", func(ctx context.Context) (map[uuid.UUID]*prefecture.Prefecture, error) </span><span class="cov7" title="9">{
+                ctx, u.tracer, "usecase", "user", "prefectureMap", func(ctx context.Context) (map[uuid.UUID]*prefecture.Prefecture, error) </span><span class="cov8" title="1">{
                         pids := make([]uuid.UUID, len(us))
-                        for i, ue := range us </span><span class="cov7" title="9">{
+                        for i, ue := range us </span><span class="cov8" title="1">{
                                 pids[i] = ue.PrefectureID()
                         }</span>
 
-                        <span class="cov7" title="9">ps, pftErr := u.pftRepo.FindByIDs(ctx, pids)
-                        if pftErr != nil </span><span class="cov1" title="1">{
+                        <span class="cov8" title="1">ps, pftErr := u.pftRepo.FindByIDs(ctx, pids)
+                        if pftErr != nil </span><span class="cov8" title="1">{
                                 return nil, pftErr
                         }</span>
 
-                        <span class="cov6" title="8">prefectureMap := make(map[uuid.UUID]*prefecture.Prefecture, len(ps))
-                        for _, p := range ps </span><span class="cov6" title="6">{
+                        <span class="cov8" title="1">prefectureMap := make(map[uuid.UUID]*prefecture.Prefecture, len(ps))
+                        for _, p := range ps </span><span class="cov8" title="1">{
                                 prefectureMap[p.ID()] = p
                         }</span>
 
-                        <span class="cov6" title="8">return prefectureMap, nil</span>
+                        <span class="cov8" title="1">return prefectureMap, nil</span>
                 })
-        <span class="cov7" title="9">if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
-        <span class="cov6" title="8">dtos := make([]UserView, len(us))
-        for i, ue := range us </span><span class="cov6" title="8">{
+        <span class="cov8" title="1">dtos := make([]UserView, len(us))
+        for i, ue := range us </span><span class="cov8" title="1">{
                 p, ok := prefectureMap[ue.PrefectureID()]
-                if !ok </span><span class="cov2" title="2">{
+                if !ok </span><span class="cov8" title="1">{
                         return nil, errOrphanPrefecture
                 }</span>
-                <span class="cov6" title="6">dtos[i] = toUserView(ue, p.Name())</span>
+                <span class="cov8" title="1">dtos[i] = toUserView(ue, p.Name())</span>
         }
 
-        <span class="cov6" title="6">return dtos, nil</span>
+        <span class="cov8" title="1">return dtos, nil</span>
 }
 
 // resolvePatchPrefecture は、部分更新時の都道府県を解決します。
 // 名前指定があれば名前で解決（入力エラーは伝播）、なければ既存 ID で解決します（未解決は参照整合性破れ）。
-func (u *usecase) resolvePatchPrefecture(ctx context.Context, name *string, currentID uuid.UUID) (*prefecture.Prefecture, error) <span class="cov6" title="6">{
-        if name != nil </span><span class="cov2" title="2">{
+func (u *usecase) resolvePatchPrefecture(ctx context.Context, name *string, currentID uuid.UUID) (*prefecture.Prefecture, error) <span class="cov8" title="1">{
+        if name != nil </span><span class="cov8" title="1">{
                 return u.pftRepo.FindByName(ctx, *name)
         }</span>
-        <span class="cov4" title="4">pftDomain, err := u.pftRepo.FindByID(ctx, currentID)
-        if xerrors.Is(err, apperror.ErrNotFound) </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">pftDomain, err := u.pftRepo.FindByID(ctx, currentID)
+        if xerrors.Is(err, apperror.ErrNotFound) </span><span class="cov8" title="1">{
                 return nil, errOrphanPrefecture
         }</span>
-        <span class="cov4" title="3">if err != nil </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov2" title="2">return pftDomain, nil</span>
+        <span class="cov8" title="1">return pftDomain, nil</span>
 }
 
 // toUserView は、ユーザーエンティティと都道府県名から DTO を構築します。
-func toUserView(u *user.User, prefectureName string) UserView <span class="cov7" title="11">{
+func toUserView(u *user.User, prefectureName string) UserView <span class="cov8" title="1">{
         return UserView{
                 FirstName:      u.FirstName(),
                 LastName:       u.LastName(),
@@ -19322,35 +19313,35 @@ type Exponential struct {
 
 // Duration は、attempt 回目（0 起算）の待機時間を返します。
 // Initial * Multiplier^attempt を計算し、Max が正なら Max で上限を設けます。
-func (e Exponential) Duration(attempt int) time.Duration <span class="cov8" title="702">{
-        if e.Initial &lt;= 0 </span><span class="cov1" title="2">{
+func (e Exponential) Duration(attempt int) time.Duration <span class="cov8" title="1">{
+        if e.Initial &lt;= 0 </span><span class="cov8" title="1">{
                 return 0
         }</span>
-        <span class="cov8" title="700">if attempt &lt; 0 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if attempt &lt; 0 </span><span class="cov8" title="1">{
                 attempt = 0
         }</span>
 
-        <span class="cov8" title="700">mult := e.Multiplier
-        if mult &lt; 1 </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">mult := e.Multiplier
+        if mult &lt; 1 </span><span class="cov8" title="1">{
                 mult = 1
         }</span>
 
-        <span class="cov8" title="700">d := float64(e.Initial)
-        for range attempt </span><span class="cov10" title="3146">{
+        <span class="cov8" title="1">d := float64(e.Initial)
+        for range attempt </span><span class="cov8" title="1">{
                 d *= mult
-                if e.Max &gt; 0 &amp;&amp; d &gt;= float64(e.Max) </span><span class="cov6" title="195">{
+                if e.Max &gt; 0 &amp;&amp; d &gt;= float64(e.Max) </span><span class="cov8" title="1">{
                         return e.Max
                 }</span>
         }
-        <span class="cov7" title="505">if e.Max &gt; 0 &amp;&amp; d &gt; float64(e.Max) </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if e.Max &gt; 0 &amp;&amp; d &gt; float64(e.Max) </span><span class="cov8" title="1">{
                 return e.Max
         }</span>
         // Max 上限なし（Max&lt;=0）かつ高 attempt で d が +Inf / int64 範囲外になりうる。
         // time.Duration(+Inf) は負値になり cooldown が即発火するため、MaxInt64 で頭打ちにする。
-        <span class="cov7" title="504">if d &gt; float64(math.MaxInt64) </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">if d &gt; float64(math.MaxInt64) </span><span class="cov8" title="1">{
                 return time.Duration(math.MaxInt64)
         }</span>
-        <span class="cov7" title="503">return time.Duration(d)</span>
+        <span class="cov8" title="1">return time.Duration(d)</span>
 }
 </pre>
 		
@@ -19362,40 +19353,40 @@ import (
 )
 
 // ParseRFC3339 は、RFC3339形式の日時文字列を解析します。
-func ParseRFC3339(s string) (time.Time, error) <span class="cov4" title="4">{
+func ParseRFC3339(s string) (time.Time, error) <span class="cov8" title="1">{
         return ParseCustomLayout(time.RFC3339, s)
 }</span>
 
 // ParseRFC3339UTC は、末尾が Z（UTC 表記）の RFC3339 文字列のみを解析します。
 // レイアウト末尾はリテラル Z 固定のため、オフセット付き入力（例 +09:00）は受理しません。
-func ParseRFC3339UTC(s string) (time.Time, error) <span class="cov6" title="7">{
+func ParseRFC3339UTC(s string) (time.Time, error) <span class="cov8" title="1">{
         return ParseCustomLayout("2006-01-02T15:04:05Z", s)
 }</span>
 
 // ParseRFC3339Nano は、RFC3339Nano形式の日時文字列を解析します。
-func ParseRFC3339Nano(s string) (time.Time, error) <span class="cov4" title="4">{
+func ParseRFC3339Nano(s string) (time.Time, error) <span class="cov8" title="1">{
         return ParseCustomLayout(time.RFC3339Nano, s)
 }</span>
 
 // ParseISO8601 は、ISO8601形式の日時文字列を解析します。
 // オフセットは Z または ±hhmm 形式（コロンなし）のみ受理します。±hh:mm 形式（例 +09:00）は解析エラーになります。
-func ParseISO8601(s string) (time.Time, error) <span class="cov4" title="4">{
+func ParseISO8601(s string) (time.Time, error) <span class="cov8" title="1">{
         return ParseCustomLayout("2006-01-02T15:04:05Z0700", s)
 }</span>
 
 // ParseDateTime は、日付と時刻（YYYY-MM-DD HH:MM:SS）の日時文字列を解析します。
-func ParseDateTime(s string) (time.Time, error) <span class="cov4" title="4">{
+func ParseDateTime(s string) (time.Time, error) <span class="cov8" title="1">{
         return ParseCustomLayout(time.DateTime, s)
 }</span>
 
 // ParseDateOnly は、日付のみ（YYYY-MM-DD）の日時文字列を解析します。
-func ParseDateOnly(s string) (time.Time, error) <span class="cov4" title="4">{
+func ParseDateOnly(s string) (time.Time, error) <span class="cov8" title="1">{
         return ParseCustomLayout(time.DateOnly, s)
 }</span>
 
 // ParseCustomLayout は、カスタムレイアウトの日時文字列を解析します。
 // layout は Go の参照時刻（2006-01-02T15:04:05Z07:00）に基づくフォーマット文字列です（time.Parse と同仕様）。
-func ParseCustomLayout(layout, s string) (time.Time, error) <span class="cov10" title="31">{
+func ParseCustomLayout(layout, s string) (time.Time, error) <span class="cov8" title="1">{
         return time.Parse(layout, s)
 }</span>
 </pre>
@@ -19410,59 +19401,59 @@ import (
 
 // toLocation は、parse で得た時刻を loc のタイムゾーンへ変換して返す共通ヘルパです。
 // loc が nil の場合、time.Time.In の panic を避けてエラーを返します。
-func toLocation(loc *time.Location, parse func() (time.Time, error)) (time.Time, error) <span class="cov10" title="18">{
-        if loc == nil </span><span class="cov1" title="1">{
+func toLocation(loc *time.Location, parse func() (time.Time, error)) (time.Time, error) <span class="cov8" title="1">{
+        if loc == nil </span><span class="cov8" title="1">{
                 return time.Time{}, xerrors.New("datetime: loc must not be nil")
         }</span>
 
-        <span class="cov9" title="17">t, err := parse()
-        if err != nil </span><span class="cov7" title="8">{
+        <span class="cov8" title="1">t, err := parse()
+        if err != nil </span><span class="cov8" title="1">{
                 return time.Time{}, err
         }</span>
 
-        <span class="cov7" title="9">return t.In(loc), nil</span>
+        <span class="cov8" title="1">return t.In(loc), nil</span>
 }
 
 // ParseRFC3339ToLocation は、RFC3339形式の日時文字列を解析し loc のタイムゾーンへ変換します。
 // loc が nil の場合はエラーを返します。
-func ParseRFC3339ToLocation(s string, loc *time.Location) (time.Time, error) <span class="cov3" title="2">{
-        return toLocation(loc, func() (time.Time, error) </span><span class="cov3" title="2">{ return ParseRFC3339(s) }</span>)
+func ParseRFC3339ToLocation(s string, loc *time.Location) (time.Time, error) <span class="cov8" title="1">{
+        return toLocation(loc, func() (time.Time, error) </span><span class="cov8" title="1">{ return ParseRFC3339(s) }</span>)
 }
 
 // ParseRFC3339UTCToLocation は、RFC3339UTC形式の日時文字列を解析し loc のタイムゾーンへ変換します。
 // loc が nil の場合はエラーを返します。
-func ParseRFC3339UTCToLocation(s string, loc *time.Location) (time.Time, error) <span class="cov6" title="5">{
-        return toLocation(loc, func() (time.Time, error) </span><span class="cov6" title="5">{ return ParseRFC3339UTC(s) }</span>)
+func ParseRFC3339UTCToLocation(s string, loc *time.Location) (time.Time, error) <span class="cov8" title="1">{
+        return toLocation(loc, func() (time.Time, error) </span><span class="cov8" title="1">{ return ParseRFC3339UTC(s) }</span>)
 }
 
 // ParseRFC3339NanoToLocation は、RFC3339Nano形式の日時文字列を解析し loc のタイムゾーンへ変換します。
 // loc が nil の場合はエラーを返します。
-func ParseRFC3339NanoToLocation(s string, loc *time.Location) (time.Time, error) <span class="cov3" title="2">{
-        return toLocation(loc, func() (time.Time, error) </span><span class="cov3" title="2">{ return ParseRFC3339Nano(s) }</span>)
+func ParseRFC3339NanoToLocation(s string, loc *time.Location) (time.Time, error) <span class="cov8" title="1">{
+        return toLocation(loc, func() (time.Time, error) </span><span class="cov8" title="1">{ return ParseRFC3339Nano(s) }</span>)
 }
 
 // ParseISO8601ToLocation は、ISO8601形式の日時文字列を解析し loc のタイムゾーンへ変換します。
 // loc が nil の場合はエラーを返します。
-func ParseISO8601ToLocation(s string, loc *time.Location) (time.Time, error) <span class="cov3" title="2">{
-        return toLocation(loc, func() (time.Time, error) </span><span class="cov3" title="2">{ return ParseISO8601(s) }</span>)
+func ParseISO8601ToLocation(s string, loc *time.Location) (time.Time, error) <span class="cov8" title="1">{
+        return toLocation(loc, func() (time.Time, error) </span><span class="cov8" title="1">{ return ParseISO8601(s) }</span>)
 }
 
 // ParseDateTimeToLocation は、日付と時刻の日時文字列を解析し loc のタイムゾーンへ変換します。
 // loc が nil の場合はエラーを返します。
-func ParseDateTimeToLocation(s string, loc *time.Location) (time.Time, error) <span class="cov3" title="2">{
-        return toLocation(loc, func() (time.Time, error) </span><span class="cov3" title="2">{ return ParseDateTime(s) }</span>)
+func ParseDateTimeToLocation(s string, loc *time.Location) (time.Time, error) <span class="cov8" title="1">{
+        return toLocation(loc, func() (time.Time, error) </span><span class="cov8" title="1">{ return ParseDateTime(s) }</span>)
 }
 
 // ParseDateOnlyToLocation は、日付のみの日時文字列を解析し loc のタイムゾーンへ変換します。
 // loc が nil の場合はエラーを返します。
-func ParseDateOnlyToLocation(s string, loc *time.Location) (time.Time, error) <span class="cov4" title="3">{
-        return toLocation(loc, func() (time.Time, error) </span><span class="cov3" title="2">{ return ParseDateOnly(s) }</span>)
+func ParseDateOnlyToLocation(s string, loc *time.Location) (time.Time, error) <span class="cov8" title="1">{
+        return toLocation(loc, func() (time.Time, error) </span><span class="cov8" title="1">{ return ParseDateOnly(s) }</span>)
 }
 
 // ParseCustomLayoutToLocation は、カスタムレイアウトの日時文字列を解析し loc のタイムゾーンへ変換します。
 // loc が nil の場合はエラーを返します。
-func ParseCustomLayoutToLocation(layout, s string, loc *time.Location) (time.Time, error) <span class="cov3" title="2">{
-        return toLocation(loc, func() (time.Time, error) </span><span class="cov3" title="2">{ return ParseCustomLayout(layout, s) }</span>)
+func ParseCustomLayoutToLocation(layout, s string, loc *time.Location) (time.Time, error) <span class="cov8" title="1">{
+        return toLocation(loc, func() (time.Time, error) </span><span class="cov8" title="1">{ return ParseCustomLayout(layout, s) }</span>)
 }
 </pre>
 		
@@ -19488,19 +19479,19 @@ import (
 //                return err
 //        }
 //        defer restore()
-func Override(key, value string) (func(), error) <span class="cov10" title="3">{
+func Override(key, value string) (func(), error) <span class="cov8" title="1">{
         prev, existed := os.LookupEnv(key)
-        if err := os.Setenv(key, value); err != nil </span><span class="cov1" title="1">{
+        if err := os.Setenv(key, value); err != nil </span><span class="cov8" title="1">{
                 return func() </span>{<span class="cov0" title="0">}</span>, xerrors.Wrap(err, fmt.Sprintf("failed to set env %q", key))
         }
-        <span class="cov6" title="2">restore := func() </span><span class="cov6" title="2">{
-                if existed </span><span class="cov1" title="1">{
+        <span class="cov8" title="1">restore := func() </span><span class="cov8" title="1">{
+                if existed </span><span class="cov8" title="1">{
                         _ = os.Setenv(key, prev)
                         return
                 }</span>
-                <span class="cov1" title="1">_ = os.Unsetenv(key)</span>
+                <span class="cov8" title="1">_ = os.Unsetenv(key)</span>
         }
-        <span class="cov6" title="2">return restore, nil</span>
+        <span class="cov8" title="1">return restore, nil</span>
 }
 </pre>
 		
@@ -19530,19 +19521,19 @@ type OS struct{}
 
 // Output は、dir をカレントとしてコマンドを実行し、標準出力を返します。
 // env は追加で設定する環境変数（"KEY=VALUE"）です。標準エラーは os.Stderr へ流します。コマンドが非ゼロ終了した場合はエラーを返します。
-func (OS) Output(ctx context.Context, dir string, env []string, name string, args []string) ([]byte, error) <span class="cov10" title="4">{
+func (OS) Output(ctx context.Context, dir string, env []string, name string, args []string) ([]byte, error) <span class="cov8" title="1">{
         var stdout bytes.Buffer
         cmd := osexec.CommandContext(ctx, name, args...) //nolint:gosec // name/args は呼び出し側で固定された信頼値
         cmd.Dir = dir
-        if len(env) &gt; 0 </span><span class="cov1" title="1">{
+        if len(env) &gt; 0 </span><span class="cov8" title="1">{
                 cmd.Env = append(os.Environ(), env...)
         }</span>
-        <span class="cov10" title="4">cmd.Stdout = &amp;stdout
+        <span class="cov8" title="1">cmd.Stdout = &amp;stdout
         cmd.Stderr = os.Stderr
-        if err := cmd.Run(); err != nil </span><span class="cov5" title="2">{
+        if err := cmd.Run(); err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov5" title="2">return stdout.Bytes(), nil</span>
+        <span class="cov8" title="1">return stdout.Bytes(), nil</span>
 }
 </pre>
 		
@@ -19561,20 +19552,20 @@ const unknown = "unknown"
 //
 //        "github.com/org/proj/internal/usecase/user.(*UserUsecase).GetUser"
 //          → lhs: "user.(*UserUsecase)", rhs: "GetUser"
-func splitFuncName(full string) (string, string) <span class="cov10" title="920">{
-        if full == "" </span><span class="cov2" title="3">{
+func splitFuncName(full string) (string, string) <span class="cov8" title="1">{
+        if full == "" </span><span class="cov8" title="1">{
                 return unknown, ""
         }</span>
 
-        <span class="cov9" title="917">if idx := strings.LastIndex(full, "/"); idx &gt;= 0 </span><span class="cov9" title="914">{
+        <span class="cov8" title="1">if idx := strings.LastIndex(full, "/"); idx &gt;= 0 </span><span class="cov8" title="1">{
                 full = full[idx+1:]
         }</span>
 
-        <span class="cov9" title="917">if idx := strings.LastIndex(full, "."); idx &gt;= 0 </span><span class="cov9" title="913">{
+        <span class="cov8" title="1">if idx := strings.LastIndex(full, "."); idx &gt;= 0 </span><span class="cov8" title="1">{
                 return full[:idx], full[idx+1:]
         }</span>
 
-        <span class="cov2" title="4">return full, ""</span>
+        <span class="cov8" title="1">return full, ""</span>
 }
 
 // ExtractFunctionName は、runtime.Func のフルネームから span 名として使いやすい
@@ -19583,12 +19574,12 @@ func splitFuncName(full string) (string, string) <span class="cov10" title="920"
 //
 //        "github.com/org/proj/internal/usecase/user.(*UserUsecase).GetUser"
 //          → "GetUser"
-func ExtractFunctionName(full string) string <span class="cov9" title="552">{
+func ExtractFunctionName(full string) string <span class="cov8" title="1">{
         _, fn := splitFuncName(full)
-        if fn == "" </span><span class="cov1" title="2">{
+        if fn == "" </span><span class="cov8" title="1">{
                 return unknown
         }</span>
-        <span class="cov9" title="550">return fn</span>
+        <span class="cov8" title="1">return fn</span>
 }
 
 // ExtractPackageName は、runtime.Func のフルネームからパッケージ名を抽出します。
@@ -19598,19 +19589,19 @@ func ExtractFunctionName(full string) string <span class="cov9" title="552">{
 //
 //        "github.com/org/proj/internal/usecase/user.(*UserUsecase).GetUser" → "user"
 //        "github.com/org/proj/internal/usecase/user.UserUsecase.GetUser"    → "user"
-func ExtractPackageName(full string) string <span class="cov8" title="364">{
+func ExtractPackageName(full string) string <span class="cov8" title="1">{
         lhs, fn := splitFuncName(full)
         // 分割できない（"." が無い）入力は抽出不能として ExtractFunctionName と
         // 同様に unknown へ正規化する。
-        if lhs == unknown || fn == "" </span><span class="cov1" title="2">{
+        if lhs == unknown || fn == "" </span><span class="cov8" title="1">{
                 return unknown
         }</span>
 
-        <span class="cov8" title="362">if before, _, ok := strings.Cut(lhs, "."); ok </span><span class="cov5" title="34">{
+        <span class="cov8" title="1">if before, _, ok := strings.Cut(lhs, "."); ok </span><span class="cov8" title="1">{
                 return before
         }</span>
 
-        <span class="cov8" title="328">return lhs</span>
+        <span class="cov8" title="1">return lhs</span>
 }
 </pre>
 		
@@ -19636,17 +19627,17 @@ type FS interface {
 type OS struct{}
 
 // ReadFile は、name のファイル内容全体を読み込んで返します。
-func (OS) ReadFile(name string) ([]byte, error) <span class="cov10" title="2">{
+func (OS) ReadFile(name string) ([]byte, error) <span class="cov8" title="1">{
         return os.ReadFile(name) //nolint:gosec // path は呼び出し側で検証された信頼パス
 }</span>
 
 // WriteFile は、data を name のファイルへ書き込みます。ファイルが存在しない場合は perm で新規作成します。
-func (OS) WriteFile(name string, data []byte, perm os.FileMode) error <span class="cov10" title="2">{
+func (OS) WriteFile(name string, data []byte, perm os.FileMode) error <span class="cov8" title="1">{
         return os.WriteFile(name, data, perm)
 }</span>
 
 // Glob は、pattern に一致するファイルパスの一覧を返します。
-func (OS) Glob(pattern string) ([]string, error) <span class="cov1" title="1">{
+func (OS) Glob(pattern string) ([]string, error) <span class="cov8" title="1">{
         return filepath.Glob(pattern)
 }</span>
 </pre>
@@ -19655,24 +19646,24 @@ func (OS) Glob(pattern string) ([]string, error) <span class="cov1" title="1">{
 package ptr
 
 // To は、引数として渡された値のポインタを返します。
-func To[T any](v T) *T <span class="cov4" title="11">{ return new(v) }</span>
+func To[T any](v T) *T <span class="cov8" title="1">{ return new(v) }</span>
 
 // Copy は、ポインタの指す値をシャローコピーした新しいポインタを返します（nil 入力時は nil）。
 // T が参照型フィールド（スライス・マップ・ポインタ等）を含む場合、その参照先は複製元と共有されます。
-func Copy[T any](v *T) *T <span class="cov10" title="313">{
-        if v == nil </span><span class="cov8" title="152">{
+func Copy[T any](v *T) *T <span class="cov8" title="1">{
+        if v == nil </span><span class="cov8" title="1">{
                 return nil
         }</span>
-        <span class="cov8" title="161">c := *v
+        <span class="cov8" title="1">c := *v
         return &amp;c</span>
 }
 
 // Deref は、p が非 nil ならその指す値を、nil なら fallback を返します。
-func Deref[T any](p *T, fallback T) T <span class="cov5" title="24">{
-        if p != nil </span><span class="cov3" title="5">{
+func Deref[T any](p *T, fallback T) T <span class="cov8" title="1">{
+        if p != nil </span><span class="cov8" title="1">{
                 return *p
         }</span>
-        <span class="cov5" title="19">return fallback</span>
+        <span class="cov8" title="1">return fallback</span>
 }
 </pre>
 		
@@ -19689,15 +19680,15 @@ import (
 //
 // ただし d == math.MaxInt64（バックオフ上限到達時に起こり得る）のときは、閉区間化のための
 // 加算が int64 をオーバーフローするため、上限 d を除いた [0, d) を返します。
-func Full(d time.Duration) time.Duration <span class="cov10" title="943">{
-        if d &lt;= 0 </span><span class="cov2" title="4">{
+func Full(d time.Duration) time.Duration <span class="cov8" title="1">{
+        if d &lt;= 0 </span><span class="cov8" title="1">{
                 return 0
         }</span>
-        <span class="cov9" title="939">n := int64(d)
-        if n != math.MaxInt64 </span><span class="cov9" title="839">{
+        <span class="cov8" title="1">n := int64(d)
+        if n != math.MaxInt64 </span><span class="cov8" title="1">{
                 n++
         }</span>
-        <span class="cov9" title="939">return time.Duration(rand.Int64N(n))</span> //nolint:gosec // jitter は暗号強度不要
+        <span class="cov8" title="1">return time.Duration(rand.Int64N(n))</span> //nolint:gosec // jitter は暗号強度不要
 }
 </pre>
 		
@@ -19756,24 +19747,24 @@ func Do(
         policy Policy,
         isRetryable func(error) bool,
         fn func(context.Context) error,
-) error <span class="cov9" title="77">{
-        if isRetryable == nil </span><span class="cov2" title="2">{
-                isRetryable = func(error) bool </span><span class="cov1" title="1">{ return false }</span>
+) error <span class="cov8" title="1">{
+        if isRetryable == nil </span><span class="cov8" title="1">{
+                isRetryable = func(error) bool </span><span class="cov8" title="1">{ return false }</span>
         }
-        <span class="cov9" title="77">attempts := max(1, policy.MaxAttempts)
+        <span class="cov8" title="1">attempts := max(1, policy.MaxAttempts)
 
         var err error
-        for attempt := 1; attempt &lt;= attempts; attempt++ </span><span class="cov10" title="85">{
+        for attempt := 1; attempt &lt;= attempts; attempt++ </span><span class="cov8" title="1">{
                 err = fn(ctx)
-                if err == nil || !isRetryable(err) || attempt == attempts </span><span class="cov9" title="73">{
+                if err == nil || !isRetryable(err) || attempt == attempts </span><span class="cov8" title="1">{
                         return err
                 }</span>
 
-                <span class="cov5" title="10">var base time.Duration
-                if policy.Backoff != nil </span><span class="cov5" title="9">{
+                <span class="cov8" title="1">var base time.Duration
+                if policy.Backoff != nil </span><span class="cov8" title="1">{
                         base = policy.Backoff(attempt - 1)
                 }</span>
-                <span class="cov5" title="10">if serr := sleeper.Sleep(ctx, Full(base)); serr != nil </span><span class="cov2" title="2">{
+                <span class="cov8" title="1">if serr := sleeper.Sleep(ctx, Full(base)); serr != nil </span><span class="cov8" title="1">{
                         return err
                 }</span>
         }
@@ -19793,12 +19784,12 @@ import (
 
 // UintToInt は、uintをintに安全に変換します。
 // オーバーフローが発生する場合はエラーを返します。
-func UintToInt(x uint) (int, error) <span class="cov10" title="9">{
+func UintToInt(x uint) (int, error) <span class="cov8" title="1">{
         const maxInt = math.MaxInt
-        if x &gt; maxInt </span><span class="cov5" title="3">{
+        if x &gt; maxInt </span><span class="cov8" title="1">{
                 return 0, xerrors.Wrap(ErrOverflow, fmt.Sprintf("uint %d exceeds MaxInt(%d)", x, maxInt))
         }</span>
-        <span class="cov8" title="6">return int(x), nil</span>
+        <span class="cov8" title="1">return int(x), nil</span>
 }
 </pre>
 		
@@ -19816,46 +19807,46 @@ const (
 )
 
 // ValidateInRange は 文字数が minLen～maxLen 内かを判定し、範囲外なら理由メッセージを返します。
-func ValidateInRange(s string, minLen, maxLen int) (bool, string) <span class="cov10" title="1084">{
+func ValidateInRange(s string, minLen, maxLen int) (bool, string) <span class="cov8" title="1">{
         n := RuneCount(s)
-        if minLen &lt;= n &amp;&amp; n &lt;= maxLen </span><span class="cov9" title="1051">{
+        if minLen &lt;= n &amp;&amp; n &lt;= maxLen </span><span class="cov8" title="1">{
                 return true, ""
         }</span>
-        <span class="cov5" title="33">return false, fmt.Sprintf(errMsgInRange, minLen, maxLen, n)</span>
+        <span class="cov8" title="1">return false, fmt.Sprintf(errMsgInRange, minLen, maxLen, n)</span>
 }
 
 // ErrorMsgInRange は、文字数が minLen ～ maxLen の範囲外であった場合に返すエラーメッセージを生成します。
-func ErrorMsgInRange(minLen, maxLen int, got string) string <span class="cov1" title="1">{
+func ErrorMsgInRange(minLen, maxLen int, got string) string <span class="cov8" title="1">{
         n := RuneCount(got)
         return fmt.Sprintf(errMsgInRange, minLen, maxLen, n)
 }</span>
 
 // ErrorMsgMaxOrLess は、文字数が maxLen を超えた場合に返すエラーメッセージを生成します。
-func ErrorMsgMaxOrLess(maxLen int, got string) string <span class="cov1" title="1">{
+func ErrorMsgMaxOrLess(maxLen int, got string) string <span class="cov8" title="1">{
         n := RuneCount(got)
         return fmt.Sprintf(errMsgMaxOrLess, maxLen, n)
 }</span>
 
 // ErrorMsgMinOrMore は、文字数が minLen 未満であった場合に返すエラーメッセージを生成します。
-func ErrorMsgMinOrMore(minLen int, got string) string <span class="cov1" title="1">{
+func ErrorMsgMinOrMore(minLen int, got string) string <span class="cov8" title="1">{
         n := RuneCount(got)
         return fmt.Sprintf(errMsgMinOrMore, minLen, n)
 }</span>
 
 // ErrorMsgStrictInRange は、文字数が minLen &lt; 文字数 &lt; maxLen の範囲に収まらなかった場合に返すエラーメッセージを生成します。
-func ErrorMsgStrictInRange(minLen, maxLen int, got string) string <span class="cov1" title="1">{
+func ErrorMsgStrictInRange(minLen, maxLen int, got string) string <span class="cov8" title="1">{
         n := RuneCount(got)
         return fmt.Sprintf(errMsgStrictInRange, minLen, maxLen, n)
 }</span>
 
 // ErrorMsgLessThanMax は、文字数が maxLen 以上だった場合に返すエラーメッセージを生成します。
-func ErrorMsgLessThanMax(maxLen int, got string) string <span class="cov1" title="1">{
+func ErrorMsgLessThanMax(maxLen int, got string) string <span class="cov8" title="1">{
         n := RuneCount(got)
         return fmt.Sprintf(errMsgLessThanMax, maxLen, n)
 }</span>
 
 // ErrorMsgGreaterThanMin は、文字数が minLen 以下だった場合に返すエラーメッセージを生成します。
-func ErrorMsgGreaterThanMin(minLen int, got string) string <span class="cov1" title="1">{
+func ErrorMsgGreaterThanMin(minLen int, got string) string <span class="cov8" title="1">{
         n := RuneCount(got)
         return fmt.Sprintf(errMsgGreaterThanMin, minLen, n)
 }</span>
@@ -19869,39 +19860,39 @@ import (
 )
 
 // RuneCount は UTF-8 文字列の文字数を返します。
-func RuneCount(s string) int <span class="cov10" title="1137">{
+func RuneCount(s string) int <span class="cov8" title="1">{
         return utf8.RuneCountInString(s)
 }</span>
 
 // InRange は minLen &lt;= 文字数 &lt;= maxLen のとき true
-func InRange(s string, minLen, maxLen int) bool <span class="cov5" title="32">{
+func InRange(s string, minLen, maxLen int) bool <span class="cov8" title="1">{
         n := RuneCount(s)
         return minLen &lt;= n &amp;&amp; n &lt;= maxLen
 }</span>
 
 // MaxOrLess は 文字数 &lt;= maxLen のとき true
-func MaxOrLess(s string, maxLen int) bool <span class="cov1" title="2">{
+func MaxOrLess(s string, maxLen int) bool <span class="cov8" title="1">{
         return RuneCount(s) &lt;= maxLen
 }</span>
 
 // MinOrMore は 文字数 &gt;= minLen のとき true
-func MinOrMore(s string, minLen int) bool <span class="cov1" title="2">{
+func MinOrMore(s string, minLen int) bool <span class="cov8" title="1">{
         return RuneCount(s) &gt;= minLen
 }</span>
 
 // StrictInRange は minLen &lt; 文字数 &lt; maxLen のとき true
-func StrictInRange(s string, minLen, maxLen int) bool <span class="cov2" title="3">{
+func StrictInRange(s string, minLen, maxLen int) bool <span class="cov8" title="1">{
         n := RuneCount(s)
         return minLen &lt; n &amp;&amp; n &lt; maxLen
 }</span>
 
 // LessThanMax は 文字数 &lt; maxLen のとき true
-func LessThanMax(s string, maxLen int) bool <span class="cov1" title="2">{
+func LessThanMax(s string, maxLen int) bool <span class="cov8" title="1">{
         return RuneCount(s) &lt; maxLen
 }</span>
 
 // GreaterThanMin は 文字数 &gt; minLen のとき true
-func GreaterThanMin(s string, minLen int) bool <span class="cov1" title="2">{
+func GreaterThanMin(s string, minLen int) bool <span class="cov8" title="1">{
         return RuneCount(s) &gt; minLen
 }</span>
 </pre>
@@ -19912,11 +19903,11 @@ import (
         guuid "github.com/google/uuid"
 )
 
-func fromGoogle(g guuid.UUID) UUID <span class="cov10" title="482">{
+func fromGoogle(g guuid.UUID) UUID <span class="cov8" title="1">{
         return UUID{b: g}
 }</span>
 
-func toGoogle(u UUID) guuid.UUID <span class="cov7" title="101">{
+func toGoogle(u UUID) guuid.UUID <span class="cov8" title="1">{
         return guuid.UUID(u.b)
 }</span>
 </pre>
@@ -19932,7 +19923,7 @@ import (
 // NewTestFromSalt はテスト専用の決定論UUID生成関数です。
 //
 // v5(SHA-1)ベースで、同じsaltなら毎回同じ値を返します。
-func NewTestFromSalt(tb testing.TB, salt string) UUID <span class="cov10" title="108">{
+func NewTestFromSalt(tb testing.TB, salt string) UUID <span class="cov8" title="1">{
         tb.Helper()
         ns := uuid.NameSpaceURL
         g := uuid.NewSHA1(ns, []byte(salt))
@@ -19953,59 +19944,59 @@ import (
 type UUID struct{ b [16]byte } //nolint:recvcheck // immutable VO; pointer receiver only for Scan (sql.Scanner)
 
 // New は、UUIDv7（時刻単調増加）を生成します。生成に失敗した場合はエラーを返します。
-func New() (UUID, error) <span class="cov6" title="36">{
+func New() (UUID, error) <span class="cov8" title="1">{
         g, err := uuid.NewV7()
-        if err != nil </span><span class="cov1" title="1">{
+        if err != nil </span><span class="cov8" title="1">{
                 return UUID{}, err
         }</span>
-        <span class="cov6" title="35">return fromGoogle(g), nil</span>
+        <span class="cov8" title="1">return fromGoogle(g), nil</span>
 }
 
 // String は、UUIDを文字列に変換します。
-func (u UUID) String() string <span class="cov7" title="46">{ return toGoogle(u).String() }</span>
+func (u UUID) String() string <span class="cov8" title="1">{ return toGoogle(u).String() }</span>
 
 // Bytes は、UUIDをバイト配列に変換します。
-func (u UUID) Bytes() [16]byte <span class="cov2" title="2">{ return u.b }</span>
+func (u UUID) Bytes() [16]byte <span class="cov8" title="1">{ return u.b }</span>
 
 // ToPrimitive は、UUIDから github.com/google/uuid の uuid.UUID を生成します。
-func (u UUID) ToPrimitive() uuid.UUID <span class="cov5" title="19">{ return toGoogle(u) }</span>
+func (u UUID) ToPrimitive() uuid.UUID <span class="cov8" title="1">{ return toGoogle(u) }</span>
 
 // IsNil は、UUIDが全てゼロであるかどうかを判定します。
-func (u UUID) IsNil() bool <span class="cov10" title="275">{ return u.b == [16]byte{} }</span>
+func (u UUID) IsNil() bool <span class="cov8" title="1">{ return u.b == [16]byte{} }</span>
 
 // Equal は、引数のUUIDと等しいかどうかを判定します。
-func (u UUID) Equal(v UUID) bool <span class="cov3" title="5">{ return u.b == v.b }</span>
+func (u UUID) Equal(v UUID) bool <span class="cov8" title="1">{ return u.b == v.b }</span>
 
 // ToPtr は、UUIDのポインタを返します。
-func (u UUID) ToPtr() *UUID <span class="cov2" title="3">{ return &amp;u }</span>
+func (u UUID) ToPtr() *UUID <span class="cov8" title="1">{ return &amp;u }</span>
 
 // EqualPtr は、ポインタを介してUUIDが等しいかどうかを判定します。
-func (u UUID) EqualPtr(v *UUID) bool <span class="cov2" title="3">{ return v != nil &amp;&amp; u.b == v.b }</span>
+func (u UUID) EqualPtr(v *UUID) bool <span class="cov8" title="1">{ return v != nil &amp;&amp; u.b == v.b }</span>
 
 // FromPrimitive は、github.com/google/uuid の uuid.UUID からドメインの UUID を生成します。
-func FromPrimitive(g uuid.UUID) UUID <span class="cov5" title="17">{ return fromGoogle(g) }</span>
+func FromPrimitive(g uuid.UUID) UUID <span class="cov8" title="1">{ return fromGoogle(g) }</span>
 
 // Parse は、文字列からUUIDを解析します。解析に失敗した場合はエラーを返します。
-func Parse(s string) (UUID, error) <span class="cov8" title="110">{
+func Parse(s string) (UUID, error) <span class="cov8" title="1">{
         g, err := uuid.Parse(s)
-        if err != nil </span><span class="cov6" title="31">{
+        if err != nil </span><span class="cov8" title="1">{
                 return UUID{}, err
         }</span>
-        <span class="cov8" title="79">return fromGoogle(g), nil</span>
+        <span class="cov8" title="1">return fromGoogle(g), nil</span>
 }
 
 // Scan は、データベースからUUIDをスキャンします。スキャンに失敗した場合はエラーを返します。
-func (u *UUID) Scan(src any) error <span class="cov9" title="243">{
+func (u *UUID) Scan(src any) error <span class="cov8" title="1">{
         var g uuid.UUID
-        if err := g.Scan(src); err != nil </span><span class="cov1" title="1">{
+        if err := g.Scan(src); err != nil </span><span class="cov8" title="1">{
                 return err
         }</span>
-        <span class="cov9" title="242">*u = fromGoogle(g)
+        <span class="cov8" title="1">*u = fromGoogle(g)
         return nil</span>
 }
 
 // Value は、UUIDをデータベースに保存するための値に変換します。変換に失敗した場合はエラーを返します。
-func (u UUID) Value() (driver.Value, error) <span class="cov6" title="34">{
+func (u UUID) Value() (driver.Value, error) <span class="cov8" title="1">{
         return toGoogle(u).Value()
 }</span>
 </pre>
@@ -20020,38 +20011,38 @@ import (
 )
 
 // New は、新しいエラーを生成します。
-func New(msg string) error <span class="cov9" title="1566">{
+func New(msg string) error <span class="cov8" title="1">{
         return errors.New(msg)
 }</span>
 
 // Wrap は、既存のエラーをラップして新しいエラーを生成します。
 // msg はラップする際の追加メッセージです。メッセージは元のエラーの前に付加されます。
 // err が nil の場合は nil を返します。
-func Wrap(err error, msg string) error <span class="cov10" title="2274">{
+func Wrap(err error, msg string) error <span class="cov8" title="1">{
         return errors.Wrap(err, msg)
 }</span>
 
 // Is は、エラーが特定のターゲットエラーと一致するかを判定します。
-func Is(err, target error) bool <span class="cov9" title="1776">{
+func Is(err, target error) bool <span class="cov8" title="1">{
         return errors.Is(err, target)
 }</span>
 
 // As は、エラーが特定のターゲット型に変換可能かを判定します。
-func As(err error, target any) bool <span class="cov8" title="549">{
+func As(err error, target any) bool <span class="cov8" title="1">{
         return errors.As(err, target)
 }</span>
 
 // Join は、複数のエラーを結合して新しいエラーを生成します。
-func Join(errs ...error) error <span class="cov6" title="110">{
+func Join(errs ...error) error <span class="cov8" title="1">{
         return errors.Join(errs...)
 }</span>
 
 // StackTrace は、err の詳細文字列表現を返します。err が cockroachdb/errors 等でスタックトレースを付加されている場合はそれも含みます。err が nil の場合は空文字列を返します。
-func StackTrace(err error) string <span class="cov4" title="17">{
-        if err == nil </span><span class="cov1" title="2">{
+func StackTrace(err error) string <span class="cov8" title="1">{
+        if err == nil </span><span class="cov8" title="1">{
                 return ""
         }</span>
-        <span class="cov4" title="15">return fmt.Sprintf("%+v", err)</span>
+        <span class="cov8" title="1">return fmt.Sprintf("%+v", err)</span>
 }
 </pre>
 		


### PR DESCRIPTION
# 概要

`docs/coverage/index.html` が実質無変更でも diff が発生し、auto-generate-docs の同期 PR（例: #503）にノイズが乗る問題を解消する。あわせて runtime イメージに同梱される OS パッケージのライセンス位置づけを README に明記する。

## 変更内容

- **Build: coverage HTML の決定的化**（`.makefiles/go/test.mk` / `docs/coverage/index.html`）
  - `gen-test-repo` の covermode を `atomic` → `set` に変更。`atomic` は各文の実行回数を記録するため、並列・時間依存テストで回数が run ごとに揺れ、`go tool cover -html` がその回数を基準に相対 10 段階で色付けする結果、カバー行が不変でも `title` / `cov` クラスが churn していた。`set` は実行有無（0/1）のみ記録するため、同一カバー集合なら HTML がバイト単位で決定的になる。
  - `set` モードで `docs/coverage/index.html` を再生成。
  - カバー率ゲートは `test-cover-ci`（`atomic` 維持）が担い、値は set/atomic で不変のため影響なし。
- **Docs: ライセンス注記の追加**（`README.md` / `README.ja.md`）
  - `runtime` イメージ（alpine ベース）に含まれる GPL-2.0-only の OS パッケージは Go バイナリにリンクされない *mere aggregation* であり、商用配布に支障しない旨を License セクションに追記。英日を同期。

## 動作確認方法

1. `make gen-test-repo` を2回実行し、`docs/coverage/index.html` がバイト単位で一致（diff=0）することを確認済み。`title` は `0` / `1` のみ。
2. `make md-lint` → 0 error（528 ファイル）、`make fix` → 変更なし。