### PR TITLE
Feat: 起動ログの可視性向上（configurator 個別ログ + build-info ログ）

### DIFF
--- a/internal/di/fx_event_logger.go
+++ b/internal/di/fx_event_logger.go
@@ -13,76 +13,76 @@ type fxEventLogger struct {
 
 // NewFxEventLogger は、fx.WithLogger に渡す fxevent.Logger を生成します。
 func NewFxEventLogger(logger logging.Logger) fxevent.Logger {
-	return &fxEventLogger{logger: logger.Named("fx")}
+	return &fxEventLogger{logger: logger.Named("Fx").CallerSkip(callSkip)}
 }
 
 func (f *fxEventLogger) LogEvent(event fxevent.Event) {
 	switch e := event.(type) {
 	case *fxevent.OnStartExecuted:
 		f.record(e.Err,
-			"fx OnStart hook failed",
+			"OnStart hook failed",
 			[]*logging.Field{logging.String("callee", e.FunctionName), logging.String("caller", e.CallerName)},
-			f.logger.Debug, "fx OnStart hook executed",
+			f.logger.Debug, "OnStart hook executed",
 			logging.String("callee", e.FunctionName), logging.String("caller", e.CallerName),
 			logging.DurationMs("runtime_ms", e.Runtime))
 	case *fxevent.OnStopExecuted:
 		f.record(e.Err,
-			"fx OnStop hook failed",
+			"OnStop hook failed",
 			[]*logging.Field{logging.String("callee", e.FunctionName), logging.String("caller", e.CallerName)},
-			f.logger.Debug, "fx OnStop hook executed",
+			f.logger.Debug, "OnStop hook executed",
 			logging.String("callee", e.FunctionName), logging.String("caller", e.CallerName),
 			logging.DurationMs("runtime_ms", e.Runtime))
 	case *fxevent.Supplied:
 		f.record(e.Err,
-			"fx supply failed",
+			"Supply failed",
 			[]*logging.Field{logging.String("type", e.TypeName), logging.String("module", e.ModuleName)},
-			f.logger.Debug, "fx supplied",
+			f.logger.Debug, "Supplied",
 			logging.String("type", e.TypeName), logging.String("module", e.ModuleName))
 	case *fxevent.Provided:
 		f.record(e.Err,
-			"fx provide failed",
+			"Provide failed",
 			[]*logging.Field{logging.String("constructor", e.ConstructorName), logging.String("module", e.ModuleName)},
-			f.logger.Debug, "fx provided",
+			f.logger.Debug, "Provided",
 			logging.String("constructor", e.ConstructorName), logging.String("module", e.ModuleName),
 			logging.Strings("output_types", e.OutputTypeNames))
 	case *fxevent.Invoked:
 		f.record(e.Err,
-			"fx invoke failed",
+			"Invoke failed",
 			[]*logging.Field{logging.String("function", e.FunctionName), logging.String("module", e.ModuleName)},
-			f.logger.Debug, "fx invoked",
+			f.logger.Debug, "Invoked",
 			logging.String("function", e.FunctionName), logging.String("module", e.ModuleName))
 	case *fxevent.Replaced:
 		f.record(e.Err,
-			"fx replace failed",
+			"Replace failed",
 			[]*logging.Field{logging.String("module", e.ModuleName)},
-			f.logger.Debug, "fx replaced",
+			f.logger.Debug, "Replaced",
 			logging.Strings("output_types", e.OutputTypeNames), logging.String("module", e.ModuleName))
 	case *fxevent.Decorated:
 		f.record(e.Err,
-			"fx decorate failed",
+			"Decorate failed",
 			[]*logging.Field{logging.String("decorator", e.DecoratorName), logging.String("module", e.ModuleName)},
-			f.logger.Debug, "fx decorated",
+			f.logger.Debug, "Decorated",
 			logging.String("decorator", e.DecoratorName), logging.String("module", e.ModuleName),
 			logging.Strings("output_types", e.OutputTypeNames))
 	case *fxevent.LoggerInitialized:
 		f.record(e.Err,
-			"fx logger initialization failed", nil,
-			f.logger.Debug, "fx custom logger initialized",
+			"Logger initialization failed", nil,
+			f.logger.Debug, "Custom logger initialized",
 			logging.String("constructor", e.ConstructorName))
 	case *fxevent.Started:
 		f.record(e.Err,
-			"fx application failed to start", nil,
-			f.logger.Info, "fx application started")
+			"Application failed to start", nil,
+			f.logger.Info, "Application started")
 	case *fxevent.Stopped:
 		f.record(e.Err,
-			"fx application failed to stop", nil,
-			f.logger.Info, "fx application stopped")
+			"Application failed to stop", nil,
+			f.logger.Info, "Application stopped")
 	case *fxevent.RollingBack:
-		f.logger.Error("fx start failed, rolling back", logging.Error(logging.ErrorKey, e.StartErr))
+		f.logger.Error("start failed, rolling back", logging.Error(logging.ErrorKey, e.StartErr))
 	case *fxevent.RolledBack:
 		f.record(e.Err,
-			"fx rollback failed", nil,
-			f.logger.Debug, "fx rolled back")
+			"Rollback failed", nil,
+			f.logger.Debug, "Application rolled back")
 	}
 }
 

--- a/internal/di/fx_event_logger_test.go
+++ b/internal/di/fx_event_logger_test.go
@@ -43,117 +43,117 @@ func TestFxEventLogger_LogEvent(t *testing.T) {
 
 	t.Run("OnStart失敗はErrorで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.OnStartExecuted{FunctionName: "f", CallerName: "c", Err: boom}, "fx OnStart hook failed", "error")
+		assertLogged(t, &fxevent.OnStartExecuted{FunctionName: "f", CallerName: "c", Err: boom}, "OnStart hook failed", "error")
 	})
 
 	t.Run("OnStart成功はDebugで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.OnStartExecuted{FunctionName: "f", CallerName: "c"}, "fx OnStart hook executed", "debug")
+		assertLogged(t, &fxevent.OnStartExecuted{FunctionName: "f", CallerName: "c"}, "OnStart hook executed", "debug")
 	})
 
 	t.Run("OnStop失敗はErrorで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.OnStopExecuted{FunctionName: "f", Err: boom}, "fx OnStop hook failed", "error")
+		assertLogged(t, &fxevent.OnStopExecuted{FunctionName: "f", Err: boom}, "OnStop hook failed", "error")
 	})
 
 	t.Run("OnStop成功はDebugで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.OnStopExecuted{FunctionName: "f"}, "fx OnStop hook executed", "debug")
+		assertLogged(t, &fxevent.OnStopExecuted{FunctionName: "f"}, "OnStop hook executed", "debug")
 	})
 
 	t.Run("Supply失敗はErrorで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.Supplied{TypeName: "T", Err: boom}, "fx supply failed", "error")
+		assertLogged(t, &fxevent.Supplied{TypeName: "T", Err: boom}, "Supply failed", "error")
 	})
 
 	t.Run("Supply成功はDebugで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.Supplied{TypeName: "T", ModuleName: "m"}, "fx supplied", "debug")
+		assertLogged(t, &fxevent.Supplied{TypeName: "T", ModuleName: "m"}, "Supplied", "debug")
 	})
 
 	t.Run("Provide失敗はErrorで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.Provided{ConstructorName: "ctor", Err: boom}, "fx provide failed", "error")
+		assertLogged(t, &fxevent.Provided{ConstructorName: "ctor", Err: boom}, "Provide failed", "error")
 	})
 
 	t.Run("Provide成功はDebugで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.Provided{ConstructorName: "ctor", ModuleName: "m", OutputTypeNames: []string{"T"}}, "fx provided", "debug")
+		assertLogged(t, &fxevent.Provided{ConstructorName: "ctor", ModuleName: "m", OutputTypeNames: []string{"T"}}, "Provided", "debug")
 	})
 
 	t.Run("Invoke失敗はErrorで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.Invoked{FunctionName: "f", Err: boom}, "fx invoke failed", "error")
+		assertLogged(t, &fxevent.Invoked{FunctionName: "f", Err: boom}, "Invoke failed", "error")
 	})
 
 	t.Run("Invoke成功はDebugで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.Invoked{FunctionName: "f", ModuleName: "m"}, "fx invoked", "debug")
+		assertLogged(t, &fxevent.Invoked{FunctionName: "f", ModuleName: "m"}, "Invoked", "debug")
 	})
 
 	t.Run("Replace失敗はErrorで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.Replaced{Err: boom}, "fx replace failed", "error")
+		assertLogged(t, &fxevent.Replaced{Err: boom}, "Replace failed", "error")
 	})
 
 	t.Run("Replace成功はDebugで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.Replaced{OutputTypeNames: []string{"T"}, ModuleName: "m"}, "fx replaced", "debug")
+		assertLogged(t, &fxevent.Replaced{OutputTypeNames: []string{"T"}, ModuleName: "m"}, "Replaced", "debug")
 	})
 
 	t.Run("Decorate失敗はErrorで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.Decorated{DecoratorName: "dec", Err: boom}, "fx decorate failed", "error")
+		assertLogged(t, &fxevent.Decorated{DecoratorName: "dec", Err: boom}, "Decorate failed", "error")
 	})
 
 	t.Run("Decorate成功はDebugで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.Decorated{DecoratorName: "dec", ModuleName: "m", OutputTypeNames: []string{"T"}}, "fx decorated", "debug")
+		assertLogged(t, &fxevent.Decorated{DecoratorName: "dec", ModuleName: "m", OutputTypeNames: []string{"T"}}, "Decorated", "debug")
 	})
 
 	t.Run("LoggerInitialized失敗はErrorで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.LoggerInitialized{Err: boom}, "fx logger initialization failed", "error")
+		assertLogged(t, &fxevent.LoggerInitialized{Err: boom}, "Logger initialization failed", "error")
 	})
 
 	t.Run("LoggerInitialized成功はDebugで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.LoggerInitialized{ConstructorName: "ctor"}, "fx custom logger initialized", "debug")
+		assertLogged(t, &fxevent.LoggerInitialized{ConstructorName: "ctor"}, "Custom logger initialized", "debug")
 	})
 
 	t.Run("Started失敗はErrorで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.Started{Err: boom}, "fx application failed to start", "error")
+		assertLogged(t, &fxevent.Started{Err: boom}, "Application failed to start", "error")
 	})
 
 	t.Run("Started成功はInfoで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.Started{}, "fx application started", "info")
+		assertLogged(t, &fxevent.Started{}, "Application started", "info")
 	})
 
 	t.Run("Stopped失敗はErrorで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.Stopped{Err: boom}, "fx application failed to stop", "error")
+		assertLogged(t, &fxevent.Stopped{Err: boom}, "Application failed to stop", "error")
 	})
 
 	t.Run("Stopped成功はInfoで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.Stopped{}, "fx application stopped", "info")
+		assertLogged(t, &fxevent.Stopped{}, "Application stopped", "info")
 	})
 
 	t.Run("RollingBackは起動失敗をErrorで記録する", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.RollingBack{StartErr: boom}, "fx start failed, rolling back", "error")
+		assertLogged(t, &fxevent.RollingBack{StartErr: boom}, "start failed, rolling back", "error")
 	})
 
 	t.Run("RolledBack失敗はErrorで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.RolledBack{Err: boom}, "fx rollback failed", "error")
+		assertLogged(t, &fxevent.RolledBack{Err: boom}, "Rollback failed", "error")
 	})
 
 	t.Run("RolledBack成功はDebugで記録される", func(t *testing.T) {
 		t.Parallel()
-		assertLogged(t, &fxevent.RolledBack{}, "fx rolled back", "debug")
+		assertLogged(t, &fxevent.RolledBack{}, "Application rolled back", "debug")
 	})
 
 	t.Run("対象外イベントは無視される", func(t *testing.T) {

--- a/internal/di/module/system.go
+++ b/internal/di/module/system.go
@@ -1,6 +1,7 @@
 package module
 
 import (
+	"go-boilerplate/internal/logging"
 	"go-boilerplate/internal/system"
 
 	"go.uber.org/fx"
@@ -12,5 +13,18 @@ func SystemModule() fx.Option {
 		fx.Provide(
 			system.NewBuildInfo,
 		),
+		fx.Invoke(
+			logBuildInfo,
+		),
+	)
+}
+
+// logBuildInfo は、起動時にアプリのビルド情報を1行ログへ出力します。
+func logBuildInfo(logger logging.Logger, bi system.BuildInfo) {
+	logger.Named("system.buildinfo").CallerSkip(callerSkipCount).Info(
+		"application build info",
+		logging.String("version", bi.Version()),
+		logging.String("revision", bi.Revision()),
+		logging.String("build_date", bi.BuildDate()),
 	)
 }

--- a/internal/di/module/system.go
+++ b/internal/di/module/system.go
@@ -1,6 +1,7 @@
 package module
 
 import (
+	"go-boilerplate/internal/config"
 	"go-boilerplate/internal/logging"
 	"go-boilerplate/internal/system"
 
@@ -20,11 +21,12 @@ func SystemModule() fx.Option {
 }
 
 // logBuildInfo は、起動時にアプリのビルド情報を1行ログへ出力します。
-func logBuildInfo(logger logging.Logger, bi system.BuildInfo) {
+func logBuildInfo(logger logging.Logger, bi system.BuildInfo, appCfg *config.ApplicationConfig) {
 	logger.Named("system.buildinfo").CallerSkip(callerSkipCount).Info(
 		"application build info",
 		logging.String("version", bi.Version()),
 		logging.String("revision", bi.Revision()),
 		logging.String("build_date", bi.BuildDate()),
+		logging.String("mode", appCfg.Mode()),
 	)
 }

--- a/internal/di/module/system_test.go
+++ b/internal/di/module/system_test.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
 
+	"go-boilerplate/internal/config"
 	"go-boilerplate/internal/logging"
 	"go-boilerplate/internal/system"
 	mock_system "go-boilerplate/internal/system/mock"
@@ -27,8 +28,9 @@ func TestSystemModule_ProvidesBuildInfo(t *testing.T) {
 
 			app := fx.New(
 				SystemModule(),
-				// logBuildInfo の Invoke が logging.Logger を要求するため供給する。
+				// logBuildInfo の Invoke が logging.Logger と ApplicationConfig を要求するため供給する。
 				fx.Provide(func() logging.Logger { return logging.NewTestLogger(t) }),
+				fx.Provide(func() *config.ApplicationConfig { return config.NewApplicationConfig(config.MockConfigForTest(t)) }),
 				fx.Populate(&bi),
 				fx.NopLogger,
 			)
@@ -50,7 +52,7 @@ func TestLogBuildInfo(t *testing.T) {
 	t.Run("正常系", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("version / revision / build_date を付与して出力する", func(t *testing.T) {
+		t.Run("version / revision / build_date / mode を付与して出力する", func(t *testing.T) {
 			t.Parallel()
 
 			logger, observed := logging.NewObservedTestLogger(t)
@@ -59,8 +61,9 @@ func TestLogBuildInfo(t *testing.T) {
 			bi.EXPECT().Version().Return("v1.2.3")
 			bi.EXPECT().Revision().Return("abc1234")
 			bi.EXPECT().BuildDate().Return("2026-07-01T00:00:00Z")
+			appCfg := config.NewApplicationConfig(config.MockConfigForTest(t))
 
-			logBuildInfo(logger, bi)
+			logBuildInfo(logger, bi, appCfg)
 
 			logs := observed.All()
 			require.Len(t, logs, 1)
@@ -73,6 +76,7 @@ func TestLogBuildInfo(t *testing.T) {
 			assert.Equal(t, "v1.2.3", fields["version"])
 			assert.Equal(t, "abc1234", fields["revision"])
 			assert.Equal(t, "2026-07-01T00:00:00Z", fields["build_date"])
+			assert.Equal(t, config.DevelopmentMode, fields["mode"])
 		})
 	})
 }

--- a/internal/di/module/system_test.go
+++ b/internal/di/module/system_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
+	"go.uber.org/mock/gomock"
 
+	"go-boilerplate/internal/logging"
 	"go-boilerplate/internal/system"
+	mock_system "go-boilerplate/internal/system/mock"
 )
 
 func TestSystemModule_ProvidesBuildInfo(t *testing.T) {
@@ -23,6 +27,8 @@ func TestSystemModule_ProvidesBuildInfo(t *testing.T) {
 
 			app := fx.New(
 				SystemModule(),
+				// logBuildInfo の Invoke が logging.Logger を要求するため供給する。
+				fx.Provide(func() logging.Logger { return logging.NewTestLogger(t) }),
 				fx.Populate(&bi),
 				fx.NopLogger,
 			)
@@ -34,6 +40,39 @@ func TestSystemModule_ProvidesBuildInfo(t *testing.T) {
 			_ = bi.Revision()
 			_ = bi.BuildDate()
 			require.NoError(t, app.Stop(context.Background()))
+		})
+	})
+}
+
+func TestLogBuildInfo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("正常系", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("version / revision / build_date を付与して出力する", func(t *testing.T) {
+			t.Parallel()
+
+			logger, observed := logging.NewObservedTestLogger(t)
+			ctrl := gomock.NewController(t)
+			bi := mock_system.NewMockBuildInfo(ctrl)
+			bi.EXPECT().Version().Return("v1.2.3")
+			bi.EXPECT().Revision().Return("abc1234")
+			bi.EXPECT().BuildDate().Return("2026-07-01T00:00:00Z")
+
+			logBuildInfo(logger, bi)
+
+			logs := observed.All()
+			require.Len(t, logs, 1)
+
+			entry := logs[0]
+			assert.Equal(t, "application build info", entry.Message)
+			assert.Equal(t, "system.buildinfo", entry.LoggerName)
+
+			fields := entry.ContextMap()
+			assert.Equal(t, "v1.2.3", fields["version"])
+			assert.Equal(t, "abc1234", fields["revision"])
+			assert.Equal(t, "2026-07-01T00:00:00Z", fields["build_date"])
 		})
 	})
 }

--- a/internal/di/server/extension/extension.go
+++ b/internal/di/server/extension/extension.go
@@ -31,8 +31,13 @@ type ServerExtends struct {
 // AppliedServerExtends は、サーバー拡張が適用されたことを示すトークンです。
 type AppliedServerExtends struct{}
 
-// SrvCfg は、サーバーの設定関数を表します。
-type SrvCfg func(*echo.Echo)
+// SrvCfg は、サーバーの設定関数とその名前（ログ出力用）を表します。
+type SrvCfg struct {
+	// Name は、設定関数の名前です（ログ出力用）
+	Name string
+	// Config は、Echo に副作用で適用される設定関数です。
+	Config func(*echo.Echo)
+}
 
 // ServeCfgOut は、サーバーの設定の出力時に使用される構造体です。
 type ServeCfgOut struct {
@@ -184,11 +189,16 @@ func extractPriorityConflicts(byPriority map[int][]string) []string {
 
 // ApplyConfigurators は、Echoに対して設定関数を適用します。
 func ApplyConfigurators(e *echo.Echo, logger logging.Logger, cfgs []SrvCfg) {
-	logger.Named("ApplyConfigurators").CallerSkip(callerSkip).Info(
+	log := logger.Named("ApplyConfigurators").CallerSkip(callerSkip)
+	log.Info(
 		"Applying server configurator",
 		logging.Int("count", len(cfgs)),
 	)
 	for _, cfg := range cfgs {
-		cfg(e)
+		log.Info(
+			"Applying server configurator",
+			logging.String("configurator", cfg.Name),
+		)
+		cfg.Config(e)
 	}
 }

--- a/internal/di/server/extension/extension_test.go
+++ b/internal/di/server/extension/extension_test.go
@@ -132,7 +132,7 @@ func TestApplyConfigurators(t *testing.T) {
 				})
 			}
 
-			ApplyConfigurators(e, logging.NewTestLogger(t), []SrvCfg{cfg})
+			ApplyConfigurators(e, logging.NewTestLogger(t), []SrvCfg{{Name: "cfg", Config: cfg}})
 
 			ctx := context.Background()
 			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/cfg", nil)
@@ -177,7 +177,7 @@ func TestApplyExtends(t *testing.T) {
 			extends := ServerExtends{
 				PreList: []PreMiddleware{{Name: "pre1", Priority: 0, Middleware: pre}},
 				UseList: []UseMiddleware{{Name: "use1", Priority: 0, Middleware: use}},
-				CfgList: []SrvCfg{cfg},
+				CfgList: []SrvCfg{{Name: "cfg", Config: cfg}},
 			}
 
 			applied, err := ApplyExtends(e, logging.NewTestLogger(t), extends)

--- a/internal/di/server/extension/inbound/ipextractor_di.go
+++ b/internal/di/server/extension/inbound/ipextractor_di.go
@@ -23,8 +23,11 @@ func provideIPExtractorServeConfig(
 	appCfg *config.ApplicationConfig, secCfg *config.SecurityConfig,
 ) extension.ServeCfgOut {
 	return extension.ServeCfgOut{
-		SrvCfg: func(e *echo.Echo) {
-			ipextractor.New(e, appCfg, secCfg)
+		SrvCfg: extension.SrvCfg{
+			Name: "ipextractor",
+			Config: func(e *echo.Echo) {
+				ipextractor.New(e, appCfg, secCfg)
+			},
 		},
 	}
 }

--- a/internal/di/server/extension/inbound/ipextractor_di_test.go
+++ b/internal/di/server/extension/inbound/ipextractor_di_test.go
@@ -28,10 +28,11 @@ func Test_provideIPExtractorServeConfig(t *testing.T) {
 		secCfg.SetCIDR(t, parsedCIDR)
 
 		out := provideIPExtractorServeConfig(appCfg, secCfg)
-		require.NotNil(t, out.SrvCfg)
+		require.NotNil(t, out.SrvCfg.Config)
+		assert.Equal(t, "ipextractor", out.SrvCfg.Name)
 
 		e := &echo.Echo{}
-		out.SrvCfg(e)
+		out.SrvCfg.Config(e)
 		require.NotNil(t, e.IPExtractor)
 		return e.IPExtractor
 	}

--- a/internal/di/server/extension/nonprod/debug_mode_di.go
+++ b/internal/di/server/extension/nonprod/debug_mode_di.go
@@ -22,8 +22,11 @@ func DebugModeModule() fx.Option {
 // provideDebugModeServeConfig は、デバッグモードのサーバー設定を提供します。
 func provideDebugModeServeConfig(appCfg *config.ApplicationConfig) extension.ServeCfgOut {
 	return extension.ServeCfgOut{
-		SrvCfg: func(e *echo.Echo) {
-			debugmode.New(e, appCfg)
+		SrvCfg: extension.SrvCfg{
+			Name: "debugmode",
+			Config: func(e *echo.Echo) {
+				debugmode.New(e, appCfg)
+			},
 		},
 	}
 }

--- a/internal/di/server/extension/nonprod/debug_mode_di_test.go
+++ b/internal/di/server/extension/nonprod/debug_mode_di_test.go
@@ -23,10 +23,11 @@ func Test_provideServeConfig(t *testing.T) {
 			appCfg.SetApplicationMode(t, config.DevelopmentMode)
 
 			out := provideDebugModeServeConfig(appCfg)
-			require.NotNil(t, out.SrvCfg)
+			require.NotNil(t, out.SrvCfg.Config)
+			assert.Equal(t, "debugmode", out.SrvCfg.Name)
 
 			e := &echo.Echo{}
-			out.SrvCfg(e)
+			out.SrvCfg.Config(e)
 			assert.True(t, e.Debug)
 		})
 
@@ -37,10 +38,11 @@ func Test_provideServeConfig(t *testing.T) {
 			appCfg.SetApplicationMode(t, config.ProductionMode)
 
 			out := provideDebugModeServeConfig(appCfg)
-			require.NotNil(t, out.SrvCfg)
+			require.NotNil(t, out.SrvCfg.Config)
+			assert.Equal(t, "debugmode", out.SrvCfg.Name)
 
 			e := &echo.Echo{}
-			out.SrvCfg(e)
+			out.SrvCfg.Config(e)
 			assert.False(t, e.Debug)
 		})
 	})

--- a/internal/di/server/extension/outbound/error_handler_di.go
+++ b/internal/di/server/extension/outbound/error_handler_di.go
@@ -25,8 +25,11 @@ func provideErrorHandlerServeConfig(
 	log logging.Logger, lf logging.LogFieldBuilder, obsCfg *config.ObservabilityConfig,
 ) extension.ServeCfgOut {
 	return extension.ServeCfgOut{
-		SrvCfg: func(e *echo.Echo) {
-			errorhandler.New(e, log, lf, obsCfg)
+		SrvCfg: extension.SrvCfg{
+			Name: "errorhandler",
+			Config: func(e *echo.Echo) {
+				errorhandler.New(e, log, lf, obsCfg)
+			},
 		},
 	}
 }

--- a/internal/di/server/extension/outbound/error_handler_di_test.go
+++ b/internal/di/server/extension/outbound/error_handler_di_test.go
@@ -19,9 +19,10 @@ func Test_provideErrorHandlerServeConfig(t *testing.T) {
 	lf := logging.NewTestLogFieldBuilder(t)
 
 	out := provideErrorHandlerServeConfig(log, lf, obsCfg)
-	require.NotNil(t, out.SrvCfg)
+	require.NotNil(t, out.SrvCfg.Config)
+	assert.Equal(t, "errorhandler", out.SrvCfg.Name)
 
 	e := &echo.Echo{}
-	out.SrvCfg(e)
+	out.SrvCfg.Config(e)
 	assert.NotNil(t, e.HTTPErrorHandler)
 }


### PR DESCRIPTION
# 概要

サーバー起動時のログの可視性を向上させる。従来は (1) どの configurator が適用されたか count しか出ず追えない、(2) ビルド情報がログに出ずどのバイナリが起動したか判別できない、という2つの盲点があった。これらを解消し、あわせて fx イベントログの命名を整理する。

build identity（version/revision）と runtime composition（どの configurator が結線されたか）は直交軸のため、build-info は専用 Invoke・configurator ログは既存の適用位置を維持し、1本のログに混ぜていない。

## 変更内容

- **configurator 個別ログ**（`internal/di/server/extension/**`）
  - `SrvCfg` を裸関数 `func(*echo.Echo)` から名前付き構造体（`Name` / `Config`）へ変更
  - `ApplyConfigurators` をミドルウェア（`ApplyMiddlewares`）と対称な2段ログ化。count に加え各 configurator 名（`debugmode` / `ipextractor` / `errorhandler`）を1件ずつ出力
  - 適用順序（group 登録順）・挙動は不変、priority は未導入
- **build-info 起動ログ**（`internal/di/module/system.go`）
  - `SystemModule` に `fx.Invoke(logBuildInfo)` を追加。起動時に `version` / `revision` / `build_date` を1行（logger 名 `system.buildinfo`）出力
  - 従来ビルド情報は `app_build_info` メトリクスと OTel リソースのみでログから起動バイナリを判別できなかった点を解消
- **fx イベントログの命名整理**（`internal/di/fx_event_logger.go`）
  - ロガー名を `fx` → `Fx` へ変更し、各メッセージから冗長な `"fx "` 接頭辞を除去
  - `CallerSkip` を付与し、caller が logging ラッパ（`logging/logger.go`）ではなく実イベント位置を指すよう補正
- **テスト**: 上記に追従（`extension` 系 / `system` 系 / `fx_event_logger` のメッセージ検証を更新・追加）
- `fxEventLogger` は fx 汎用イベントアダプタのため、configurator/build-info 情報の相乗りはさせていない

## 動作確認方法

1. `make lint` / `make test` が pass（`extension` 系・`system` 系パッケージ coverage 100%）
2. `make serve` で起動し、ログを確認:
   - `Applying server configurator {count: 3}` の後に `{configurator: "..."}` が3件出力される
   - `system.buildinfo application build info {version, revision, build_date}` が1行出力される
   - fx イベントログが `Fx` ロガー名・`"fx "` 接頭辞なしのメッセージで出力される

🤖 Generated with [Claude Code](https://claude.com/claude-code)